### PR TITLE
minor Performance improvements

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2322,14 +2322,9 @@ namespace TorannMagic
             return true;
         }
 
-        public static bool AutoUndrafter_Undead_Prefix(AutoUndrafter __instance)
+        public static bool AutoUndrafter_Undead_Prefix(AutoUndrafter __instance, Pawn ___pawn)
         {
-            Pawn pawn = Traverse.Create(root: __instance).Field(name: "pawn").GetValue<Pawn>();
-            if (pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
-            {
-                return false;
-            }
-            return true;
+            return !___pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD"), false);
         }
 
         public static bool PawnRenderer_Blur_Prefix(PawnRenderer __instance, ref Vector3 drawLoc, Pawn ___pawn, Rot4? rotOverride = default(Rot4?), bool neverAimWeapon = false)
@@ -2837,6 +2832,7 @@ namespace TorannMagic
                 if (undeadCaravan[i].IsColonist && !(undeadCaravan[i].health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")) || undeadCaravan[i].health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadAnimalHD")) || undeadCaravan[i].health.hediffSet.HasHediff(HediffDef.Named("TM_LichHD"))))
                 {
                     allUndead = false;
+                    break;
                 }
             }
             __result = !allUndead;


### PR DESCRIPTION
reduces the average load of `Get_NightResting_Undead` by 0.326ms in a Caravan of 2 Colonists & 14 Animals  (all none undead)

saves ~0.228ms for `AutoUndrafter_Undead_Prefix` by using https://github.com/pardeike/Harmony/wiki/Patching#patch-parameters