### PR TITLE
Change InBounds harmony patch to an extension method for optimization

### DIFF
--- a/RimWorldOfMagic/.gitignore
+++ b/RimWorldOfMagic/.gitignore
@@ -1,4 +1,6 @@
 # Ignore Rider generated folder (Main Dev uses Visual Studio and Rider can auto generate this folder)
 **/.idea/
+# Assembly references are located in different locations per user
 *.csproj
+# Caches are generated and should not be in source control
 **/*.cache

--- a/RimWorldOfMagic/.gitignore
+++ b/RimWorldOfMagic/.gitignore
@@ -1,6 +1,7 @@
 # Ignore Rider generated folder (Main Dev uses Visual Studio and Rider can auto generate this folder)
 **/.idea/
-# Assembly references are located in different locations per user
-*.csproj
-# Caches are generated and should not be in source control
-**/*.cache
+
+# ReSharper/Rider settings
+*.DotSettings.user
+
+*.cache

--- a/RimWorldOfMagic/.gitignore
+++ b/RimWorldOfMagic/.gitignore
@@ -1,0 +1,4 @@
+# Ignore Rider generated folder (Main Dev uses Visual Studio and Rider can auto generate this folder)
+**/.idea/
+*.csproj
+**/*.cache

--- a/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
@@ -40,7 +40,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(pawn.Map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(pawn.Map) && curCell.IsValid)
                 {
                     List<Thing> thingList;
                     thingList = curCell.GetThingList(pawn.Map);
@@ -64,7 +64,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(pawn.Map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(pawn.Map) && curCell.IsValid)
                 {
                     List<Thing> thingList;
                     thingList = curCell.GetThingList(pawn.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
@@ -112,7 +112,7 @@ namespace TorannMagic.AutoCast
                             //Log.Warning("failed path check");
                         }
                         //Log.Message("can reach after phase: " + canReach);
-                        if (canReach && phaseToCell.IsValid && phaseToCell.InBounds(caster.Map) && phaseToCell.Walkable(caster.Map) && !phaseToCell.Fogged(caster.Map))// && ((phaseToCell - caster.Position).LengthHorizontal < distanceToTarget))
+                        if (canReach && phaseToCell.IsValid && phaseToCell.InBoundsWithNullCheck(caster.Map) && phaseToCell.Walkable(caster.Map) && !phaseToCell.Fogged(caster.Map))// && ((phaseToCell - caster.Position).LengthHorizontal < distanceToTarget))
                         {
 
                             PawnPath ppc = caster.Map.pathFinder.FindPath(caster.Position, jobTarget.Cell, TraverseParms.For(TraverseMode.PassDoors, Danger.Deadly), PathEndMode.ClosestTouch);
@@ -386,7 +386,7 @@ namespace TorannMagic.AutoCast
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = target;
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;
-                if (distanceToTarget >= minRange && jobTarget != null && jobTarget.Cell.IsValid && jobTarget.Cell.InBounds(casterComp.Pawn.Map) && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range)) //&& distanceToTarget < (abilitydef.MainVerb.range * .9f)
+                if (distanceToTarget >= minRange && jobTarget != null && jobTarget.Cell.IsValid && jobTarget.Cell.InBoundsWithNullCheck(casterComp.Pawn.Map) && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range)) //&& distanceToTarget < (abilitydef.MainVerb.range * .9f)
                 {
                     Job job = ability.GetJob(AbilityContext.AI, jobTarget);
                     job.endIfCantShootTargetFromCurPos = true;
@@ -407,7 +407,7 @@ namespace TorannMagic.AutoCast
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = target;
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;
-                if (distanceToTarget >= minRange && jobTarget != null && jobTarget.Cell.IsValid && jobTarget.Cell.InBounds(casterComp.Pawn.Map) && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range)) //&& distanceToTarget < (abilitydef.MainVerb.range * .9f)
+                if (distanceToTarget >= minRange && jobTarget != null && jobTarget.Cell.IsValid && jobTarget.Cell.InBoundsWithNullCheck(casterComp.Pawn.Map) && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range)) //&& distanceToTarget < (abilitydef.MainVerb.range * .9f)
                 {
                     Job job = ability.GetJob(AbilityContext.AI, jobTarget);
                     job.endIfCantShootTargetFromCurPos = true;
@@ -1190,7 +1190,7 @@ namespace TorannMagic.AutoCast
                                 Log.Warning("failed path check");
                             }
 
-                            if (canReach && blinkToCell.IsValid && blinkToCell.InBounds(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map))// && ((blinkToCell - caster.Position).LengthHorizontal < distanceToTarget))
+                            if (canReach && blinkToCell.IsValid && blinkToCell.InBoundsWithNullCheck(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map))// && ((blinkToCell - caster.Position).LengthHorizontal < distanceToTarget))
                             {
                                 PawnPath ppc = caster.Map.pathFinder.FindPath(caster.Position, jobTarget.Cell, TraverseParms.For(TraverseMode.PassDoors, Danger.Deadly), PathEndMode.ClosestTouch);
                                 float currentCost = ppc.TotalCost;
@@ -1369,7 +1369,7 @@ namespace TorannMagic.AutoCast
                         IntVec3 blinkToCell = caster.Position + (directionToTarget * maxDistance).ToIntVec3();
                         //Log.Message("doing partial blink to cell " + blinkToCell);
                         //FleckMaker.ThrowHeatGlow(blinkToCell, caster.Map, 1f);
-                        if (blinkToCell.IsValid && blinkToCell.InBounds(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map) && ((blinkToCell - caster.Position).LengthHorizontal < distanceToTarget))
+                        if (blinkToCell.IsValid && blinkToCell.InBoundsWithNullCheck(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map) && ((blinkToCell - caster.Position).LengthHorizontal < distanceToTarget))
                         {
                             DoBlink(caster, blinkToCell, carriedThing);
                             success = true;
@@ -1532,7 +1532,7 @@ namespace TorannMagic.AutoCast
                             Log.Warning("failed path check");
                         }
 
-                        if (canReach && blinkToCell.IsValid && blinkToCell.InBounds(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map))
+                        if (canReach && blinkToCell.IsValid && blinkToCell.InBoundsWithNullCheck(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map))
                         {
                             PawnPath ppc = caster.Map.pathFinder.FindPath(caster.Position, jobTarget.Cell, TraverseParms.For(TraverseMode.PassDoors, Danger.Deadly), PathEndMode.ClosestTouch);
                             float currentCost = ppc.TotalCost;

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_60mmMortar.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_60mmMortar.cs
@@ -200,7 +200,7 @@ namespace TorannMagic
         {
             List<IntVec3> cellRange = new List<IntVec3>();
             cellRange.Clear();
-            if (!pos.InBounds(map))
+            if (!pos.InBoundsWithNullCheck(map))
             {
                 return null;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
@@ -141,7 +141,7 @@ namespace TorannMagic
             for (int i = 0; i < num; i++)
             {
                 IntVec3 intVec = center + GenRadial.RadialPattern[i];
-                if (intVec.InBounds(map))
+                if (intVec.InBoundsWithNullCheck(map))
                 {
                     float lengthHorizontal = (center - intVec).LengthHorizontal;
                     float num2 = 1f - lengthHorizontal / radius;

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
@@ -85,7 +85,7 @@ namespace TorannMagic
                         {
                             curCell = targets.ToArray<IntVec3>()[i];
 
-                            if (curCell.InBounds(base.Map) && curCell.IsValid)
+                            if (curCell.InBoundsWithNullCheck(base.Map) && curCell.IsValid)
                             {
                                 Pawn victim = curCell.GetFirstPawn(base.Map);
                                 if (victim != null && !victim.Dead && victim.RaceProps.IsFlesh)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMArcaneCapacitor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMArcaneCapacitor.cs
@@ -91,7 +91,7 @@ namespace TorannMagic
         public static List<IntVec3> PortableCellsAround(IntVec3 pos, Map map)
         {
             Building_TMArcaneCapacitor.portableCells.Clear();
-            if (!pos.InBounds(map))
+            if (!pos.InBoundsWithNullCheck(map))
             {
                 return Building_TMArcaneCapacitor.portableCells;
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift.cs
@@ -223,7 +223,7 @@ namespace TorannMagic
 
         private bool IsGoodLocationForStrike(IntVec3 loc)
         {
-            bool flag1 = loc.InBounds(base.Map);
+            bool flag1 = loc.InBoundsWithNullCheck(base.Map);
             bool flag2 = loc.IsValid;
             bool flag3 = !loc.Fogged(base.Map);
             bool flag4 = loc.DistanceToEdge(base.Map) > 2;
@@ -413,7 +413,7 @@ namespace TorannMagic
             for (int j = 0; j < targets.Count(); j++)
             {
                 curCell = targets.ToArray<IntVec3>()[j];
-                if (curCell.InBounds(this.Map) && curCell.IsValid && curCell.Walkable(this.Map))
+                if (curCell.InBoundsWithNullCheck(this.Map) && curCell.IsValid && curCell.Walkable(this.Map))
                 {
                     SpawnThings rogueElemental = new SpawnThings();
                     if (rnd < 2)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift_Defenders.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift_Defenders.cs
@@ -227,7 +227,7 @@ namespace TorannMagic
 
         private bool IsGoodLocationForStrike(IntVec3 loc)
         {
-            bool flag1 = loc.InBounds(base.Map);
+            bool flag1 = loc.InBoundsWithNullCheck(base.Map);
             bool flag2 = loc.IsValid;
             bool flag3 = !loc.Fogged(base.Map);
             bool flag4 = loc.DistanceToEdge(base.Map) > 2;
@@ -433,7 +433,7 @@ namespace TorannMagic
             for (int j = 0; j < targets.Count(); j++)
             {
                 curCell = targets.ToArray<IntVec3>()[j];
-                if (curCell.InBounds(this.Map) && curCell.IsValid && curCell.Walkable(this.Map))
+                if (curCell.InBoundsWithNullCheck(this.Map) && curCell.IsValid && curCell.Walkable(this.Map))
                 {
                     SpawnThings rogueElemental = new SpawnThings();
                     if (rnd < 2)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMPortal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMPortal.cs
@@ -260,7 +260,7 @@ namespace TorannMagic
         public static List<IntVec3> PortableCellsAround(IntVec3 pos, Map map)
         {
             Building_TMPortal.portableCells.Clear();
-            if (!pos.InBounds(map))
+            if (!pos.InBoundsWithNullCheck(map))
             {
                 return Building_TMPortal.portableCells;
 
@@ -298,7 +298,7 @@ namespace TorannMagic
                 for (int i = 0; i < targets.Count(); i++)
                 {
                     curCell = targets.ToArray<IntVec3>()[i];
-                    if (curCell.InBounds(this.Map) && curCell.IsValid)
+                    if (curCell.InBoundsWithNullCheck(this.Map) && curCell.IsValid)
                     {
                         Pawn interactingPawn = curCell.GetFirstPawn(this.Map);
                         if (interactingPawn != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMTotem_Earth.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMTotem_Earth.cs
@@ -43,7 +43,7 @@ namespace TorannMagic
                     for (int i = 0; i < targetCells.Count(); i++)
                     {
                         curCell = targetCells[i];
-                        if (curCell.IsValid && curCell.InBounds(this.Map))
+                        if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Map))
                         {
                             List<Thing> thingList = curCell.GetThingList(this.Map);
                             for (int j = 0; j < thingList.Count(); j++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TM_DMP.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TM_DMP.cs
@@ -104,7 +104,7 @@ namespace TorannMagic
         public static List<IntVec3> PortableCellsAround(IntVec3 pos, Map map)
         {
             Building_TM_DMP.portableCells.Clear();
-            if (!pos.InBounds(map))
+            if (!pos.InBoundsWithNullCheck(map))
             {
                 return Building_TM_DMP.portableCells;
 

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
@@ -98,7 +98,7 @@ namespace TorannMagic
             for (int i = 0; i < targetCells.Count(); i++)
             {
                 curCell = targetCells[i];
-                if (curCell.IsValid && curCell.InBounds(this.Pawn.Map))
+                if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Pawn.Map))
                 {
                     if(isExplosion)
                     {
@@ -139,7 +139,7 @@ namespace TorannMagic
             for (int i = 0; i < targetCells.Count(); i++)
             {
                 curCell = targetCells[i];
-                if (curCell.IsValid && curCell.InBounds(this.Pawn.Map))
+                if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Pawn.Map))
                 {
                     Vector3 launchVector = GetVector(this.Pawn.Position, curCell);
                     Pawn knockbackPawn = curCell.GetFirstPawn(this.Pawn.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -7201,7 +7201,7 @@ namespace TorannMagic
                         GenPlace.TryPlaceThing(thing, this.earthSprites, this.earthSpriteMap, ThingPlaceMode.Near, null);
                     }
                 }
-                if (curCell.InBounds(map) && curCell.IsValid && terrain != null)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid && terrain != null)
                 {
                     if (terrain.defName == "MarshyTerrain" || terrain.defName == "Mud" || terrain.defName == "Marsh")
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
@@ -271,7 +271,7 @@ namespace TorannMagic
                 {
                     tmpPos.z++;
                 }
-                if (tmpPos.IsValid && tmpPos.InBounds(map) && tmpPos.Walkable(map))
+                if (tmpPos.IsValid && tmpPos.InBoundsWithNullCheck(map) && tmpPos.Walkable(map))
                 {
                     targetPos = tmpPos;
                     this.Pawn.DeSpawn();

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
@@ -216,7 +216,7 @@ namespace TorannMagic
                 for (int i = 0; i < targetCells.Count(); i++)
                 {
                     curCell = targetCells[i];
-                    if (curCell.IsValid && curCell.InBounds(this.Pawn.Map))
+                    if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Pawn.Map))
                     {
                         if (isExplosion)
                         {
@@ -262,7 +262,7 @@ namespace TorannMagic
             for (int i = 0; i < targetCells.Count(); i++)
             {
                 curCell = targetCells[i];
-                if (curCell.IsValid && curCell.InBounds(this.Pawn.Map))
+                if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Pawn.Map))
                 {
                     Vector3 launchVector = TM_Calc.GetVector(this.Pawn.Position, curCell);
                     Pawn knockbackPawn = curCell.GetFirstPawn(this.Pawn.Map);
@@ -700,7 +700,7 @@ namespace TorannMagic
             returnThings.Clear();
             for (int i = 0; i < searchCells.Count(); i++)
             {
-                if (searchCells[i].IsValid && searchCells[i].InBounds(this.Pawn.Map))
+                if (searchCells[i].IsValid && searchCells[i].InBoundsWithNullCheck(this.Pawn.Map))
                 {
                     List<Thing> cellList = searchCells[i].GetThingList(this.Pawn.Map);
                     for (int j = 0; j<cellList.Count(); j++)

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonLichController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonLichController.cs
@@ -264,7 +264,7 @@ namespace TorannMagic
         {
             this.nextChargeAttack = this.Props.chargeCooldownTicks + Find.TickManager.TicksGame;
             bool flag = t != null && t.DistanceToEdge(this.Pawn.Map) > 6;
-            if (flag && t.InBounds(this.Pawn.Map) && t.IsValid && t.Walkable(this.Pawn.Map) && Pawn.Position.DistanceTo(t) <= 60)
+            if (flag && t.InBoundsWithNullCheck(this.Pawn.Map) && t.IsValid && t.Walkable(this.Pawn.Map) && Pawn.Position.DistanceTo(t) <= 60)
             {
                 this.castingCompleteTick = Find.TickManager.TicksGame + this.Props.chargeAttackDelay;
                 this.flightTarget = t;
@@ -728,7 +728,7 @@ namespace TorannMagic
                         c.Destroy(DestroyMode.Vanish);
                     }
                 }
-                if (curCell.InBounds(map) && curCell.Walkable(map))
+                if (curCell.InBoundsWithNullCheck(map) && curCell.Walkable(map))
                 {
                     SpawnThings skeleton = new SpawnThings();
                     if (Rand.Chance(geChance + corpseMult))

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_DemonAssault.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_DemonAssault.cs
@@ -91,7 +91,7 @@ namespace TorannMagic.Conditions
             int accuracy = 5 - eventDifficulty;
             rndPos.x += Rand.Range(-accuracy, accuracy);
             rndPos.z += Rand.Range(-accuracy, accuracy);
-            if (rndPos.IsValid && rndPos.InBounds(this.SingleMap) && rndPos.DistanceToEdge(this.SingleMap) > 6)
+            if (rndPos.IsValid && rndPos.InBoundsWithNullCheck(this.SingleMap) && rndPos.DistanceToEdge(this.SingleMap) > 6)
             {
                 if (eventDifficulty > 2 && Rand.Chance(eventDifficulty * .05f))
                 {
@@ -349,7 +349,7 @@ namespace TorannMagic.Conditions
 
         private bool IsGoodLocationForSpawn(IntVec3 loc)
         {
-            return loc.InBounds(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
+            return loc.InBoundsWithNullCheck(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
         }
 
         private bool IsGoodCenterLocation(IntVec2 loc)

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_ElementalAssault.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_ElementalAssault.cs
@@ -129,7 +129,7 @@ namespace TorannMagic.Conditions
 
         private bool IsGoodLocationForSpawn(IntVec3 loc)
         {
-            return loc.InBounds(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
+            return loc.InBoundsWithNullCheck(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
         }
 
         private bool IsGoodCenterLocation(IntVec2 loc)

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_WanderingLich.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_WanderingLich.cs
@@ -363,7 +363,7 @@ namespace TorannMagic.Conditions
 
         private bool IsGoodLocationForSpawn(IntVec3 loc)
         {
-            return loc.InBounds(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
+            return loc.InBoundsWithNullCheck(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
         }
 
         private bool IsGoodCenterLocation(IntVec2 loc)
@@ -437,7 +437,7 @@ namespace TorannMagic.Conditions
             for (int j = 0; j < targets.Count(); j++)
             {
                 curCell = targets.ToArray<IntVec3>()[j];
-                if (curCell.InBounds(map) && curCell.IsValid && curCell.Walkable(map))
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid && curCell.Walkable(map))
                 {
                     SpawnThings skeleton = new SpawnThings();
                     if (Rand.Chance(geChance))

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
@@ -288,7 +288,7 @@ namespace TorannMagic
                         }
                         else
                         {
-                            bool flag3 = this.DestinationCell.InBounds(base.Map);
+                            bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                             if (flag3)
                             {
                                 base.Position = this.DestinationCell;
@@ -298,7 +298,7 @@ namespace TorannMagic
                     }
                     else
                     {
-                        bool flag3 = this.DestinationCell.InBounds(base.Map);
+                        bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                         if (flag3)
                         {
                             base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DeathBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DeathBolt.cs
@@ -252,7 +252,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0 && !impacted;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -268,14 +268,14 @@ namespace TorannMagic
                     CellRect cellRect = CellRect.CenteredOn(base.Position, 2);
                     cellRect.ClipInsideMap(base.Map);
                     IntVec3 spreadingDarknessCell;
-                    if(!(cellRect.CenterCell.GetTerrain(base.Map).passability == Traversability.Impassable) && !cellRect.CenterCell.IsValid || !cellRect.CenterCell.InBounds(base.Map))
+                    if(!(cellRect.CenterCell.GetTerrain(base.Map).passability == Traversability.Impassable) && !cellRect.CenterCell.IsValid || !cellRect.CenterCell.InBoundsWithNullCheck(base.Map))
                     {
                         this.ticksFollowingImpact = -1;
                     }
                     for (int i = 0; i < 2; i++)
                     {
                         spreadingDarknessCell = cellRect.RandomCell;
-                        if (spreadingDarknessCell.InBounds(base.Map) && spreadingDarknessCell.IsValid)
+                        if (spreadingDarknessCell.InBoundsWithNullCheck(base.Map) && spreadingDarknessCell.IsValid)
                         {
                             GenExplosion.DoExplosion(spreadingDarknessCell, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_DeathBolt, this.pawn, Mathf.RoundToInt((Rand.Range(.4f * this.def.projectile.GetDamageAmount(1, null), .8f * this.def.projectile.GetDamageAmount(1, null)) + (3f * pwrVal)) * this.arcaneDmg), 2, this.def.projectile.soundExplode, def, null, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
                             TM_MoteMaker.ThrowDiseaseMote(base.Position.ToVector3Shifted(), base.Map, .6f);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DemonFlight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DemonFlight.cs
@@ -194,7 +194,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DirtDevil.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DirtDevil.cs
@@ -259,7 +259,7 @@ namespace TorannMagic
                     }
                     else
                     {
-                        bool flag3 = this.DestinationCell.InBounds(base.Map);
+                        bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                         if (flag3)
                         {
                             base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DragonStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DragonStrike.cs
@@ -194,7 +194,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -292,7 +292,7 @@ namespace TorannMagic
                         {
                             Vector3 launchVector = TM_Calc.GetVector(this.origin, hitThing.Position.ToVector3());
                             IntVec3 projectedPosition = hitThing.Position + ((10f - distanceToTarget) * (1 + (.15f * verVal)) * launchVector).ToIntVec3();
-                            if (projectedPosition.IsValid && projectedPosition.InBounds(hitThing.Map))
+                            if (projectedPosition.IsValid && projectedPosition.InBoundsWithNullCheck(hitThing.Map))
                             {
                                 LaunchFlyingObect(projectedPosition, hitPawn, Mathf.RoundToInt(10f - distanceToTarget));
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_EyeOfTheStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_EyeOfTheStorm.cs
@@ -204,7 +204,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -404,7 +404,7 @@ namespace TorannMagic
             for (int i = 0; i < (15 + 4*pwrVal); i++)
             {
                 IntVec3 strikeCell = dissipationList.RandomElement();
-                if (strikeCell.InBounds(base.Map) && strikeCell.IsValid && !strikeCell.Fogged(this.Map))
+                if (strikeCell.InBoundsWithNullCheck(base.Map) && strikeCell.IsValid && !strikeCell.Fogged(this.Map))
                 {
                     DrawStrike(this.ExactPosition.ToIntVec3(), strikeCell.ToVector3Shifted());
                     for (int k = 0; k < Rand.Range(1, 8); k++)

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Flight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Flight.cs
@@ -175,7 +175,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Leap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Leap.cs
@@ -166,7 +166,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightLance.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightLance.cs
@@ -212,7 +212,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0 && !impacted;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightningTrap.cs
@@ -207,7 +207,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -352,7 +352,7 @@ namespace TorannMagic
             for (int i = 0; i < 4; i++)
             {
                 IntVec3 strikeCell = dissipationList.RandomElement();
-                if (strikeCell.InBounds(base.Map) && strikeCell.IsValid && !strikeCell.Fogged(this.Map))
+                if (strikeCell.InBoundsWithNullCheck(base.Map) && strikeCell.IsValid && !strikeCell.Fogged(this.Map))
                 {
                     DrawStrike(this.ExactPosition.ToIntVec3(), strikeCell.ToVector3Shifted());
                     for (int k = 0; k < Rand.Range(1, 8); k++)

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LivingWall.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LivingWall.cs
@@ -625,7 +625,7 @@ namespace TorannMagic
                                     }
                                     else
                                     {
-                                        bool flag3 = this.DestinationCell.InBounds(base.Map);
+                                        bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                                         if (flag3)
                                         {
                                             base.Position = this.DestinationCell;
@@ -636,7 +636,7 @@ namespace TorannMagic
                                 }
                                 else
                                 {
-                                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                                     if (flag3)
                                     {
                                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsiStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsiStorm.cs
@@ -117,7 +117,7 @@ namespace TorannMagic
             this.strikeCells = GenRadial.RadialCellsAround(this.centerLoc, 7, true).ToList();
             for(int i =0; i < this.strikeCells.Count(); i++)
             {
-                if(!this.strikeCells[i].InBounds(this.pawn.Map) || !this.strikeCells[i].IsValid)
+                if(!this.strikeCells[i].InBoundsWithNullCheck(this.pawn.Map) || !this.strikeCells[i].IsValid)
                 {
                     this.strikeCells.Remove(this.strikeCells[i]);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicDash.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicDash.cs
@@ -210,7 +210,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicLeap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicLeap.cs
@@ -185,7 +185,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -279,7 +279,7 @@ namespace TorannMagic
             {
                 victim = null;
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(this.Map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(this.Map) && curCell.IsValid)
                 {
                     victim = curCell.GetFirstPawn(map);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicStorm.cs
@@ -317,7 +317,7 @@ namespace TorannMagic
                     }
                     else
                     {
-                        bool flag3 = this.DestinationCell.InBounds(base.Map);
+                        bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                         if (flag3)
                         {
                             base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ShadowBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ShadowBolt.cs
@@ -220,7 +220,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -298,7 +298,7 @@ namespace TorannMagic
                 intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
                 //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f * this.def.projectile.GetDamageAmount(1,null), 1.1f * this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
 
-                if (intVec.IsValid && intVec.InBounds(this.Map))
+                if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
                 {
                     List<Thing> hitList = new List<Thing>();
                     hitList = intVec.GetThingList(base.Map);
@@ -314,7 +314,7 @@ namespace TorannMagic
                 intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
                 //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f * this.def.projectile.GetDamageAmount(1,null), 1.1f * this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
 
-                if (intVec.IsValid && intVec.InBounds(this.Map))
+                if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
                 {
                     List<Thing> hitList = new List<Thing>();
                     hitList = intVec.GetThingList(base.Map);
@@ -330,7 +330,7 @@ namespace TorannMagic
                 intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
                 //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f*this.def.projectile.GetDamageAmount(1,null), 1.1f*this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
 
-                if (intVec.IsValid && intVec.InBounds(this.Map))
+                if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
                 {
                     List<Thing> hitList = new List<Thing>();
                     hitList = intVec.GetThingList(base.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
@@ -187,7 +187,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -420,7 +420,7 @@ namespace TorannMagic
                         for (int i = 0; i < outsideRing.Count; i++)
                         {
                             IntVec3 intVec = outsideRing[i];
-                            if (intVec.IsValid && intVec.InBounds(base.Map))
+                            if (intVec.IsValid && intVec.InBoundsWithNullCheck(base.Map))
                             {
                                 Vector3 moteDirection = TM_Calc.GetVector(this.ExactPosition.ToIntVec3(), intVec);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Rubble, this.ExactPosition, base.Map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
@@ -504,7 +504,7 @@ namespace TorannMagic
                         for (int i = 0; i < outsideRing.Count; i++)
                         {
                             IntVec3 intVec = outsideRing[i];
-                            if (intVec.IsValid && intVec.InBounds(base.Map))
+                            if (intVec.IsValid && intVec.InBoundsWithNullCheck(base.Map))
                             {
                                 Vector3 moteDirection = TM_Calc.GetVector(this.ExactPosition.ToIntVec3(), intVec);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_BloodSquirt, this.ExactPosition, base.Map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(4f, 13f), (Quaternion.AngleAxis(Rand.Range(60, 120), Vector3.up) * moteDirection).ToAngleFlat(), 0);
@@ -575,7 +575,7 @@ namespace TorannMagic
                     for (int i = 0; i < outsideRing.Count; i++)
                     {
                         IntVec3 intVec = outsideRing[i];
-                        if (intVec.IsValid && intVec.InBounds(base.Map))
+                        if (intVec.IsValid && intVec.InBoundsWithNullCheck(base.Map))
                         {
                             Vector3 moteDirection = TM_Calc.GetVector(this.ExactPosition.ToIntVec3(), intVec);
                             TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Rubble, this.ExactPosition, base.Map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
@@ -628,7 +628,7 @@ namespace TorannMagic
                     {
                         if (this.shouldDismiss)
                         {
-                            bool flag3 = this.DestinationCell.InBounds(base.Map);
+                            bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                             if (flag3)
                             {
                                 base.Position = this.DestinationCell;
@@ -649,7 +649,7 @@ namespace TorannMagic
                                 }
                                 else
                                 {
-                                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                                     if (flag3)
                                     {
                                         base.Position = this.DestinationCell;
@@ -661,7 +661,7 @@ namespace TorannMagic
                             }
                             else
                             {
-                                bool flag3 = this.DestinationCell.InBounds(base.Map);
+                                bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                                 if (flag3)
                                 {
                                     base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritWolves.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritWolves.cs
@@ -176,7 +176,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -240,7 +240,7 @@ namespace TorannMagic
                 if (lastRadial != null && lastRadial.Count() > 0)
                 {
                     curCell = lastRadial.RandomElement();
-                    if (curCell.InBounds(base.Map) && curCell.IsValid)
+                    if (curCell.InBoundsWithNullCheck(base.Map) && curCell.IsValid)
                     {
                         ThingDef moteSmoke = TorannMagicDefOf.Mote_Base_Smoke;
                         if (Rand.Chance(.5f))
@@ -270,7 +270,7 @@ namespace TorannMagic
                 for (int i = 0; i < effectRadial.Count(); i++)
                 {
                     curCell = effectRadial.ToArray<IntVec3>()[i];
-                    if (curCell.InBounds(base.Map) && curCell.IsValid)
+                    if (curCell.InBoundsWithNullCheck(base.Map) && curCell.IsValid)
                     {
                         hitList = curCell.GetThingList(base.Map);
                         for (int j = 0; j < hitList.Count; j++)

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ValiantCharge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ValiantCharge.cs
@@ -219,7 +219,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Whirlwind.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Whirlwind.cs
@@ -180,7 +180,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/GenGridExtensions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/GenGridExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Verse;
+
+namespace TorannMagic
+{
+    public static class GenGridExtensions
+    {
+        public static bool InBoundsWithNullCheck(this IntVec3 c, Map map)
+        {
+            return map != null && c.InBounds(map);
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/GenGridExtensions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/GenGridExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using System;
+using Verse;
 
 namespace TorannMagic
 {
@@ -6,7 +7,16 @@ namespace TorannMagic
     {
         public static bool InBoundsWithNullCheck(this IntVec3 c, Map map)
         {
-            return map != null && c.InBounds(map);
+            // Use try catch as there are only rare exceptions when c is deleted after call but before Inbounds is called
+            try
+            {
+                return c.InBounds(map);
+            }
+            catch (NullReferenceException e)
+            {
+                Log.Warning($"NullReference during InBounds call: {e.ToString()}");
+                return false;
+            }
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/TMPawnGolem.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/TMPawnGolem.cs
@@ -522,7 +522,7 @@ namespace TorannMagic.Golems
                 IntVec3 cell = infoTarget.Cell;
                 FleckMaker.ThrowAirPuffUp(infoTarget.CenterVector3, this.Map);
                 FleckMaker.ThrowHeatGlow(infoTarget.Cell, this.Map, 1f);
-                if (cell.IsValid && cell.InBounds(this.Map) && !cell.Fogged(this.Map) && cell.Standable(this.Map) && ReachabilityUtility.CanReach(this, infoTarget, PathEndMode.OnCell, Danger.Deadly, false, false, TraverseMode.ByPawn))
+                if (cell.IsValid && cell.InBoundsWithNullCheck(this.Map) && !cell.Fogged(this.Map) && cell.Standable(this.Map) && ReachabilityUtility.CanReach(this, infoTarget, PathEndMode.OnCell, Danger.Deadly, false, false, TraverseMode.ByPawn))
                 {
                     Golem.dormantPosition = cell;
                     Golem.dormantMap = this.Map;

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/Verb_GolemSmash.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/Verb_GolemSmash.cs
@@ -26,7 +26,7 @@ namespace TorannMagic.Golems
                     for (int i = 0; i < targetCells.Count; i++)
                     {
                         curCell = targetCells[i];                        
-                        if (curCell.IsValid && curCell.InBounds(CasterPawn.Map))
+                        if (curCell.IsValid && curCell.InBoundsWithNullCheck(CasterPawn.Map))
                         {
                             float angle = (Quaternion.AngleAxis(90, Vector3.up) * TM_Calc.GetVector(target.Cell, curCell)).ToAngleFlat();
                             TM_MoteMaker.ThrowGenericFleck(FleckDefOf.DustPuffThick, target.CenterVector3, CasterPawn.Map, Rand.Range(.5f, .8f), Rand.Range(.3f, .5f), .1f, Rand.Range(.3f, .5f), 0, 1.5f, angle, Rand.Range(0, 360));

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -207,22 +207,12 @@ namespace TorannMagic
                     typeof(bool),
                     typeof(bool)
                 }, null), null, new HarmonyMethod(typeof(TorannMagicMod), "TryStartCastOn_Prefix", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(GenGrid), "InBounds", new Type[]
-                {
-                    typeof(IntVec3),
-                    typeof(Map)
-                }, null), new HarmonyMethod(typeof(TorannMagicMod), "IntVec3Inbounds_NullCheck_Prefix", null), null);
             harmonyInstance.Patch(AccessTools.Method(typeof(VerbProperties), "AdjustedCooldown", new Type[]
                 {
                     typeof(Tool),
                     typeof(Pawn),
                     typeof(Thing)
                 }, null), null, new HarmonyMethod(typeof(TorannMagicMod), "GolemVerb_AdjustedCooldown_Postfix", null), null);
-            //harmonyInstance.Patch(AccessTools.Method(typeof(GenGrid), "InBounds", new Type[]
-            //    {
-            //        typeof(IntVec3),
-            //        typeof(Map)
-            //    }, null), new HarmonyMethod(typeof(TorannMagicMod), "IntVec3Inbounds_NullCheck_Prefix", null), null);
             ////harmonyInstance.Patch(AccessTools.Method(typeof(AbilityUser.PawnAbility), "GetJob"),
             ////    new HarmonyMethod(typeof(TorannMagicMod), "PawnAbility_GetJob_Prefix"));
             ////harmonyInstance.Patch(AccessTools.Method(typeof(QuestNode_RaceProperty), "Matches", new Type[]
@@ -2260,16 +2250,6 @@ namespace TorannMagic
                     }
                 }
             }
-        }
-
-        public static bool IntVec3Inbounds_NullCheck_Prefix(IntVec3 c, Map map, ref bool __result)
-        {
-            if (c != null && map != null)
-            {
-                return true;
-            }
-            __result = false;
-            return false;
         }
 
         public static bool CompAbilityItem_Overlay_Prefix(CompAbilityItem __instance)

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Dominate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Dominate.cs
@@ -126,7 +126,7 @@ namespace TorannMagic
                     for (int i = 0; i < targets.Count(); i++)
                     {
                         curCell = targets.ToArray<IntVec3>()[i];
-                        if (curCell.InBounds(map) && curCell.IsValid)
+                        if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                         {
                             victim = curCell.GetFirstPawn(map);
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PortalDestination.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PortalDestination.cs
@@ -109,7 +109,7 @@ namespace TorannMagic
                 portalTarget.canTargetFires = false;
                 portalTarget.canTargetBuildings = false;
                 portalTarget.canTargetItems = false;
-                portalTarget.validator = ((TargetInfo x) => x.IsValid && !x.Cell.Fogged(map) && x.Cell.InBounds(map) && x.Cell.Walkable(map));  //TargetingParameters.ForDropPodsDestination()
+                portalTarget.validator = ((TargetInfo x) => x.IsValid && !x.Cell.Fogged(map) && x.Cell.InBoundsWithNullCheck(map) && x.Cell.Walkable(map));  //TargetingParameters.ForDropPodsDestination()
                 Find.Targeter.BeginTargeting(portalTarget, delegate (LocalTargetInfo x)
                 {                    
                     portalBldg.PortalDestinationPosition = x.Cell;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Attraction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Attraction.cs
@@ -91,7 +91,7 @@ namespace TorannMagic
                 cellList = targets.ToList<IntVec3>();
                 for(int i = 0; i < cellList.Count(); i ++)
                 {
-                    if (cellList[i].IsValid && cellList[i].InBounds(pawn.Map))
+                    if (cellList[i].IsValid && cellList[i].InBoundsWithNullCheck(pawn.Map))
                     {
                         victim = cellList[i].GetFirstPawn(pawn.Map);
                         if (victim != null && !victim.Dead && !victim.Downed)
@@ -134,7 +134,7 @@ namespace TorannMagic
                 for (int i = 0; i < 3; i++)
                 {
                     curCell = cellList.RandomElement();
-                    if (curCell.IsValid && curCell.InBounds(base.Map))
+                    if (curCell.IsValid && curCell.InBoundsWithNullCheck(base.Map))
                     {
                         victim = curCell.GetFirstPawn(base.Map);
                         if (victim != null && !victim.Dead && victim.RaceProps.IsFlesh && victim != this.pawn)
@@ -155,7 +155,7 @@ namespace TorannMagic
                 for(int i =0; i < hediffCellList.Count(); i++)
                 {
                     curCell = hediffCellList[i];
-                    if (curCell.IsValid && curCell.InBounds(base.Map))
+                    if (curCell.IsValid && curCell.InBoundsWithNullCheck(base.Map))
                     {
                         victim = curCell.GetFirstPawn(base.Map);
                         if (victim != null && !victim.Dead && victim != this.pawn)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Blizzard.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Blizzard.cs
@@ -69,7 +69,7 @@ namespace TorannMagic
                 Initialize(map);
             }
             impactPos = cellRect.RandomCell;
-            if (this.age > lastStrikeLarge + Rand.Range(200 - (pwrVal * 30), duration/(4 + pwrVal)) && impactPos.Standable(map) && impactPos.InBounds(map) && impactPos.DistanceToEdge(map) >= 2)
+            if (this.age > lastStrikeLarge + Rand.Range(200 - (pwrVal * 30), duration/(4 + pwrVal)) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map) && impactPos.DistanceToEdge(map) >= 2)
             {
                 this.lastStrikeLarge = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Blizzard_Large, impactPos, map);
@@ -79,7 +79,7 @@ namespace TorannMagic
                 snowCount++;
             }
             impactPos = cellRect.RandomCell;
-            if (this.age > lastStrikeTiny + Rand.Range(6-(pwrVal), 18-(2*pwrVal)) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if (this.age > lastStrikeTiny + Rand.Range(6-(pwrVal), 18-(2*pwrVal)) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeTiny = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Blizzard_Tiny, impactPos, map);
@@ -89,7 +89,7 @@ namespace TorannMagic
                 snowCount++;
             }
             impactPos = cellRect.RandomCell;
-            if ( this.age > lastStrikeSmall + Rand.Range(30-(2*pwrVal), 60-(4*pwrVal)) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if ( this.age > lastStrikeSmall + Rand.Range(30-(2*pwrVal), 60-(4*pwrVal)) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeSmall = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Blizzard_Small, impactPos, map);
@@ -136,7 +136,7 @@ namespace TorannMagic
             for (int i = 0; i < num; i++)
             {
                 IntVec3 intVec = center + GenRadial.RadialPattern[i];
-                if (intVec.InBounds(map))
+                if (intVec.InBoundsWithNullCheck(map))
                 {
                     float lengthHorizontal = (center - intVec).LengthHorizontal;
                     float num2 = 1f - lengthHorizontal / radius;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_BloodMoon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_BloodMoon.cs
@@ -105,13 +105,13 @@ namespace TorannMagic
 
                 this.CheckSpawnSustainer();
 
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     List<IntVec3> cellList = GenRadial.RadialCellsAround(base.Position, this.radius, true).ToList();
                     for (int i = 0; i < cellList.Count; i++)
                     {
                         curCell = cellList[i];
-                        if (curCell.InBounds(map) && curCell.IsValid)
+                        if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                         {
                             this.bloodCircleCells.Add(curCell);
                         }
@@ -122,7 +122,7 @@ namespace TorannMagic
                     for (int i = 0; i < cellList.Count; i++)
                     {
                         curCell = cellList[i];
-                        if (curCell.InBounds(map) && curCell.IsValid)
+                        if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                         {
                             outerRing.Add(curCell);
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChainLightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChainLightning.cs
@@ -184,7 +184,7 @@ namespace TorannMagic
 
         public void DamageCell(IntVec3 c, Pawn caster)
         {
-            if (c != default(IntVec3) && c.IsValid && c.InBounds(this.Map))
+            if (c != default(IntVec3) && c.IsValid && c.InBoundsWithNullCheck(this.Map))
             {
                 FleckMaker.ThrowLightningGlow(c.ToVector3Shifted(), this.Map, 1f);
                 List<Thing> thingList = c.GetThingList(this.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChronostaticField.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChronostaticField.cs
@@ -91,7 +91,7 @@ namespace TorannMagic
             cellList = GenRadial.RadialCellsAround(base.Position, this.radius, true).ToList(); //this.radius instead of 2
             for (int i = 0; i < cellList.Count; i++)
             {
-                if (cellList[i].IsValid && cellList[i].InBounds(this.Map))
+                if (cellList[i].IsValid && cellList[i].InBoundsWithNullCheck(this.Map))
                 {
                     List<Thing> thingList = cellList[i].GetThingList(this.Map);
                     if (thingList != null && thingList.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_CorpseExplosion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_CorpseExplosion.cs
@@ -66,7 +66,7 @@ namespace TorannMagic
                 CellRect cellRect = CellRect.CenteredOn(base.Position, 1);
                 cellRect.ClipInsideMap(map);
                 IntVec3 curCell = cellRect.CenterCell;
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     Pawn undead = curCell.GetFirstPawn(map);
                     bool flag = undead != null && !undead.Dead;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_DryGround.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_DryGround.cs
@@ -27,7 +27,7 @@ namespace TorannMagic
                 {
                     curCell = cells.ToArray<IntVec3>()[i];
                     terrain = curCell.GetTerrain(map);
-                    if (curCell.InBounds(map) && curCell.IsValid && terrain.driesTo != null)
+                    if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid && terrain.driesTo != null)
                     {
                         if (terrain.defName == "MarshyTerrain" || terrain.defName == "Mud" || terrain.defName == "Marsh")
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_EarthernHammer.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_EarthernHammer.cs
@@ -82,7 +82,7 @@ namespace TorannMagic
             this.launchCells = GenRadial.RadialCellsAround(caster.Position, this.radius, false).ToList();
             for (int i = 0; i < launchCells.Count(); i++)
             {
-                if (launchCells[i].IsValid && launchCells[i].InBounds(caster.Map))
+                if (launchCells[i].IsValid && launchCells[i].InBoundsWithNullCheck(caster.Map))
                 {
                     List<Thing> cellList = launchCells[i].GetThingList(caster.Map);
                     bool invalidCell = false;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Encase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Encase.cs
@@ -104,7 +104,7 @@ namespace TorannMagic
                 //{
                 for(int k =0; k < wall.Count(); k++)
                 { 
-                    if(wall[k].position.IsValid && wall[k].position.InBounds(caster.Map) && !wall[k].position.Fogged(caster.Map) && !wall[k].position.InNoZoneEdgeArea(caster.Map))
+                    if(wall[k].position.IsValid && wall[k].position.InBoundsWithNullCheck(caster.Map) && !wall[k].position.Fogged(caster.Map) && !wall[k].position.InNoZoneEdgeArea(caster.Map))
                     //if (wallPositions[k].IsValid && wallPositions[k].InBounds(caster.Map) && !wallPositions[k].Fogged(caster.Map) && !wallPositions[k].InNoZoneEdgeArea(caster.Map))
                     {
                         if (wall[k].terrain.defName == "Marsh" || wall[k].terrain.defName == "WaterShallow" || wall[k].terrain.defName == "WaterMovingShallow" || wall[k].terrain.defName == "WaterOceanShallow" || wall[k].terrain.defName == "WaterMovingChestDeep")

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Explosion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Explosion.cs
@@ -160,7 +160,7 @@ namespace TorannMagic
                     IEnumerable<IntVec3> explosionCells = newExplosionCells.Except(oldExplosionCells);
                     foreach (IntVec3 cell in explosionCells)
                     {
-                        if (cell.InBounds(map))
+                        if (cell.InBoundsWithNullCheck(map))
                         {
                             Vector3 heading = (cell - centerCell).ToVector3();
                             float distance = heading.magnitude;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireball.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireball.cs
@@ -45,7 +45,7 @@ namespace TorannMagic
             for (int i = 0; i < (pwrVal * 3); i++)
 			{
 				IntVec3 randomCell = cellRect.RandomCell;
-                if(randomCell.IsValid && randomCell.InBounds(map) && !randomCell.Fogged(map))
+                if(randomCell.IsValid && randomCell.InBoundsWithNullCheck(map) && !randomCell.Fogged(map))
                 {
                     this.FireExplosion(randomCell, map, 2.2f, ver);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firestorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firestorm.cs
@@ -72,7 +72,7 @@ namespace TorannMagic
             }
 
             impactPos = cellRect.RandomCell;
-            if (this.age > lastStrikeLarge + Rand.Range((200/(1+pwrVal))+20, (duration/(1+pwrVal))+40) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if (this.age > lastStrikeLarge + Rand.Range((200/(1+pwrVal))+20, (duration/(1+pwrVal))+40) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeLarge = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Firestorm_Large, impactPos, map);
@@ -85,13 +85,13 @@ namespace TorannMagic
                 }                
             }
             impactPos = cellRect.RandomCell;
-            if (this.age > lastStrikeTiny + Rand.Range(7-pwrVal, 20-pwrVal) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if (this.age > lastStrikeTiny + Rand.Range(7-pwrVal, 20-pwrVal) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeTiny = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Firestorm_Tiny, impactPos, map);
             }
             impactPos = cellRect.RandomCell;
-            if ( this.age > lastStrikeSmall + Rand.Range(18-(2*pwrVal), 42-(2*pwrVal)) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if ( this.age > lastStrikeSmall + Rand.Range(18-(2*pwrVal), 42-(2*pwrVal)) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeSmall = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Firestorm_Small, impactPos, map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
@@ -91,7 +91,7 @@ namespace TorannMagic
                 {
                     curCell = targets.ToArray<IntVec3>()[i];
 
-                    if (curCell.InBounds(map) && curCell.IsValid)
+                    if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                     {
                         victim = curCell.GetFirstPawn(map);
                         if(victim != null && !victim.Dead && victim.RaceProps.IsFlesh)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_HealingCircle.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_HealingCircle.cs
@@ -148,7 +148,7 @@ namespace TorannMagic
             {                
                 Pawn pawn = null;                
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     pawn = curCell.GetFirstPawn(map);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
@@ -127,7 +127,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     victim = curCell.GetFirstPawn(map);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_IgniteBlood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_IgniteBlood.cs
@@ -128,7 +128,7 @@ namespace TorannMagic
                 for (int i = 0; i < 30; i++)
                 {
                     IntVec3 randomCell = cellList.RandomElement();
-                    if (randomCell.IsValid && randomCell.InBounds(pawn.Map) && !randomCell.Fogged(pawn.Map) && randomCell.Walkable(pawn.Map))
+                    if (randomCell.IsValid && randomCell.InBoundsWithNullCheck(pawn.Map) && !randomCell.Fogged(pawn.Map) && randomCell.Walkable(pawn.Map))
                     {
                         //FilthMaker.MakeFilth(randomCell, this.Map, ThingDefOf.Filth_Blood, 1);
                         //Log.Message("creating blood at " + randomCell);
@@ -185,7 +185,7 @@ namespace TorannMagic
                 List<IntVec3> cellList = GenRadial.RadialCellsAround(this.BF[i].position, .4f + this.BF[i].pulseCount, false).ToList();
                 for (int j = 0; j < cellList.Count; j++)
                 {
-                    if (cellList[j].IsValid && cellList[j].InBounds(this.Map))
+                    if (cellList[j].IsValid && cellList[j].InBoundsWithNullCheck(this.Map))
                     {
                         List<Thing> thingList = cellList[j].GetThingList(this.Map);
                         for (int k = 0; k < thingList.Count; k++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
@@ -152,7 +152,7 @@ namespace TorannMagic
 
         public void DamageCell(IntVec3 c, Thing caster)
         {
-            if (c != default(IntVec3) && c.IsValid && c.InBounds(this.Map))
+            if (c != default(IntVec3) && c.IsValid && c.InBoundsWithNullCheck(this.Map))
             {
                 FleckMaker.ThrowLightningGlow(c.ToVector3Shifted(), this.Map, 1f);
                 List<Thing> thingList = c.GetThingList(this.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningCloud.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningCloud.cs
@@ -93,7 +93,7 @@ namespace TorannMagic
                     for (int i = 0; i < 3; i++)
                     {
                         randomCell = cellRect.RandomCell;
-                        if (randomCell.InBounds(map))
+                        if (randomCell.InBoundsWithNullCheck(map))
                         {
                             victim = randomCell.GetFirstPawn(map);
                             if (victim != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningStorm.cs
@@ -79,7 +79,7 @@ namespace TorannMagic
 				if (((this.boltDelay + this.lastStrike) < this.age))
 				{
 					IntVec3 randomCell = cellRect.RandomCell;
-                    if (randomCell.IsValid && randomCell.InBounds(base.Map))
+                    if (randomCell.IsValid && randomCell.InBoundsWithNullCheck(base.Map))
                     {
                         //Map.weatherManager.eventHandler.AddEvent(new WeatherEvent_LightningStrike(map, randomCell));
                         Map.weatherManager.eventHandler.AddEvent(new TM_WeatherEvent_MeshFlash(map, randomCell, TM_MatPool.standardLightning, DamageDefOf.Flame, this.launcher, -1, 1.9f, 1f, 1.5f));

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Overwhelm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Overwhelm.cs
@@ -92,7 +92,7 @@ namespace TorannMagic
             for (int j = 0; j < targets.Count; j++)
             {
                 IntVec3 curCell = targets[j];
-                if (map != null && curCell.IsValid && curCell.InBounds(map))
+                if (map != null && curCell.IsValid && curCell.InBoundsWithNullCheck(map))
                 {
                     HolyExplosion(pwrVal, verVal, curCell, map, 0.4f);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsychicShock.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsychicShock.cs
@@ -83,7 +83,7 @@ namespace TorannMagic
                     for (int j = 0; j < targets.Count(); j++)
                     {
                         IntVec3 curCell = targets.ToArray<IntVec3>()[j];
-                        if (curCell.IsValid && curCell.InBounds(pawn.Map))
+                        if (curCell.IsValid && curCell.InBoundsWithNullCheck(pawn.Map))
                         {
                             Vector3 angle = GetVector(explosionCenters[i], curCell);
                             if (explosionRadii[i] <= 3)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
@@ -36,7 +36,7 @@ namespace TorannMagic
                 curCell = targets.ToArray<IntVec3>()[i];
 
                 TM_MoteMaker.ThrowPoisonMote(curCell.ToVector3Shifted(), map, .3f);
-                if (curCell.InBounds(map))
+                if (curCell.InBoundsWithNullCheck(map))
                 { 
                     Corpse corpse = null;
                     List<Thing> thingList;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Repulsion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Repulsion.cs
@@ -100,14 +100,14 @@ namespace TorannMagic
                     curCell = cellList[i];
                     Vector3 angle = GetVector(base.Position, curCell);
                     TM_MoteMaker.ThrowArcaneWaveMote(curCell.ToVector3(), this.Map, .3f * (curCell - base.Position).LengthHorizontal, .1f, .05f, .3f, 0, 3, (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat(), (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat());
-                    if (curCell.IsValid && curCell.InBounds(this.Map))
+                    if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Map))
                     {
                         victim = curCell.GetFirstPawn(this.Map);
                         if (victim != null && !victim.Dead)
                         {
                             Vector3 launchVector = GetVector(base.Position, victim.Position);
                             IntVec3 projectedPosition = victim.Position + (force * launchVector).ToIntVec3();
-                            if (projectedPosition.IsValid && projectedPosition.InBounds(this.Map))
+                            if (projectedPosition.IsValid && projectedPosition.InBoundsWithNullCheck(this.Map))
                             {
                                 if (Rand.Chance(TM_Calc.GetSpellSuccessChance(pawn, victim, true)))
                                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
@@ -79,7 +79,7 @@ namespace TorannMagic
 
                 this.CheckSpawnSustainer();
 
-                if (curCell.InBounds(map))
+                if (curCell.InBoundsWithNullCheck(map))
                 {
                     Corpse corpse = null;
                     List<Thing> thingList;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Scorn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Scorn.cs
@@ -183,7 +183,7 @@ namespace TorannMagic
                         for (int j = 0; j < targets.Count(); j++)
                         {
                             IntVec3 curCell = targets[j];
-                            if (this.map != null && curCell.IsValid && curCell.InBounds(this.map))
+                            if (this.map != null && curCell.IsValid && curCell.InBoundsWithNullCheck(this.map))
                             {
                                 GenExplosion.DoExplosion(curCell, this.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.pawn, (int)((this.def.projectile.GetDamageAmount(1, null) * (1 + .15 * pwrVal)) * this.arcaneDmg * Rand.Range(.75f, 1.25f)), 0, TorannMagicDefOf.TM_SoftExplosion, def, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
@@ -102,7 +102,7 @@ namespace TorannMagic
                 {
                     tmpPos.z++;
                 }
-                if(tmpPos.IsValid && tmpPos.InBounds(map) && tmpPos.Walkable(map))
+                if(tmpPos.IsValid && tmpPos.InBoundsWithNullCheck(map) && tmpPos.Walkable(map))
                 {
                     targetPos = tmpPos;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Snowball.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Snowball.cs
@@ -98,7 +98,7 @@ namespace TorannMagic
 			for (int i = 0; i < num; i++)
 			{
 				IntVec3 intVec = center + GenRadial.RadialPattern[i];
-				if (intVec.InBounds(map))
+				if (intVec.InBoundsWithNullCheck(map))
 				{
 					float lengthHorizontal = (center - intVec).LengthHorizontal;
 					float num2 = 1f - lengthHorizontal / radius;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonPoppi.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonPoppi.cs
@@ -59,7 +59,7 @@ namespace TorannMagic
                 for (int i = 0; i < 4 + pwrVal; i++)
                 {
                     centerCell = cellRect.RandomCell;
-                    if (centerCell.IsValid && centerCell.InBounds(pawn.Map) && centerCell.Standable(pawn.Map) && !centerCell.Fogged(pawn.Map))
+                    if (centerCell.IsValid && centerCell.InBoundsWithNullCheck(pawn.Map) && centerCell.Standable(pawn.Map) && !centerCell.Fogged(pawn.Map))
                     {
                         spawnThing.factionDef = TorannMagicDefOf.TM_ElementalFaction;
                         spawnThing.spawnCount = 1;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ThunderStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ThunderStrike.cs
@@ -100,12 +100,12 @@ namespace TorannMagic
             if (directionOffset != default(Vector3))
             {
                 currentPos = (this.origin + directionOffset).ToIntVec3();
-                if (currentPos != default(IntVec3) && currentPos.IsValid && currentPos.InBounds(base.Map) && currentPos.Walkable(base.Map) && currentPos.DistanceToEdge(base.Map) > 3)
+                if (currentPos != default(IntVec3) && currentPos.IsValid && currentPos.InBoundsWithNullCheck(base.Map) && currentPos.Walkable(base.Map) && currentPos.DistanceToEdge(base.Map) > 3)
                 {
                     CellRect cellRect = CellRect.CenteredOn(currentPos, 1);
                     //cellRect.ClipInsideMap(base.Map);
                     IntVec3 rndCell = cellRect.RandomCell;
-                    if (rndCell != null && rndCell != default(IntVec3) && rndCell.IsValid && rndCell.InBounds(base.Map) && rndCell.Walkable(base.Map) && rndCell.DistanceToEdge(base.Map) > 3)
+                    if (rndCell != null && rndCell != default(IntVec3) && rndCell.IsValid && rndCell.InBoundsWithNullCheck(base.Map) && rndCell.Walkable(base.Map) && rndCell.DistanceToEdge(base.Map) > 3)
                     {
                         Map.weatherManager.eventHandler.AddEvent(new TM_WeatherEvent_MeshFlash(base.Map, rndCell, TM_MatPool.chiLightning, TMDamageDefOf.DamageDefOf.TM_ChiBurn, this.launcher, Mathf.RoundToInt(Rand.Range(8, 14) * (1 +(.12f * pwrVal)) * this.arcaneDmg), Rand.Range(1.5f, 2f)));
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_WetGround.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_WetGround.cs
@@ -28,7 +28,7 @@ namespace TorannMagic
             for (int i = 0; i < cells.Count(); i++)
             {
                 curCell = cells.ToArray<IntVec3>()[i];                
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     terrain = curCell.GetTerrain(map);
                     if (terrain.defName == "Sand" || terrain.defName == "Gravel")

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -377,6 +377,7 @@
     <Compile Include="FlyingObject_TimeDelay.cs" />
     <Compile Include="FlyingObject_ValiantCharge.cs" />
     <Compile Include="FlyingObject_Whirlwind.cs" />
+    <Compile Include="GenGridExtensions.cs" />
     <Compile Include="Gizmo_EnergyStatus.cs" />
     <Compile Include="Gizmo_StatusBar.cs" />
     <Compile Include="HarmonyPatches.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
@@ -249,7 +249,7 @@ namespace TorannMagic
             {                
                 if (verb != null && verb.verbProps != null && (pawn.Position - TargetLocA).LengthHorizontal < verb.verbProps.range)
                 {
-                    if (TargetLocA.IsValid && TargetLocA.InBounds(pawn.Map) && !TargetLocA.Fogged(pawn.Map))  //&& TargetLocA.Walkable(pawn.Map)
+                    if (TargetLocA.IsValid && TargetLocA.InBoundsWithNullCheck(pawn.Map) && !TargetLocA.Fogged(pawn.Map))  //&& TargetLocA.Walkable(pawn.Map)
                     {
                         ShootLine shootLine;
                         bool validTarg = verb.TryFindShootLineFromTo(pawn.Position, TargetLocA, out shootLine);

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
@@ -1596,7 +1596,7 @@ namespace TorannMagic
                         cellList = GenRadial.RadialCellsAround(p.Position, 6, true).ToList();
                         for (int i = 0; i < cellList.Count; i++)
                         {
-                            if (cellList[i].IsValid && cellList[i].InBounds(p.Map))
+                            if (cellList[i].IsValid && cellList[i].InBoundsWithNullCheck(p.Map))
                             {
                                 List<Thing> thingList = cellList[i].GetThingList(p.Map);
                                 if (thingList != null && thingList.Count > 0)
@@ -2140,7 +2140,7 @@ namespace TorannMagic
                     for (int i = 0; i < targets.Count; i++)
                     {
                         curCell = targets.ToArray<IntVec3>()[i];
-                        if (curCell.InBounds(map) && curCell.IsValid)
+                        if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                         {
                             victim = curCell.GetFirstPawn(map);
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -1884,7 +1884,7 @@ namespace TorannMagic
                 IntVec3 tmp = currentPos;
                 tmp.x += (Rand.Range(-radius, radius));
                 tmp.z += Rand.Range(-radius, radius);
-                if (tmp.InBounds(pawn.Map) && tmp.IsValid && tmp.Walkable(pawn.Map) && tmp.DistanceToEdge(pawn.Map) > 8)
+                if (tmp.InBoundsWithNullCheck(pawn.Map) && tmp.IsValid && tmp.Walkable(pawn.Map) && tmp.DistanceToEdge(pawn.Map) > 8)
                 {
                     List<Pawn> threatCount = TM_Calc.FindPawnsNearTarget(pawn, 4, tmp, true);
                     if (threatCount != null)
@@ -1918,7 +1918,7 @@ namespace TorannMagic
             for (int k = 0; k < outerCells.Count; k++)
             {
                 IntVec3 wall = outerCells[k];
-                if (wall.IsValid && wall.InBounds(map) && !wall.Fogged(map) && wall.Standable(map) && (!wall.Roofed(map) || allowRoofed))
+                if (wall.IsValid && wall.InBoundsWithNullCheck(map) && !wall.Fogged(map) && wall.Standable(map) && (!wall.Roofed(map) || allowRoofed))
                 {
                     List<Thing> cellList = new List<Thing>();
                     try
@@ -4264,7 +4264,7 @@ namespace TorannMagic
             List<IntVec3> cellList = GenAdjFast.AdjacentCells8Way(cell);
             for (int i = 0; i < cellList.Count; i++)
             {
-                if (cellList[i] != default(IntVec3) && cellList[i].InBounds(map) && cellList[i].Walkable(map) && !cellList[i].Fogged(map))
+                if (cellList[i] != default(IntVec3) && cellList[i].InBoundsWithNullCheck(map) && cellList[i].Walkable(map) && !cellList[i].Fogged(map))
                 {
                     cell = cellList[i];
                     break;
@@ -4278,7 +4278,7 @@ namespace TorannMagic
             List<IntVec3> cellList = GenRadial.RadialCellsAround(cell, range, true).InRandomOrder().ToList();
             for (int i = 0; i < cellList.Count; i++)
             {
-                if (cellList[i] != default(IntVec3) && cellList[i].InBounds(map) && !cellList[i].Fogged(map))
+                if (cellList[i] != default(IntVec3) && cellList[i].InBoundsWithNullCheck(map) && !cellList[i].Fogged(map))
                 {
                     cell = cellList[i];
                     break;
@@ -4577,7 +4577,7 @@ namespace TorannMagic
         {
             //Determines if a cell has a wall built on it
             Building wall = null;
-            if (cell != default(IntVec3) && cell.InBounds(map))
+            if (cell != default(IntVec3) && cell.InBoundsWithNullCheck(map))
             {
                 List<Thing> tList = cell.GetThingList(map);
                 if(tList != null && tList.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeSpin.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeSpin.cs
@@ -116,7 +116,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(base.CasterPawn.Map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(base.CasterPawn.Map) && curCell.IsValid)
                 {
                     victim = curCell.GetFirstPawn(map);
                 }
@@ -125,12 +125,7 @@ namespace TorannMagic
                 {
                     for (int j = 0; j < 2+pwrVal; j++)
                     {
-                        bool newTarg = false;
                         if (Rand.Chance(.5f + .04f*(pwrVal+verVal)))
-                        {
-                            newTarg = true;
-                        }
-                        if (newTarg)
                         {
                             DrawStrike(center, victim.Position.ToVector3(), map);
                             damageEntities(victim, null, GetWeaponDmg(this.CasterPawn), DamageDefOf.Cut);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_EarthSprites.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_EarthSprites.cs
@@ -135,7 +135,7 @@ namespace TorannMagic
                 IntVec3 cell = cellList[i];                
                 bldg = cell.GetFirstBuilding(this.CasterPawn.Map);
                 terrain = cell.GetTerrain(this.CasterPawn.Map);
-                if (cell.InBounds(this.CasterPawn.Map) && bldg == null && terrain == terrainDef)
+                if (cell.InBoundsWithNullCheck(this.CasterPawn.Map) && bldg == null && terrain == terrainDef)
                 {
                     this.CasterPawn.Map.terrainGrid.SetTerrain(cell, TerrainDef.Named("Gravel"));
                     FleckMaker.ThrowSmoke(cell.ToVector3Shifted(), this.CasterPawn.Map, Rand.Range(.8f, 1.2f));

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_FoldReality.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_FoldReality.cs
@@ -79,7 +79,7 @@ namespace TorannMagic
                 portalTarget.canTargetFires = false;
                 portalTarget.canTargetBuildings = false;
                 portalTarget.canTargetItems = false;
-                portalTarget.validator = ((TargetInfo x) => x.IsValid && !x.Cell.Fogged(map) && x.Cell.InBounds(map) && x.Cell.Walkable(map));
+                portalTarget.validator = ((TargetInfo x) => x.IsValid && !x.Cell.Fogged(map) && x.Cell.InBoundsWithNullCheck(map) && x.Cell.Walkable(map));
                 Find.Targeter.BeginTargeting(portalTarget, delegate (LocalTargetInfo x)
                 {
 
@@ -142,7 +142,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];                
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     List<Thing> thingList = curCell.GetThingList(map);
                     for(int j = 0; j < thingList.Count(); j++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
@@ -182,7 +182,7 @@ namespace TorannMagic
             {
                 curCell = targets.ToArray<IntVec3>()[i];
                 FleckMaker.ThrowDustPuff(curCell, map, .2f);
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     victim = curCell.GetFirstPawn(map);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShatterSentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShatterSentinel.cs
@@ -80,7 +80,7 @@ namespace TorannMagic
             for (int i = 0; i < outsideRing.Count; i++)
             {
                 IntVec3 intVec = outsideRing[i];
-                if (intVec.IsValid && intVec.InBounds(map))
+                if (intVec.IsValid && intVec.InBoundsWithNullCheck(map))
                 {
                     Vector3 moteDirection = TM_Calc.GetVector(sentinel.DrawPos.ToIntVec3(), intVec);
                     TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Rubble, sentinel.DrawPos, map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonSpiritWolves.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonSpiritWolves.cs
@@ -61,7 +61,7 @@ namespace TorannMagic
             {
                 foreach (IntVec3 c in tmpList)
                 {
-                    if (c != null && (c.IsValid && c.Standable(map) && c.InBounds(map)))
+                    if (c != null && (c.IsValid && c.Standable(map) && c.InBoundsWithNullCheck(map)))
                     {
                         cellList.Add(c);
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/SeerRing_Fire.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/SeerRing_Fire.cs
@@ -31,7 +31,7 @@ namespace TorannMagic.Weapon
                 try
                 {
                     IntVec3 randomCell = cellRect.RandomCell;
-                    if (randomCell.IsValid && randomCell.InBounds(map))
+                    if (randomCell.IsValid && randomCell.InBoundsWithNullCheck(map))
                     {
                         this.FireExplosion(randomCell, map, 1f);
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Verb_ArcaneBarrier.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Verb_ArcaneBarrier.cs
@@ -67,7 +67,7 @@ namespace TorannMagic.Weapon
             for (int i = 0; i < 5; i++)
             {
                 currentPosR = GetNewPos(currentPosR, this.currentTarget.Cell.x <= destinationRPos.x, this.currentTarget.Cell.z <= destinationRPos.z, false, 0, 0, xProbR, 1 - xProbR);
-                if(currentPosR.IsValid && currentPosR.InBounds(this.CasterPawn.Map) && !currentPosR.Impassable(this.CasterPawn.Map) && this.currentPosR.Walkable(this.CasterPawn.Map))
+                if(currentPosR.IsValid && currentPosR.InBoundsWithNullCheck(this.CasterPawn.Map) && !currentPosR.Impassable(this.CasterPawn.Map) && this.currentPosR.Walkable(this.CasterPawn.Map))
                 {
                     bool flag = true;
                     foreach (Thing current in currentPosR.GetThingList(this.CasterPawn.Map))
@@ -84,7 +84,7 @@ namespace TorannMagic.Weapon
                     }
                 }
                 currentPosL = GetNewPos(currentPosL, this.currentTarget.Cell.x <= destinationLPos.x, this.currentTarget.Cell.z <= destinationLPos.z, false, 0, 0, xProbL, 1 - xProbL);
-                if (currentPosL.IsValid && currentPosL.InBounds(this.CasterPawn.Map) && !currentPosL.Impassable(this.CasterPawn.Map) && this.currentPosL.Walkable(this.CasterPawn.Map))
+                if (currentPosL.IsValid && currentPosL.InBoundsWithNullCheck(this.CasterPawn.Map) && !currentPosL.Impassable(this.CasterPawn.Map) && this.currentPosL.Walkable(this.CasterPawn.Map))
                 {
                     bool flag = true;
                     foreach (Thing current in currentPosL.GetThingList(this.CasterPawn.Map))

--- a/RimWorldOfMagic/RimWorldOfMagic/WeatherEvent_HailWave.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WeatherEvent_HailWave.cs
@@ -63,7 +63,7 @@ namespace TorannMagic
                 validCells.Clear();
                 foreach(IntVec3 c in cells)
                 {
-                    if(c.InBounds(map) && c.DistanceToEdge(map) > 2)
+                    if(c.InBoundsWithNullCheck(map) && c.DistanceToEdge(map) > 2)
                     {
                         if (c.Roofed(map))
                         {
@@ -79,7 +79,7 @@ namespace TorannMagic
                     }
                 }                
                 currentVec = currentVec + (2 *waveDirection);                
-                if(!currentVec.ToIntVec3().InBounds(map))
+                if(!currentVec.ToIntVec3().InBoundsWithNullCheck(map))
                 {                    
                     this.age = this.duration;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/WorldTransport/TM_TransportPodsArrivalActionUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorldTransport/TM_TransportPodsArrivalActionUtility.cs
@@ -111,7 +111,7 @@ namespace TorannMagic.WorldTransport
             for (int i = 0; i < dropPods.Count; i++)
             {
                 IntVec3 result = default(IntVec3);
-                if (!exactCell || !(near.InBounds(map) && near.Walkable(map) && !near.Roofed(map)))
+                if (!exactCell || !(near.InBoundsWithNullCheck(map) && near.Walkable(map) && !near.Roofed(map)))
                 {                    
                     DropCellFinder.TryFindDropSpotNear(near, map, out result, allowFogged: false, canRoofPunch: true);
                 }


### PR DESCRIPTION
Change the InBounds (IntVec3) prefix to an extension method to avoid millions of conditional checks. 

I don't have a ton of context as I'm just starting to look at this project, but I can't seem to think of a reason why vanilla calls to InBounds need to be checked for nulls (unless it's the actual self-destroying pawns that are causing the NullReference). When testing without the prefix I could only get a NullReferenceException somewhat reliably with lullaby cast on spirit wolves. My guess is that during the cast, the pawn itself has been destroyed as it was when cast on spirit wolves right as they were disappearing. 

I have not done extensive testing as I don't really know how besides using dubs performance analyzer and dev tools. I was getting about 10 tps back on my years long colony with a lot of mods. In performance analyzer, the amount of conditions being checked were cut down by millions every couple of seconds at about 110 tps (vanilla + mods seems to call InBounds a LOT, whereas this mod, not as much (about 4 times every few seconds at 120 tps)). Upon testing with just expansions, this mod and the requirements, the difference was not that noticeable (probably didn't increase the number of pawns enough).

Wanted your opinion to see if this approach could work, or if you've seen issues with this approach during development. 

I did NOT include the dll/pdb in the pull request as I figured it's easiest to avoid conflicts that way. I DID include a .gitignore (though I might have it in the wrong place tbh as Rider seems to be ignoring some rules).

