### PR TITLE
Address all 'Merge Casts with Type Checks' for code brevity and less duplicate condition checks

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
@@ -593,10 +593,9 @@ namespace TorannMagic.AutoCast
                 if (pwr.level >= 2)
                 {
                     jobTarget = TM_Calc.FindNearbyAfflictedPawnAny(caster, (int)(abilitydef.MainVerb.range * .9f));
-                    if(jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn)
+                    if(jobTarget != null && jobTarget.Thing is Pawn jobPawn)
                     {
-                        Pawn jobPawn = jobTarget.Thing as Pawn;
-                        if(jobPawn.health != null && jobPawn.health.hediffSet != null && !(jobPawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_DiseaseImmunityHD) || jobPawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_DiseaseImmunity2HD)))
+                        if(jobPawn.health != null && jobPawn.health?.hediffSet != null && !(jobPawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_DiseaseImmunityHD) || jobPawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_DiseaseImmunity2HD)))
                         {
 
                         }
@@ -673,9 +672,8 @@ namespace TorannMagic.AutoCast
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;                
                 if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing != null)
                 {
-                    if (abilitydef == TorannMagicDefOf.TM_CauterizeWound && jobTarget.Thing is Pawn)
+                    if (abilitydef == TorannMagicDefOf.TM_CauterizeWound && jobTarget.Thing is Pawn targetPawn)
                     {
-                        Pawn targetPawn = jobTarget.Thing as Pawn;
                         if (targetPawn.health.HasHediffsNeedingTend(false))
                         {
                             Job job = ability.GetJob(AbilityContext.AI, jobTarget);
@@ -713,15 +711,14 @@ namespace TorannMagic.AutoCast
                 if (jobTarget != null)
                 {
                     float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;
-                    if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget.Thing != null && jobTarget.Thing is Pawn)
+                    if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget.Thing is Pawn targetPawn)
                     {
-                        Pawn targetPawn = jobTarget.Thing as Pawn;
                         if (targetPawn.health != null && targetPawn.health.hediffSet != null && !targetPawn.health.hediffSet.HasHediff(hediffDef, false))
                         {
                             Job job = ability.GetJob(AbilityContext.AI, jobTarget);
                             DoJob.Execute(job, caster);
                             success = true;
-                            TM_Action.TM_Toils.GotoAndWait(jobTarget.Thing as Pawn, caster, Mathf.RoundToInt(ability.Def.MainVerb.warmupTime * 60));
+                            TM_Action.TM_Toils.GotoAndWait(targetPawn, caster, Mathf.RoundToInt(ability.Def.MainVerb.warmupTime * 60));
                         }
                     }
                 }
@@ -772,9 +769,9 @@ namespace TorannMagic.AutoCast
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = TM_Calc.FindNearbyEnemy(caster, (int)(abilitydef.MainVerb.range * .9f));
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;
-                if (distanceToTarget > minRange && distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range))
+                if (
+                    distanceToTarget > minRange && distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing is Pawn targetPawn && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range))
                 {
-                    Pawn targetPawn = jobTarget.Thing as Pawn;
                     if (!targetPawn.health.hediffSet.HasHediff(hediffDef, false))
                     {
                         Job job = ability.GetJob(AbilityContext.AI, jobTarget);
@@ -976,9 +973,8 @@ namespace TorannMagic.AutoCast
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = TM_Calc.FindNearbyPawn(caster, (int)(abilitydef.MainVerb.range * .9f));
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;                
-                if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn)
+                if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing is Pawn targetPawn)
                 {
-                    Pawn targetPawn = jobTarget.Thing as Pawn;
                     if (targetPawn.RaceProps.Humanlike && targetPawn.IsColonist)
                     {
                         bool tatteredApparel = false;
@@ -1049,9 +1045,8 @@ namespace TorannMagic.AutoCast
             {
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = TM_Calc.FindNearbyMage(caster, (int)(abilitydef.MainVerb.range * 1.5f), false);
-                if (jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
+                if (jobTarget != null && jobTarget.Thing is Pawn targetPawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
                 {
-                    Pawn targetPawn = jobTarget.Thing as Pawn;
                     CompAbilityUserMagic targetPawnComp = targetPawn.GetComp<CompAbilityUserMagic>();
                     if (targetPawn.CurJobDef.joyKind != null || targetPawn.CurJobDef == JobDefOf.Wait_Wander || targetPawn.CurJobDef == JobDefOf.GotoWander)
                     {
@@ -1083,9 +1078,8 @@ namespace TorannMagic.AutoCast
             {
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = TM_Calc.FindNearbyFighter(caster, (int)(abilitydef.MainVerb.range * 1.5f), false);
-                if (jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
+                if (jobTarget != null && jobTarget.Thing is Pawn targetPawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
                 {
-                    Pawn targetPawn = jobTarget.Thing as Pawn;
                     CompAbilityUserMight targetPawnComp = targetPawn.GetComp<CompAbilityUserMight>();
                     if ((targetPawn.CurJobDef.joyKind != null && targetPawn.CurJobDef != TorannMagicDefOf.JobDriver_TM_Meditate) || targetPawn.CurJobDef == JobDefOf.Wait_Wander || targetPawn.CurJobDef == JobDefOf.GotoWander)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
@@ -476,15 +476,11 @@ namespace TorannMagic
         public override void PostPreApplyDamage(DamageInfo dinfo, out bool absorbed)
         {
             base.PostPreApplyDamage(dinfo, out absorbed);
-            if(dinfo.Instigator != null)
+            if (dinfo.Instigator is Building instigatorThing)
             {
-                Thing instigatorThing = dinfo.Instigator;
-                if(instigatorThing is Building)
+                if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
                 {
-                    if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
-                    {
-                        this.buildingThreats.AddDistinct(instigatorThing as Building);
-                    }
+                    this.buildingThreats.AddDistinct(instigatorThing);
                 }
             }
         }
@@ -593,9 +589,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
@@ -252,18 +252,17 @@ namespace TorannMagic
             Map map = this.Pawn.Map;
             IntVec3 targetPos = target.Position;
             IntVec3 tmpPos = targetPos;
-            if (!target.DestroyedOrNull() && target is Pawn)
+            if (!target.DestroyedOrNull() && target is Pawn targetPawn)
             {
-                Pawn p = target as Pawn;
-                if (p.Rotation == Rot4.East)
+                if (targetPawn.Rotation == Rot4.East)
                 {
                     tmpPos.x--;
                 }
-                else if (p.Rotation == Rot4.West)
+                else if (targetPawn.Rotation == Rot4.West)
                 {
                     tmpPos.x++;
                 }
-                else if (p.Rotation == Rot4.North)
+                else if (targetPawn.Rotation == Rot4.North)
                 {
                     tmpPos.z--;
                 }
@@ -284,32 +283,31 @@ namespace TorannMagic
 
         public void DoStrike(Thing target)
         {
-            if (target != null && target is Pawn)
+            if (target != null && target is Pawn targetPawn)
             {
-                Pawn t = target as Pawn;
-                if (t.Faction == null || (t.Faction != null && t.Faction != this.Pawn.Faction))
+                if (targetPawn.Faction == null || (targetPawn.Faction != null && targetPawn.Faction != this.Pawn.Faction))
                 {
                     for (int i = 0; i < 4; i++)
                     {
-                        if (!t.DestroyedOrNull() && !t.Dead && t.Map != null)
+                        if (!targetPawn.DestroyedOrNull() && !targetPawn.Dead && targetPawn.Map != null)
                         {
                             int dmg = shadowStrikeDamage + pwrVal;
                             if (Rand.Chance(shadowStrikeCritChance))
                             {
                                 dmg *= 3;
                             }
-                            BodyPartRecord bpr = t.health.hediffSet.GetRandomNotMissingPart(DamageDefOf.Stab, BodyPartHeight.Undefined, BodyPartDepth.Outside);
-                            TM_Action.DamageEntities(target, bpr, dmg, Rand.Range(0f, .5f), DamageDefOf.Stab, this.Pawn);
-                            Vector3 rndPos = t.DrawPos;
+                            BodyPartRecord bpr = targetPawn.health.hediffSet.GetRandomNotMissingPart(DamageDefOf.Stab, BodyPartHeight.Undefined, BodyPartDepth.Outside);
+                            TM_Action.DamageEntities(targetPawn, bpr, dmg, Rand.Range(0f, .5f), DamageDefOf.Stab, this.Pawn);
+                            Vector3 rndPos = targetPawn.DrawPos;
                             rndPos.x += Rand.Range(-.2f, .2f);
                             rndPos.z += Rand.Range(-.2f, .2f);
-                            TM_MoteMaker.ThrowBloodSquirt(rndPos, t.Map, Rand.Range(.6f, 1f));
-                            TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_CrossStrike, rndPos, t.Map, Rand.Range(.6f, 1f), .4f, 0f, Rand.Range(.2f, .5f), 0, 0, 0, Rand.Range(0, 360));
+                            TM_MoteMaker.ThrowBloodSquirt(rndPos, targetPawn.Map, Rand.Range(.6f, 1f));
+                            TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_CrossStrike, rndPos, targetPawn.Map, Rand.Range(.6f, 1f), .4f, 0f, Rand.Range(.2f, .5f), 0, 0, 0, Rand.Range(0, 360));
                         }
                     }
-                    if (!t.DestroyedOrNull() && !t.Dead && !t.Downed)
+                    if (!targetPawn.DestroyedOrNull() && !targetPawn.Dead && !targetPawn.Downed)
                     {
-                        Job job = new Job(JobDefOf.AttackMelee, t);
+                        Job job = new Job(JobDefOf.AttackMelee, targetPawn);
                         this.Pawn.jobs.TryTakeOrderedJob(job);
                     }
                 }
@@ -419,9 +417,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSentinel.cs
@@ -95,9 +95,8 @@ namespace TorannMagic
 
                                 }
 
-                                if(this.target.Thing is Pawn)
+                                if(this.target.Thing is Pawn prisonerPawn)
                                 {
-                                    Pawn prisonerPawn = this.target.Thing as Pawn;
                                     if(prisonerPawn.IsPrisoner)
                                     {
                                         Job job = new Job(JobDefOf.AttackMelee, prisonerPawn);
@@ -240,9 +239,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
@@ -599,15 +599,11 @@ namespace TorannMagic
         public override void PostPreApplyDamage(DamageInfo dinfo, out bool absorbed)
         {
             base.PostPreApplyDamage(dinfo, out absorbed);
-            if(dinfo.Instigator != null)
+            if (dinfo.Instigator is Building instigatorThing)
             {
-                Thing instigatorThing = dinfo.Instigator;
-                if(instigatorThing is Building)
+                if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
                 {
-                    if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
-                    {
-                        this.buildingThreats.AddDistinct(instigatorThing as Building);
-                    }
+                    this.buildingThreats.AddDistinct(instigatorThing);
                 }
             }
         }
@@ -678,9 +674,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonLichController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonLichController.cs
@@ -606,16 +606,12 @@ namespace TorannMagic
         {
             base.PostPreApplyDamage(dinfo, out absorbed);
             //Log.Message("taking damage");
-            if (dinfo.Instigator != null)
+            if (dinfo.Instigator is Building instigatorThing)
             {
-                Thing instigatorThing = dinfo.Instigator;
-                if (instigatorThing is Building)
+                if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
                 {
-                    if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
-                    {
-                        //Log.Message("adding building threat");
-                        this.buildingThreats.AddDistinct(instigatorThing as Building);
-                    }
+                    //Log.Message("adding building threat");
+                    this.buildingThreats.AddDistinct(instigatorThing);
                 }
             }
         }
@@ -689,9 +685,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_DivineBlessing.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_DivineBlessing.cs
@@ -33,13 +33,11 @@ namespace TorannMagic.Conditions
                 
                 for (int i = 0; i < allThings.Count; i++)
                 {
-                    Thing t = allThings[i];
-                    if(t != null && t is Corpse)
+                    if (allThings[i] is Corpse corpse)
                     {
-                        Corpse c = t as Corpse;
-                        if(c.InnerPawn.IsColonist && !c.IsDessicated())
+                        if(corpse.InnerPawn.IsColonist && !corpse.IsDessicated())
                         {
-                            potentialResurrection.Add(c);
+                            potentialResurrection.Add(corpse);
                         }
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/CompEnchantedItem.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/CompEnchantedItem.cs
@@ -174,10 +174,9 @@ namespace TorannMagic.Enchantment
 
         private void InitializeAbilities(ThingWithComps abilityThing)
         {
-            if (abilityThing is Apparel)
+            if (abilityThing is Apparel abilityApparel)
             {
-                Apparel abilityApparel = abilityThing as Apparel;
-                if (abilityApparel != null && abilityApparel.Wearer != null)
+                if (abilityApparel.Wearer != null)
                 {
                     CompAbilityItem comp = abilityApparel.TryGetComp<CompAbilityItem>();
                     if (comp != null)
@@ -231,9 +230,8 @@ namespace TorannMagic.Enchantment
                     }
                 }
                 Thing primary = this.parent as Thing;
-                if(primary != null && primary.ParentHolder is Pawn_EquipmentTracker)
-                {                    
-                    Pawn_EquipmentTracker pet = primary.ParentHolder as Pawn_EquipmentTracker;
+                if(primary != null && primary.ParentHolder is Pawn_EquipmentTracker pet)
+                {
                     if(pet.pawn != null && pet.pawn.equipment != null && pet.pawn.equipment.Primary == primary)
                     {
                         if (pet.pawn.health.hediffSet.GetFirstHediffOfDef(hediff, false) != null)
@@ -269,9 +267,8 @@ namespace TorannMagic.Enchantment
                     // abilities;
                 }
                 ThingWithComps primary = this.parent as ThingWithComps;
-                if (primary != null && primary.ParentHolder is Pawn_EquipmentTracker)
+                if (primary != null && primary.ParentHolder is Pawn_EquipmentTracker pet)
                 {
-                    Pawn_EquipmentTracker pet = primary.ParentHolder as Pawn_EquipmentTracker;
                     if (pet.pawn != null && pet.pawn.equipment != null && pet.pawn.equipment.Primary == primary)
                     {
                         this.InitializeAbilities(primary);

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitInfuse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitInfuse.cs
@@ -43,9 +43,8 @@ namespace TorannMagic.Enchantment
             
             if (this.currentTarget != null && base.CasterPawn != null)
             {
-                if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
+                if(this.currentTarget.Thing is Pawn victim)
                 {
-                    Pawn victim = this.currentTarget.Thing as Pawn;
                     if(victim.Faction != null && victim.RaceProps.Humanlike && victim.story != null && victim.story.traits != null && !TM_Calc.IsUndeadNotVamp(victim))
                     {
                         int traitsApplied = 0;

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitThief.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitThief.cs
@@ -42,9 +42,8 @@ namespace TorannMagic.Enchantment
             bool result = false;
             if (this.currentTarget != null && base.CasterPawn != null)
             {
-                if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
+                if(this.currentTarget.Thing is Pawn victim)
                 {
-                    Pawn victim = this.currentTarget.Thing as Pawn;
                     if(victim.Faction != null && victim.RaceProps.Humanlike && victim.story != null && victim.story.traits != null && victim.story.traits.allTraits.Count > 0 && !TM_Calc.IsUndead(victim))
                     {
                         if (Rand.Chance(TM_Calc.GetSpellSuccessChance(this.CasterPawn, victim, true)))

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitor.cs
@@ -39,9 +39,8 @@ namespace TorannMagic.Enchantment
             CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
             if (this.currentTarget != null && base.CasterPawn != null && comp != null)
             {
-                if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
+                if(this.currentTarget.Thing is Pawn traitor)
                 {
-                    Pawn traitor = this.currentTarget.Thing as Pawn;
                     if(traitor.Faction != null && traitor.Faction != this.CasterPawn.Faction && traitor.RaceProps.Humanlike)
                     {
                         if (Rand.Chance(TM_Calc.GetSpellSuccessChance(this.CasterPawn, traitor, true)))

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
@@ -394,18 +394,17 @@ namespace TorannMagic
                 hitThing.TakeDamage(this.impactDamage.Value);
             }
             ImpactOverride();
-            if (this.flyingThing is Pawn)
+            if (this.flyingThing is Pawn flyingPawn)
             {
                 try
                 {
                     SoundDefOf.Ambient_AltitudeWind.sustainFadeoutTime.Equals(30.0f);
 
-                    GenSpawn.Spawn(this.flyingThing, base.Position, base.Map);
-                    Pawn p = this.flyingThing as Pawn;
+                    GenSpawn.Spawn(flyingPawn, base.Position, base.Map);
                     if (this.earlyImpact)
                     {
-                        damageEntities(p, this.impactForce, DamageDefOf.Blunt);
-                        damageEntities(p, 2 * this.impactForce, DamageDefOf.Stun);
+                        damageEntities(flyingPawn, this.impactForce, DamageDefOf.Blunt);
+                        damageEntities(flyingPawn, 2 * this.impactForce, DamageDefOf.Stun);
                     }
                     this.Destroy(DestroyMode.Vanish);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
@@ -349,17 +349,16 @@ namespace TorannMagic
                 if (this.flyingThing != null)
                 {
                     GenSpawn.Spawn(this.flyingThing, base.Position, base.Map);
-                    if (this.flyingThing is Pawn)
+                    if (this.flyingThing is Pawn flyingPawn)
                     {
-                        Pawn p = this.flyingThing as Pawn;
-                        if (p.IsColonist && this.drafted)
+                        if (flyingPawn.IsColonist && this.drafted)
                         {
-                            p.drafter.Drafted = true;
+                            flyingPawn.drafter.Drafted = true;
                         }
                         if (this.earlyImpact)
                         {
-                            damageEntities(p, this.impactForce, DamageDefOf.Blunt);
-                            damageEntities(p, this.impactForce, DamageDefOf.Stun);
+                            damageEntities(flyingPawn, this.impactForce, DamageDefOf.Blunt);
+                            damageEntities(flyingPawn, this.impactForce, DamageDefOf.Stun);
                         }
                     }
                     else if (flyingThing.def.thingCategories != null && (flyingThing.def.thingCategories.Contains(ThingCategoryDefOf.Chunks) || flyingThing.def.thingCategories.Contains(ThingCategoryDef.Named("StoneChunks"))))

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
@@ -838,11 +838,10 @@ namespace TorannMagic
             }
             else if(solAction == SoLAction.BrightenDay)
             {
-                if(this.assignedTarget != null && this.assignedTarget is Pawn)
+                if(this.assignedTarget is Pawn assignedPawn)
                 {
-                    Pawn p = this.assignedTarget as Pawn;
                     ActualLightCost(6f);
-                    p.needs.mood.thoughts.memories.TryGainMemory(TorannMagicDefOf.TM_BrightDayTD);
+                    assignedPawn.needs.mood.thoughts.memories.TryGainMemory(TorannMagicDefOf.TM_BrightDayTD);
                     Action_CircleTarget(this.assignedTarget, out destTarget);
                     queuedAction = SoLAction.Returning;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_TimeDelay.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_TimeDelay.cs
@@ -328,12 +328,11 @@ namespace TorannMagic
             if (this.Map != null)
             {
                 GenPlace.TryPlaceThing(this.flyingThing, base.Position, base.Map, ThingPlaceMode.Direct);
-                if (this.flyingThing is Pawn)
+                if (this.flyingThing is Pawn flyingPawn)
                 {
-                    Pawn p = this.flyingThing as Pawn;
-                    if (p.IsColonist && this.drafted && p.drafter != null)
+                    if (flyingPawn.IsColonist && this.drafted && flyingPawn.drafter != null)
                     {
-                        p.drafter.Drafted = true;
+                        flyingPawn.drafter.Drafted = true;
                     }
                 }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompGolem.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompGolem.cs
@@ -66,15 +66,11 @@ namespace TorannMagic.Golems
         {
             get
             {
-                if(threatTarget != null)
+                if (threatTarget is Pawn pawn)
                 {
-                    if (threatTarget is Pawn)
+                    if(pawn.DestroyedOrNull() || pawn.Dead || pawn.Downed || pawn.Map == null)
                     {
-                        Pawn p = threatTarget as Pawn;
-                        if(p.DestroyedOrNull() || p.Dead || p.Downed || p.Map == null)
-                        {
-                            threatTarget = null;
-                        }
+                        threatTarget = null;
                     }
                 }
                 return threatTarget;
@@ -98,14 +94,13 @@ namespace TorannMagic.Golems
                 {
                     return false;
                 }
-                if (targetThing is Pawn)
+                if (targetThing is Pawn targetPawn)
                 {
-                    Pawn p = targetThing as Pawn;
-                    if (p.Dead || p.Downed)
+                    if (targetPawn.Dead || targetPawn.Downed)
                     {
                         return false;
                     }
-                    if (checkThreatPath && p.CanReach(source, PathEndMode.ClosestTouch, Danger.Deadly, false, false, TraverseMode.PassDoors))
+                    if (checkThreatPath && targetPawn.CanReach(source, PathEndMode.ClosestTouch, Danger.Deadly, false, false, TraverseMode.PassDoors))
                     {
                         return false;
                     }
@@ -324,9 +319,9 @@ namespace TorannMagic.Golems
                 {
                     foreach(Thing t in innerContainer)
                     {
-                        if(t is Building_TMGolemBase)
+                        if(t is Building_TMGolemBase tmGolemBase)
                         {
-                            dormantThing = t as Building_TMGolemBase;
+                            dormantThing = tmGolemBase;
                         }
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ApplyDamage.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ApplyDamage.cs
@@ -30,9 +30,9 @@ namespace TorannMagic.Golems
         public override void Apply(LocalTargetInfo target, Pawn caster, TM_GolemAbilityDef ability, float effectLevel = 1f, float effectBonus = 1f)
         {
             base.Apply(target, caster, ability);
-            if (target.Thing != null && target.Thing is Pawn)
+            if (target.Thing is Pawn pawn)
             {
-                TM_Action.DamageEntities_AoE(damageType, damageAmount * LevelModifier * effectBonus, armorPenetration * effectBonus, caster, target.Thing as Pawn, caster.Map, splashRadius);
+                TM_Action.DamageEntities_AoE(damageType, damageAmount * LevelModifier * effectBonus, armorPenetration * effectBonus, caster, pawn, caster.Map, splashRadius);
             }
         }
 
@@ -42,24 +42,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (p.health == null)
-            {
-                return false;
-            }
-            if (p.health.hediffSet == null)
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || pawn.health == null || pawn.health.hediffSet == null)
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ApplyHediff.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ApplyHediff.cs
@@ -28,10 +28,9 @@ namespace TorannMagic.Golems
         public override void Apply(LocalTargetInfo target, Pawn caster, TM_GolemAbilityDef ability, float effectLevel = 1f, float effectBonus = 1f)
         {
             base.Apply(target, caster, ability);
-            if (target.Thing != null && target.Thing is Pawn)
+            if (target.Thing is Pawn pawn)
             {
-                Pawn p = target.Thing as Pawn;
-                HealthUtility.AdjustSeverity(p, hediff, severity * LevelModifier * effectBonus);
+                HealthUtility.AdjustSeverity(pawn, hediff, severity * LevelModifier * effectBonus);
             }
         }
 
@@ -41,30 +40,15 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (p.health == null)
-            {
-                return false;
-            }
-            if (p.health.hediffSet == null)
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || pawn.health == null || pawn.health.hediffSet == null)
             {
                 return false;
             }
             if (!canStack)
             {
-                Hediff hd = p.health.hediffSet.GetFirstHediffOfDef(hediff);
+                Hediff hd = pawn.health.hediffSet.GetFirstHediffOfDef(hediff);
                 if (hd != null)
                 {
                     return false;

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_Dismember.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_Dismember.cs
@@ -24,9 +24,8 @@ namespace TorannMagic.Golems
         public override void Apply(LocalTargetInfo target, Pawn caster, TM_GolemAbilityDef ability, float effectLevel = 1f, float effectBonus = 1f)
         {
             base.Apply(target, caster, ability);
-            if (target.Thing != null && target.Thing is Pawn)
+            if (target.Thing is Pawn victim)
             {
-                Pawn victim = target.Thing as Pawn;
                 List<BodyPartRecord> bprList = new List<BodyPartRecord>();
                 bprList.Clear();
                 List<BodyPartRecord> bprLegs = victim.health.hediffSet.GetNotMissingParts(BodyPartHeight.Undefined, BodyPartDepth.Outside, BodyPartTagDefOf.MovingLimbCore, null).ToList();
@@ -73,24 +72,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (p.health == null)
-            {
-                return false;
-            }
-            if (p.health.hediffSet == null)
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || pawn.health == null || pawn.health.hediffSet == null)
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_HealPawn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_HealPawn.cs
@@ -33,20 +33,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (!TM_Calc.IsPawnInjured(p))
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || !TM_Calc.IsPawnInjured(pawn))
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_LaunchThing.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_LaunchThing.cs
@@ -51,10 +51,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing != null && target.Thing is Pawn)
+            if (target.Thing is Pawn pawn)
             {
-                Pawn p = target.Thing as Pawn;
-                if (p.Dead || p.Downed)
+                if (pawn.Dead || pawn.Downed)
                 {
                     return false;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ShieldPawn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ShieldPawn.cs
@@ -42,20 +42,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (!TM_Calc.IsPawnInjured(p))
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || !TM_Calc.IsPawnInjured(pawn))
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/ITab_GolemPawn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/ITab_GolemPawn.cs
@@ -36,17 +36,12 @@ namespace TorannMagic.Golems
         {
             get
             {
-                Thing singleSelectedThing = Find.Selector.SingleSelectedThing;
-                if (singleSelectedThing != null && singleSelectedThing is TMPawnGolem)
+                if (Find.Selector.SingleSelectedThing is TMPawnGolem golemPawn)
                 {
-                    TMPawnGolem golem_pawn = singleSelectedThing as TMPawnGolem;
-                    if(golem_pawn != null)
+                    CompGolem cg = golemPawn.TryGetComp<CompGolem>();
+                    if (cg != null)
                     {
-                        CompGolem cg = golem_pawn.TryGetComp<CompGolem>();
-                        if (cg != null)
-                        {
-                            return cg.Upgrades;
-                        }
+                        return cg.Upgrades;
                     }
                 }
                 return null;

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/ITab_GolemWorkstation.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/ITab_GolemWorkstation.cs
@@ -23,14 +23,9 @@ namespace TorannMagic.Golems
         {
             get
             {
-                Thing singleSelectedThing = Find.Selector.SingleSelectedThing;
-                if (singleSelectedThing != null && singleSelectedThing is Building_TMGolemBase)
+                if (Find.Selector.SingleSelectedThing is Building_TMGolemBase golemBuilding)
                 {
-                    Building_TMGolemBase golem_building = singleSelectedThing as Building_TMGolemBase;
-                    if(golem_building != null)
-                    {
-                        return golem_building.Upgrades;
-                    }
+                    return golemBuilding.Upgrades;
                 }
                 return null;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/JobGiver_EngageThreatInRange.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/JobGiver_EngageThreatInRange.cs
@@ -30,9 +30,8 @@ namespace TorannMagic.Golems
             {
                 return null;
             }
-            if (meleeThreat is Pawn)
+            if (meleeThreat is Pawn meleeThreatPawn)
             {
-                Pawn meleeThreatPawn = meleeThreat as Pawn;
                 if (meleeThreatPawn.IsInvisible())
                 {
                     return null;

--- a/RimWorldOfMagic/RimWorldOfMagic/Hediff_ApothecaryHerbs.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Hediff_ApothecaryHerbs.cs
@@ -63,11 +63,10 @@ namespace TorannMagic
                 {
                     this.Severity += .4f * (1f + (.1f * herbVer));
                 }
-                if(this.pawn.Map == null && this.pawn.ParentHolder is Caravan)
+                if(this.pawn.Map == null && this.pawn.ParentHolder is Caravan caravan)
                 {
-                    Caravan car = this.pawn.ParentHolder as Caravan;
                     bool flag;
-                    if (!car.NightResting)
+                    if (!caravan.NightResting)
                     {
                         this.Severity += (ForagedFoodPerDayCalculator.GetBaseForagedNutritionPerDay(this.pawn, out flag)/50f) * (1f + (.05f * herbVer));
                     }                    

--- a/RimWorldOfMagic/RimWorldOfMagic/Need_Mana.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Need_Mana.cs
@@ -460,10 +460,9 @@ namespace TorannMagic
                                             }
                                             TM_MoteMaker.ThrowBloodSquirt(current.Position.ToVector3Shifted(), current.Map, 2.5f);
                                         }
-                                        else if (current.ParentHolder != null && current.ParentHolder is Caravan)
+                                        else if (current.ParentHolder is Caravan caravan)
                                         {
-                                            Caravan van = current.ParentHolder as Caravan;                                            
-                                            van.RemovePawn(current);
+                                            caravan.RemovePawn(current);
                                         }
                                         current.Destroy();
                                         undeadCount--;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChargeBattery.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChargeBattery.cs
@@ -24,10 +24,9 @@ namespace TorannMagic
             bldg = cellRect.CenterCell.GetFirstBuilding(map);            
             if (bldg != null)
             {
-                if (bldg is Building_TMGolemBase)
+                if (bldg is Building_TMGolemBase golemBase)
                 {
-                    Building_TMGolemBase gb = bldg as Building_TMGolemBase;
-                    gb.Energy.AddEnergyFlat(400 * comp.arcaneDmg);
+                    golemBase.Energy.AddEnergyFlat(400 * comp.arcaneDmg);
                 }
                 else if (bldg.GetComp<CompPowerBattery>() != null)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
@@ -165,9 +165,8 @@ namespace TorannMagic
         {
             int amt = Mathf.RoundToInt(Rand.Range(.5f, 1.5f) * d);
             DamageInfo dinfo = new DamageInfo(type, amt, 0, (float)-1, null, null, null, DamageInfo.SourceCategory.ThingOrUnknown);
-            if (this.launcher != null && this.launcher is Pawn)
+            if (this.launcher is Pawn caster)
             {
-                Pawn caster = this.launcher as Pawn;
                 dinfo = new DamageInfo(type, amt, 0, (float)-1, caster, null, null, DamageInfo.SourceCategory.ThingOrUnknown);                
             }
             bool flag = e != null;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
@@ -61,16 +61,15 @@ namespace TorannMagic
         private void Initialize(Thing t)
         {
             GenClamor.DoClamor(this, 2f, ClamorDefOf.Ability);
-            if (!t.DestroyedOrNull() && t is Pawn)
+            if (!t.DestroyedOrNull() && t is Pawn pawn)
             {
-                Pawn p = t as Pawn;
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
                 if (comp != null && comp.MagicData != null)
                 {
                     //pwrVal = TM_Calc.GetMagicSkillLevel(p, comp.MagicData.MagicPowerSkill_ChainLightning, "TM_ChainLightning", "_pwr", true);
                     //verVal = TM_Calc.GetMagicSkillLevel(p, comp.MagicData.MagicPowerSkill_ChainLightning, "TM_ChainLightning", "_ver", true);
-                    pwrVal = TM_Calc.GetSkillPowerLevel(p, TorannMagicDefOf.TM_ChainLightning);
-                    verVal = TM_Calc.GetSkillVersatilityLevel(p, TorannMagicDefOf.TM_ChainLightning);
+                    pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_ChainLightning);
+                    verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_ChainLightning);
                     this.arcaneDmg = comp.arcaneDmg;
                 }                
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
@@ -238,10 +238,9 @@ namespace TorannMagic
                                     }
                                 }
                             }
-                            else if (corpseThing is Pawn)
+                            else if (corpseThing is Pawn undeadPawn)
                             {
-                                Pawn undeadPawn = corpseThing as Pawn;
-                                if(undeadPawn != pawn && !TM_Calc.IsNecromancer(undeadPawn) && TM_Calc.IsUndead(corpseThing as Pawn))
+                                if(undeadPawn != pawn && !TM_Calc.IsNecromancer(undeadPawn) && TM_Calc.IsUndead(undeadPawn))
                                 {
                                     RemoveHediffsAddictionsAndPermanentInjuries(undeadPawn);
                                     TM_MoteMaker.ThrowPoisonMote(curCell.ToVector3Shifted(), map, .6f);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Refraction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Refraction.cs
@@ -166,27 +166,26 @@ namespace TorannMagic
                 for (int i = 0; i < cellList.Count; i++)
                 {
                     Thing t = cellList[i];
-                    if (t is Projectile && t.def.defName != "Projectile_Refraction" && !(t is Mote))
+                    if (t is Projectile projectile && projectile.def.defName != "Projectile_Refraction")
                     {
-                        Projectile proj = t as Projectile;
-                        IntVec3 projOrigin = Traverse.Create(root: proj).Field(name: "origin").GetValue<Vector3>().ToIntVec3();
+                        IntVec3 projOrigin = Traverse.Create(root: projectile).Field(name: "origin").GetValue<Vector3>().ToIntVec3();
 
-                        if (proj != null && proj.Launcher != null && (proj.Launcher.Faction != null || proj.def.defName == "Projectile_LightLaser") && !proj.def.projectile.flyOverhead && !wallPositions.Contains(projOrigin))
+                        if (projectile.Launcher != null && (projectile.Launcher.Faction != null || projectile.def.defName == "Projectile_LightLaser") && !projectile.def.projectile.flyOverhead && !wallPositions.Contains(projOrigin))
                         {
-                            if (proj.Launcher.Faction != this.caster.Faction)
+                            if (projectile.Launcher.Faction != this.caster.Faction)
                             {
                                 Vector3 displayEffect = this.wallPositions[k].ToVector3Shifted();
                                 displayEffect.x += Rand.Range(-.2f, .2f);
                                 displayEffect.z += Rand.Range(-.2f, .2f);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_LightBarrier, displayEffect, this.Map, .4f, .2f, .05f, .2f, 0, 0, 0, 0);
-                                IntVec3 targetVec = Traverse.Create(root: proj).Field(name: "destination").GetValue<Vector3>().ToIntVec3();
+                                IntVec3 targetVec = Traverse.Create(root: projectile).Field(name: "destination").GetValue<Vector3>().ToIntVec3();
                                 float targetRange = (this.Position - targetVec).LengthHorizontal;
-                                LocalTargetInfo initialTarget = proj.intendedTarget;
+                                LocalTargetInfo initialTarget = projectile.intendedTarget;
                                 targetVec.x += Mathf.RoundToInt(Rand.Range(-eMissVar, eMissVar) * targetRange);
                                 targetVec.z += Mathf.RoundToInt(Rand.Range(-eMissVar, eMissVar) * targetRange);
-                                TM_CopyAndLaunchProjectile.CopyAndLaunchThingFromPosition(proj.def, proj.Launcher, wallPositions[k], this.Map, targetVec, intendedTarget, ProjectileHitFlags.All, null);
-                                proj.Destroy(DestroyMode.Vanish);
-                                this.wallEnergy -= proj.def.projectile.GetDamageAmount(1f);
+                                TM_CopyAndLaunchProjectile.CopyAndLaunchThingFromPosition(projectile.def, projectile.Launcher, wallPositions[k], this.Map, targetVec, intendedTarget, ProjectileHitFlags.All, null);
+                                projectile.Destroy(DestroyMode.Vanish);
+                                this.wallEnergy -= projectile.def.projectile.GetDamageAmount(1f);
                             }
                             else
                             {
@@ -194,13 +193,13 @@ namespace TorannMagic
                                 displayEffect.x += Rand.Range(-.2f, .2f);
                                 displayEffect.z += Rand.Range(-.2f, .2f);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_LightBarrier, displayEffect, this.Map, .4f, .2f, .05f, .2f, 0, 0, 0, 0);
-                                IntVec3 targetCell = proj.intendedTarget.Cell;
+                                IntVec3 targetCell = projectile.intendedTarget.Cell;
                                 float targetRange = (this.Position - targetCell).LengthHorizontal;
-                                LocalTargetInfo initialTarget = proj.intendedTarget;
+                                LocalTargetInfo initialTarget = projectile.intendedTarget;
                                 targetCell.x += Mathf.RoundToInt(Rand.Range(-fMissVar, fMissVar) * targetRange);
                                 targetCell.z += Mathf.RoundToInt(Rand.Range(-fMissVar, fMissVar) * targetRange);
-                                TM_CopyAndLaunchProjectile.CopyAndLaunchThingFromPosition(proj.def, proj.Launcher, wallPositions[k], this.Map, targetCell, initialTarget, ProjectileHitFlags.All);
-                                this.wallEnergy -= proj.def.projectile.GetDamageAmount(1f);
+                                TM_CopyAndLaunchProjectile.CopyAndLaunchThingFromPosition(projectile.def, projectile.Launcher, wallPositions[k], this.Map, targetCell, initialTarget, ProjectileHitFlags.All);
+                                this.wallEnergy -= projectile.def.projectile.GetDamageAmount(1f);
                             }
                         }
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
@@ -64,12 +64,11 @@ namespace TorannMagic
 
             if (!this.initialized)
             {
-                if (this.launcher is Pawn)
+                if (this.launcher is Pawn casterPawn)
                 {
-                    caster = this.launcher as Pawn;
-                    CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-                    MagicPowerSkill ver = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_ver");
-                    MagicPowerSkill pwr = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_eff");
+                    CompAbilityUserMagic comp = casterPawn.GetComp<CompAbilityUserMagic>();
+                    MagicPowerSkill ver = casterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_ver");
+                    MagicPowerSkill pwr = casterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_eff");
                     verVal = ver.level;
                     pwrVal = pwr.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
@@ -83,18 +83,17 @@ namespace TorannMagic
             this.startPos = caster.Position;
             IntVec3 targetPos = target.Position;
             IntVec3 tmpPos = targetPos;
-            if(!target.DestroyedOrNull() && target is Pawn)
+            if(!target.DestroyedOrNull() && target is Pawn pawn)
             {
-                Pawn p = target as Pawn;
-                if(p.Rotation == Rot4.East)
+                if(pawn.Rotation == Rot4.East)
                 {
                     tmpPos.x--;
                 }
-                else if(p.Rotation == Rot4.West)
+                else if(pawn.Rotation == Rot4.West)
                 {
                     tmpPos.x++;
                 }
-                else if(p.Rotation == Rot4.North)
+                else if(pawn.Rotation == Rot4.North)
                 {
                     tmpPos.z--;
                 }
@@ -142,10 +141,9 @@ namespace TorannMagic
 
         public void DoStrike(Thing target)
         {
-            if (target != null && target is Pawn)
+            if (target != null && target is Pawn targetPawn)
             {
-                Pawn t = target as Pawn;
-                if (t.Faction == null || (t.Faction != null && t.Faction != caster.Faction))
+                if (targetPawn.Faction == null || (targetPawn.Faction != null && targetPawn.Faction != caster.Faction))
                 {
                     //List<BodyPartRecord> partList = new List<BodyPartRecord>();
                     //partList.Clear();
@@ -159,26 +157,26 @@ namespace TorannMagic
                     //}
                     for (int i = 0; i < 4; i++)
                     {
-                        if (!t.DestroyedOrNull() && !t.Dead && t.Map != null)
+                        if (!targetPawn.DestroyedOrNull() && !targetPawn.Dead && targetPawn.Map != null)
                         {
                             int dmg = Mathf.RoundToInt(this.weaponDamage);
                             if (Rand.Chance(critChance))
                             {
                                 dmg *= 3;
                             }
-                            BodyPartRecord bpr = t.health.hediffSet.GetRandomNotMissingPart(DamageDefOf.Stab, BodyPartHeight.Undefined, BodyPartDepth.Outside);
-                            TM_Action.DamageEntities(target, bpr, dmg, Rand.Range(0f, .5f), DamageDefOf.Stab, this.caster);
-                            Vector3 rndPos = t.DrawPos;
+                            BodyPartRecord bpr = targetPawn.health.hediffSet.GetRandomNotMissingPart(DamageDefOf.Stab, BodyPartHeight.Undefined, BodyPartDepth.Outside);
+                            TM_Action.DamageEntities(targetPawn, bpr, dmg, Rand.Range(0f, .5f), DamageDefOf.Stab, this.caster);
+                            Vector3 rndPos = targetPawn.DrawPos;
                             rndPos.x += Rand.Range(-.2f, .2f);
                             rndPos.z += Rand.Range(-.2f, .2f);
-                            TM_MoteMaker.ThrowBloodSquirt(rndPos, t.Map, Rand.Range(.6f, 1f));
-                            TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_CrossStrike, rndPos, t.Map, Rand.Range(.6f, 1f), .4f, 0f, Rand.Range(.2f, .5f), 0, 0, 0, Rand.Range(0, 360));
+                            TM_MoteMaker.ThrowBloodSquirt(rndPos, targetPawn.Map, Rand.Range(.6f, 1f));
+                            TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_CrossStrike, rndPos, targetPawn.Map, Rand.Range(.6f, 1f), .4f, 0f, Rand.Range(.2f, .5f), 0, 0, 0, Rand.Range(0, 360));
                         }
                     }
-                    if (!t.DestroyedOrNull() && !t.Dead && !t.Downed && caster.IsColonist)
+                    if (!targetPawn.DestroyedOrNull() && !targetPawn.Dead && !targetPawn.Downed && caster.IsColonist)
                     {
                         caster.drafter.Drafted = true;
-                        Job job = new Job(JobDefOf.AttackMelee, t);
+                        Job job = new Job(JobDefOf.AttackMelee, targetPawn);
                         caster.jobs.TryTakeOrderedJob(job, JobTag.DraftedOrder);
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spinning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spinning.cs
@@ -18,9 +18,8 @@ namespace TorannMagic
         public override void Tick()
         {
             base.Tick();
-            if(Find.TickManager.TicksGame % 2 == 0 && daggerCount > 0 && this.launcher != null && this.launcher is Pawn)
+            if(Find.TickManager.TicksGame % 2 == 0 && daggerCount > 0 && this.launcher is Pawn caster)
             {
-                Pawn caster = this.launcher as Pawn;
                 CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
                 if(comp != null)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spite.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spite.cs
@@ -40,9 +40,9 @@ namespace TorannMagic
                 verVal = 3;
             }
 
-            if(victim == null && this.intendedTarget != null && this.intendedTarget.Thing != null && this.intendedTarget.Thing is Pawn)
+            if(victim == null && this.intendedTarget != null && this.intendedTarget.Thing is Pawn intendedPawn)
             {
-                victim = this.intendedTarget.Thing as Pawn;
+                victim = intendedPawn;
             }
             
             if (victim != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_TempestStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_TempestStrike.cs
@@ -46,9 +46,8 @@ namespace TorannMagic
         {
             if (spinCheck)
             {
-                if (this.launcher is Pawn)
+                if (this.launcher is Pawn pawn)
                 {
-                    Pawn pawn = this.launcher as Pawn;
                     if (pawn.equipment != null && pawn.equipment.Primary != null)
                     {
                         ThingWithComps weaponComp = pawn.equipment.Primary;

--- a/RimWorldOfMagic/RimWorldOfMagic/StatPart_Undead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/StatPart_Undead.cs
@@ -13,10 +13,9 @@ namespace TorannMagic
 
         public override void TransformValue(StatRequest req, ref float val)
         {
-            if (req.HasThing && req.Thing is Pawn)
+            if (req.HasThing && req.Thing is Pawn reqPawn)
             {
-                Pawn reqPawn = req.Thing as Pawn;
-                if (reqPawn != null && TM_Calc.IsUndeadNotVamp(reqPawn))
+                if (TM_Calc.IsUndeadNotVamp(reqPawn))
                 {
                     val *= 0f;
                 }
@@ -25,10 +24,9 @@ namespace TorannMagic
 
         public override string ExplanationPart(StatRequest req)
         {
-            if (req.HasThing && req.Thing is Pawn)
+            if (req.HasThing && req.Thing is Pawn reqPawn)
             {
-                Pawn reqPawn = req.Thing as Pawn;
-                if (reqPawn != null && TM_Calc.IsUndeadNotVamp(reqPawn))
+                if (TM_Calc.IsUndeadNotVamp(reqPawn))
                 {
                     return "TM_StatsReport_Undead".Translate();
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/TMDefs/TM_Autocast.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMDefs/TM_Autocast.cs
@@ -194,13 +194,12 @@ namespace TorannMagic.TMDefs
         //Advanced condition cases
         private bool DamageTaken(TM_AutocastCondition con, Thing t)
         {
-            if (t is Pawn)
+            if (t is Pawn pawn)
             {
-                Pawn p = t as Pawn;
-                if (p != null && p.health != null && p.health.hediffSet != null)
+                if (pawn.health != null && pawn.health.hediffSet != null)
                 {
                     //Log.Message("pawn injured? " + TM_Calc.IsPawnInjured(p, con.valueA) + " invert is " + con.invert);
-                    return (con.invert ? !TM_Calc.IsPawnInjured(p, con.valueA) : TM_Calc.IsPawnInjured(p, con.valueA));
+                    return (con.invert ? !TM_Calc.IsPawnInjured(pawn, con.valueA) : TM_Calc.IsPawnInjured(pawn, con.valueA));
                 }
             }
             return false;

--- a/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilitySelf.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilitySelf.cs
@@ -27,9 +27,8 @@ namespace TorannMagic
             //{
             Find.Targeter.targetingSource = verb;
             //}
-            if (this.verb.Ability.Def is TMAbilityDef)
+            if (this.verb.Ability.Def is TMAbilityDef tmAbility)
             {
-                TMAbilityDef tmAbility = (TMAbilityDef)(this.verb.Ability.Def);
                 CompAbilityUserMight compMight = this.pawn.TryGetComp<CompAbilityUserMight>();
                 CompAbilityUserMagic compMagic = this.pawn.TryGetComp<CompAbilityUserMagic>();
                 if (tmAbility.manaCost > 0 && pawn.story != null && pawn.story.traits != null && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))

--- a/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
@@ -43,11 +43,10 @@ namespace TorannMagic
                 targetPawn = TargetThingA as Pawn;
             }
 
-            cooldownFlag = this.verb.Ability.CooldownTicksLeft > 0 ? true : false;
+            cooldownFlag = this.verb.Ability.CooldownTicksLeft > 0;
 
-            if(this.verb.Ability.Def is TMAbilityDef)
+            if(this.verb.Ability.Def is TMAbilityDef tmAbilityDef)
             { 
-                TMAbilityDef tmAbility = (TMAbilityDef)(this.verb.Ability.Def);
                 CompAbilityUserMight compMight = this.pawn.TryGetComp<CompAbilityUserMight>();
                 CompAbilityUserMagic compMagic = this.pawn.TryGetComp<CompAbilityUserMagic>();
                 //if (compMagic != null)
@@ -58,13 +57,13 @@ namespace TorannMagic
                 //{
                 //    //compMight.AIAbilityJob = null;
                 //}
-                if (tmAbility.manaCost > 0 && pawn.story != null && pawn.story.traits != null && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
+                if (tmAbilityDef.manaCost > 0 && pawn.story != null && pawn.story.traits != null && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
                     if(this.pawn.Map.gameConditionManager.ConditionIsActive(TorannMagicDefOf.TM_ManaStorm))
                     {
                         //DamageInfo dinfo2;
                         //BodyPartRecord vitalPart = null;
-                        int amt = Mathf.RoundToInt(compMagic.ActualManaCost(tmAbility) * 100f);
+                        int amt = Mathf.RoundToInt(compMagic.ActualManaCost(tmAbilityDef) * 100f);
                         //IEnumerable<BodyPartRecord> partSearch = pawn.def.race.body.AllParts;
                         //vitalPart = partSearch.FirstOrDefault<BodyPartRecord>((BodyPartRecord x) => x.def.tags.Contains(BodyPartTagDefOf.ConsciousnessSource));
                         //dinfo2 = new DamageInfo(TMDamageDefOf.DamageDefOf.TM_Arcane, amt, 10, 0, pawn as Thing, vitalPart, null, DamageInfo.SourceCategory.ThingOrUnknown);
@@ -77,7 +76,7 @@ namespace TorannMagic
                     }
                     if (compMagic != null && compMagic.Mana != null)
                     {
-                        if (compMagic.ActualManaCost(tmAbility) > compMagic.Mana.CurLevel)
+                        if (compMagic.ActualManaCost(tmAbilityDef) > compMagic.Mana.CurLevel)
                         {
                             energyFlag = true;
                         }
@@ -87,11 +86,11 @@ namespace TorannMagic
                         energyFlag = true;
                     }
                 }
-                if (tmAbility.staminaCost > 0)
+                if (tmAbilityDef.staminaCost > 0)
                 {
                     if (compMight != null && compMight.Stamina != null)
                     {
-                        if (compMight.ActualStaminaCost(tmAbility) > compMight.Stamina.CurLevel)
+                        if (compMight.ActualStaminaCost(tmAbilityDef) > compMight.Stamina.CurLevel)
                         {
                             energyFlag = true;
                         }
@@ -206,10 +205,9 @@ namespace TorannMagic
                         //bool inRange = (pawn.Position - TargetLocA).LengthHorizontal < verb.verbProps.range;
                         //if (inRange && validTarg)
                         //{
-                        if (verb != null && verb.Ability != null && verb.Ability.Def is TMAbilityDef)
-                        { 
-                            TMAbilityDef tmad = (TMAbilityDef)(verb.Ability.Def);
-                            if (tmad != null && tmad.relationsAdjustment != 0 && targetPawn.Faction != null && targetPawn.Faction != this.pawn.Faction && !targetPawn.Faction.HostileTo(this.pawn.Faction))
+                        if (verb != null && verb.Ability != null && verb.Ability.Def is TMAbilityDef tmad)
+                        {
+                            if (tmad.relationsAdjustment != 0 && targetPawn.Faction != null && targetPawn.Faction != this.pawn.Faction && !targetPawn.Faction.HostileTo(this.pawn.Faction))
                             {
                                 targetPawn.Faction.TryAffectGoodwillWith(this.pawn.Faction, tmad.relationsAdjustment, true, false, TorannMagicDefOf.TM_OffensiveMagic, null);
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
@@ -78,9 +78,8 @@ namespace TorannMagic
         {
             Thing instigator = dinfo.Instigator;
 
-            if (instigator is Pawn)
+            if (instigator is Pawn meleePawn)
             {
-                Pawn meleePawn = instigator as Pawn;
                 if ((dinfo.Weapon != null && dinfo.Weapon.IsMeleeWeapon) || dinfo.WeaponBodyPartGroup != null)
                 {
                     DamageInfo dinfo2 = new DamageInfo(dinfo.Def, dinfo.Amount, dinfo.ArmorPenetrationInt, dinfo.Angle, reflectingPawn, null, null, DamageInfo.SourceCategory.ThingOrUnknown, meleePawn);
@@ -93,17 +92,15 @@ namespace TorannMagic
         {
             Thing instigator = dinfo.Instigator;
 
-            if (instigator is Pawn)
+            if (instigator is Pawn shooterPawn)
             {
-                Pawn shooterPawn = instigator as Pawn;
                 if (dinfo.Weapon != null && !dinfo.Weapon.IsMeleeWeapon && dinfo.WeaponBodyPartGroup == null)
                 {
                     TM_CopyAndLaunchProjectile.CopyAndLaunchThing(shooterPawn.equipment.PrimaryEq.PrimaryVerb.verbProps.defaultProjectile, reflectingPawn, instigator, shooterPawn, ProjectileHitFlags.All, null);
                 }
             }
-            if (instigator is Building)
+            if (instigator is Building turret)
             {
-                Building turret = instigator as Building;
                 ThingDef projectile = null;
 
                 if (turret.def.building.turretGunDef != null)
@@ -131,9 +128,8 @@ namespace TorannMagic
         {
             Thing instigator = dinfo.Instigator;
 
-            if (instigator is Pawn)
+            if (instigator is Pawn shooterPawn)
             {
-                Pawn shooterPawn = instigator as Pawn;
                 if (dinfo.Weapon != null && !dinfo.Weapon.IsMeleeWeapon && dinfo.WeaponBodyPartGroup == null)
                 {
                     Pawn randomTarget = null;
@@ -144,9 +140,8 @@ namespace TorannMagic
                     }
                 }
             }
-            if (instigator is Building)
+            if (instigator is Building turret)
             {
-                Building turret = instigator as Building;
                 ThingDef projectile = null;
 
                 if (turret.def.building.turretGunDef != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -249,12 +249,11 @@ namespace TorannMagic
 
         public static bool IsWall(Thing t)
         {
-            if(t != null && t is Building)
+            if(t is Building building)
             {
-                Building b = t as Building;
-                if (b.def.passability == Traversability.Impassable && b.def.holdsRoof)
+                if (building.def.passability == Traversability.Impassable && building.def.holdsRoof)
                 {
-                    if (t.def.defName.ToLower().Contains("wall") || (t.def.label.ToLower().Contains("wall")))
+                    if (building.def.defName.ToLower().Contains("wall") || (building.def.label.ToLower().Contains("wall")))
                     {
                         return true;
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodForBlood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodForBlood.cs
@@ -34,9 +34,8 @@ namespace TorannMagic
             }
             this.arcaneDmg = base.CasterPawn.GetComp<CompAbilityUserMagic>().arcaneDmg;
             this.arcaneDmg *= (1 + (.1f * bpwr.level));
-            if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
+            if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn victim)
             {
-                Pawn victim = this.currentTarget.Thing as Pawn;
                 if (victim.RaceProps.BloodDef != null && victim != this.CasterPawn)
                 {
                     for (int i = 0; i < 4; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse.cs
@@ -43,11 +43,9 @@ namespace TorannMagic
             MagicPowerSkill manaRegen = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
 
             Thing undeadThing = this.currentTarget.Thing;
-            if (undeadThing is Pawn)
+            if (undeadThing is Pawn undead)
             {
-                Pawn undead = (Pawn)undeadThing;
-
-                bool flag = undead != null && !undead.Dead;
+                bool flag = !undead.Dead;
                 if (flag)
                 {
                     if (TM_Calc.IsUndead(undead))

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Legion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Legion.cs
@@ -56,21 +56,19 @@ namespace TorannMagic
         {
             bool result = false;
 
-            if (this.currentTarget != null && base.CasterPawn != null && this.currentTarget.Thing is Pawn)
+            if (this.currentTarget != null && base.CasterPawn != null && this.currentTarget.Thing is Pawn targetPawn)
             {
-                Pawn targetPawn = this.currentTarget.Thing as Pawn;
                 if (targetPawn.RaceProps.Humanlike)
                 {
                     CompAbilityUserMight mightPawn = targetPawn.GetComp<CompAbilityUserMight>();
 
-                    TMAbilityDef tempAbility = null;
                     CompAbilityUserMight mightComp = this.CasterPawn.GetComp<CompAbilityUserMight>();
                     
                     if (mightPawn.IsMightUser)
                     {
                         if (!targetPawn.story.traits.HasTrait(TM_Calc.GetMightTrait(this.CasterPawn)))
                         {
-                            tempAbility = TM_Calc.GetCopiedMightAbility(targetPawn, base.CasterPawn);
+                            TMAbilityDef tempAbility = TM_Calc.GetCopiedMightAbility(targetPawn, base.CasterPawn);
 
                             if (tempAbility != null)
                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Mimic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Mimic.cs
@@ -56,9 +56,8 @@ namespace TorannMagic
         {
             bool result = false;
 
-            if (this.currentTarget != null && base.CasterPawn != null && this.currentTarget.Thing is Pawn)
+            if (this.currentTarget != null && base.CasterPawn != null && this.currentTarget.Thing is Pawn targetPawn)
             {
-                Pawn targetPawn = this.currentTarget.Thing as Pawn;
                 if (targetPawn.RaceProps.Humanlike)
                 {
                     CompAbilityUserMagic magicPawn = targetPawn.GetComp<CompAbilityUserMagic>();

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ReverseTime.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ReverseTime.cs
@@ -220,9 +220,8 @@ namespace TorannMagic
         {
 
             thing.HitPoints = Mathf.Clamp(thing.HitPoints + Mathf.RoundToInt((200 + (100 * pwrVal)) * this.arcaneDmg), 0, thing.MaxHitPoints);
-            if (thing is Apparel)
+            if (thing is Apparel apparelThing)
             {
-                Apparel apparelThing = thing as Apparel;
                 if(apparelThing.WornByCorpse)
                 {
                     apparelThing.Notify_PawnResurrected();

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowCall.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowCall.cs
@@ -53,16 +53,15 @@ namespace TorannMagic
                             soulPawn = compS.polyHost;
                         }
                     }
-                    if (soulPawn.ParentHolder != null && soulPawn.ParentHolder is Caravan)
+                    if (soulPawn.ParentHolder is Caravan caravan)
                     {
                         //Log.Message("caravan detected");
                         //p.DeSpawn();
-                        Caravan van = soulPawn.ParentHolder as Caravan;
-                        van.RemovePawn(soulPawn);
+                        caravan.RemovePawn(soulPawn);
                         GenPlace.TryPlaceThing(soulPawn, this.CasterPawn.Position, this.CasterPawn.Map, ThingPlaceMode.Near);
-                        if(van.PawnsListForReading != null && van.PawnsListForReading.Count <= 0)
+                        if(caravan.PawnsListForReading != null && caravan.PawnsListForReading.Count <= 0)
                         {
-                            CaravanEnterMapUtility.Enter(van, this.CasterPawn.Map, CaravanEnterMode.Center, CaravanDropInventoryMode.DropInstantly, false);
+                            CaravanEnterMapUtility.Enter(caravan, this.CasterPawn.Map, CaravanEnterMode.Center, CaravanDropInventoryMode.DropInstantly, false);
                         }
                         
                         //Messages.Message("" + p.LabelShort + " has shadow stepped to a caravan with " + soulPawn.LabelShort, MessageTypeDefOf.NeutralEvent);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowStep.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowStep.cs
@@ -49,12 +49,11 @@ namespace TorannMagic
                             soulPawnSpawned = true;
                         }
                     }
-                    if(soulPawn.ParentHolder != null && soulPawn.ParentHolder is Caravan)
+                    if(soulPawn.ParentHolder is Caravan caravan)
                     {
                         //Log.Message("caravan detected");
                         //p.DeSpawn();
-                        Caravan van = soulPawn.ParentHolder as Caravan;
-                        van.AddPawn(p, true);
+                        caravan.AddPawn(p, true);
                         Find.WorldPawns.PassToWorld(p);
                         p.Notify_PassedToWorld();
                         Messages.Message("" + p.LabelShort + " has shadow stepped to a caravan with " + soulPawn.LabelShort, MessageTypeDefOf.NeutralEvent);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Teach.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Teach.cs
@@ -37,12 +37,11 @@ namespace TorannMagic
             Map map = base.CasterPawn.Map;
             Pawn mentor = base.CasterPawn;
 
-            if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn && this.currentTarget.Thing != mentor)
+            if(this.currentTarget.Thing is Pawn student && this.currentTarget.Thing != mentor)
             {
-                Pawn student = this.currentTarget.Thing as Pawn;
                 if (this.Ability.Def == TorannMagicDefOf.TM_TeachMagic)
                 {
-                    if (TM_Calc.IsMagicUser(mentor) && !TM_Calc.IsCrossClass(mentor, true) && student != null && student.story != null)
+                    if (TM_Calc.IsMagicUser(mentor) && !TM_Calc.IsCrossClass(mentor, true) && student.story != null)
                     {
                         if (TM_Calc.IsMagicUser(student) && !TM_Calc.IsCrossClass(student, true))
                         {
@@ -75,7 +74,7 @@ namespace TorannMagic
                 }
                 if (this.Ability.Def == TorannMagicDefOf.TM_TeachMight)
                 {
-                    if (TM_Calc.IsMightUser(mentor) && !TM_Calc.IsCrossClass(mentor, false) && student != null && student.story != null)
+                    if (TM_Calc.IsMightUser(mentor) && !TM_Calc.IsCrossClass(mentor, false) && student.story != null)
                     {
                         if (TM_Calc.IsMightUser(student) && !TM_Calc.IsCrossClass(student, false))
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_TigerStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_TigerStrike.cs
@@ -31,27 +31,28 @@ namespace TorannMagic
                     {
                         TM_Action.DamageEntities(target, null, 4, DamageDefOf.Stun, this.CasterPawn);
                     }
-                    if(verVal > 1 && Rand.Chance(.4f) && target is Pawn)
+
+                    Pawn targetPawn = target as Pawn;
+                    if(verVal > 1 && Rand.Chance(.4f) && targetPawn != null)
                     {
-                        if(TM_Calc.IsMagicUser(target as Pawn))
+                        if(TM_Calc.IsMagicUser(targetPawn))
                         {
-                            CompAbilityUserMagic compMagic = target.TryGetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic compMagic = targetPawn.TryGetComp<CompAbilityUserMagic>();
                             float manaDrain = Mathf.Clamp(compMagic.Mana.CurLevel, 0, .25f);
                             this.CasterPawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD).Severity += (manaDrain * 100);
                             compMagic.Mana.CurLevel -= manaDrain;
 
                         }
-                        else if(TM_Calc.IsMightUser(target as Pawn))
+                        else if(TM_Calc.IsMightUser(targetPawn))
                         {
-                            CompAbilityUserMight compMight = target.TryGetComp<CompAbilityUserMight>();
+                            CompAbilityUserMight compMight = targetPawn.TryGetComp<CompAbilityUserMight>();
                             float staminaDrain = Mathf.Clamp(compMight.Stamina.CurLevel, 0, .25f);
                             this.CasterPawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD).Severity += (staminaDrain * 100);
                             compMight.Stamina.CurLevel -= staminaDrain;
                         }
                     }
-                    if(verVal > 2 && Rand.Chance(.1f) && target is Pawn)
+                    if(verVal > 2 && Rand.Chance(.1f) && targetPawn != null)
                     {
-                        Pawn targetPawn = target as Pawn;
                         IEnumerable<BodyPartRecord> rangeOfParts = (targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BloodPumpingSource).Concat(
                             targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BloodFiltrationSource).Concat(
                                 targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BreathingPathway).Concat(
@@ -70,9 +71,8 @@ namespace TorannMagic
                     strikeStartVec.x += Rand.Range(-.2f, .2f);
                     Vector3 angle = TM_Calc.GetVector(strikeStartVec, strikeEndVec);
                     TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_TigerStrike, strikeStartVec, this.CasterPawn.Map, .4f, .08f, .03f, .05f, 0, 8f, (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat(), (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat());
-                    if(!target.DestroyedOrNull() && target is Pawn)
+                    if(!target.DestroyedOrNull() && targetPawn != null)
                     {
-                        Pawn targetPawn = target as Pawn;
                         if(targetPawn.Downed || targetPawn.Dead)
                         {
                             continueAttack = false;

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/CompBPReflector.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/CompBPReflector.cs
@@ -109,9 +109,8 @@ namespace TorannMagic.Weapon
                     TM_MoteMaker.ThrowSparkFlashMote(drawPos, this.GetPawn.Map, 2f);
                     Thing thing = new Thing();
                     thing.def = dinfo.Weapon;
-                    if (instigator is Pawn)
+                    if (instigator is Pawn shooterPawn)
                     {
-                        Pawn shooterPawn = instigator as Pawn;
                         if (!dinfo.Weapon.IsMeleeWeapon && dinfo.WeaponBodyPartGroup == null)
                         {
                             TM_CopyAndLaunchProjectile.CopyAndLaunchThing(shooterPawn.equipment.PrimaryEq.PrimaryVerb.verbProps.defaultProjectile, this.GetPawn, instigator, shooterPawn, ProjectileHitFlags.IntendedTarget, null);

--- a/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoMagicBill.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoMagicBill.cs
@@ -157,10 +157,9 @@ namespace TorannMagic
                     CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>();
                     if (compMagic != null && compMagic.Mana != null)
                     {
-                        if (thing is Building_TMMagicCircle)
+                        if (thing is Building_TMMagicCircle tmMagicCircle)
                         {
-                            Building_TMMagicCircle mc = thing as Building_TMMagicCircle;
-                            if(mc.InteractionCellOccupied())
+                            if(tmMagicCircle.InteractionCellOccupied())
                             {
                                 return null;
                             }
@@ -247,15 +246,14 @@ namespace TorannMagic
                         
                         List<Pawn> billPawns = new List<Pawn>();
                         billPawns.Clear();
-                        if (bill.recipe is MagicRecipeDef)
+                        if (bill.recipe is MagicRecipeDef magicRecipeDef)
                         {
-                            MagicRecipeDef magicRecipe = bill.recipe as MagicRecipeDef;
                             CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>(); 
                             if(magicCircle.IsActive)
                             {
                                 issueBill = false;
                             }
-                            if (!magicCircle.CanEverDoBill(bill, out billPawns, magicRecipe))
+                            if (!magicCircle.CanEverDoBill(bill, out billPawns, magicRecipeDef))
                             {
                                 issueBill = false;
                             }
@@ -294,13 +292,13 @@ namespace TorannMagic
                                 if (TryFindBestBillIngredients(bill, pawn, (Thing)giver, chosenIngThings))
                                 {
                                     this.magicCircle = thing as Building_TMMagicCircle;
-                                    if (this.magicCircle != null && bill.recipe is MagicRecipeDef)
+                                    if (this.magicCircle != null && bill.recipe is MagicRecipeDef recipeDef)
                                     {
-                                        this.magicCircle.magicRecipeDef = bill.recipe as MagicRecipeDef;
+                                        this.magicCircle.magicRecipeDef = recipeDef;
                                         this.magicCircle.MageList.Clear();
                                         magicCircle.MageList.Add(pawn);
                                         //Log.Message("assigning magic bill to " + pawn.LabelShort);
-                                        if (bill.recipe is MagicRecipeDef && billPawns.Count > 1)
+                                        if (recipeDef != null && billPawns.Count > 1)
                                         {
                                             for (int j = 0; j < billPawns.Count; j++)
                                             {


### PR DESCRIPTION
I used a Rider inspection to address most cases of type checking after casting when it could be addressed easily.  I used pattern matching as the solution most of the time (though in certain scenarios I did keep the casting, but brought it above the blocks when it made sense. Half of the time, the changes were just for code brevity and style, but the other half did help remove duplicate checking for null.

See https://www.jetbrains.com/help/rider/MergeCastWithTypeCheck.html for more reasoning.