### PR TITLE
Refactor MagicPower and MightPower into a base class Power

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserExtensions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserExtensions.cs
@@ -1,0 +1,102 @@
+using System;
+using AbilityUser;
+using RimWorld;
+using Verse;
+
+namespace TorannMagic
+{
+    public static class CompAbilityUserExtensions
+    {
+        public static bool IsCastInRange(this CompAbilityUser abilityUser, Power power, LocalTargetInfo localTarget, PawnAbility ability)
+        {
+            if (!power.autocasting.ValidType(power.autocasting.GetTargetType, localTarget))
+            {
+                return false;
+            }
+            if (power.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(abilityUser.Pawn.Position, localTarget.Thing, abilityUser.Pawn, power.autocasting.minRange, ability.Def.MainVerb.range))
+            {
+                return false;
+            }
+            if (power.autocasting.maxRange != 0f && power.autocasting.maxRange < (abilityUser.Pawn.Position - localTarget.Thing.Position).LengthHorizontal)
+            {
+                return false;
+            }
+      
+            return true;
+        }
+            
+        //I'm not particularly thrilled with this delegate approach, but it seems to be the best performance with
+        //the least amount of repeated code I can think of
+        public static bool CanTargetOtherPawn(
+            this CompAbilityUser abilityUser, 
+            Power power, 
+            LocalTargetInfo localTarget, 
+            PawnAbility ability, 
+            Func<Pawn, bool> enemyInvalidCondition
+            )
+        { 
+            if (!abilityUser.IsCastInRange(power, localTarget, ability))
+            {
+                return false;
+            }
+            
+            Thing targetThing = localTarget.Thing;
+            bool isHostile = targetThing.Faction != null && targetThing.Faction.HostileTo(abilityUser.Pawn.Faction);
+            bool targetEnemy = power.autocasting.targetEnemy && isHostile;
+            
+            if (targetThing is Pawn targetPawn)
+            {
+                if (targetEnemy && enemyInvalidCondition(targetPawn))
+                {
+                    return false;
+                }
+            }
+            
+            bool targetNeutral = power.autocasting.targetNeutral && !isHostile;
+            bool targetFriendly = power.autocasting.targetFriendly && targetThing.Faction == abilityUser.Pawn.Faction;
+            return (targetEnemy || targetNeutral || targetFriendly) && power.autocasting.ValidConditions(abilityUser.Pawn, targetThing);
+        }
+
+        public static bool CanTargetOtherPawn(
+            this CompAbilityUser abilityUser, 
+            Power power, 
+            LocalTargetInfo localTarget, 
+            PawnAbility ability,
+            Func<Pawn, bool> enemyInvalidCondition,
+            Func<Pawn, Power, bool> neutralInvalidCondition)
+        {
+            if (!abilityUser.IsCastInRange(power, localTarget, ability))
+            {
+                return false;
+            }
+            
+            Thing targetThing = localTarget.Thing;
+            bool isHostile = targetThing.Faction != null && targetThing.Faction.HostileTo(abilityUser.Pawn.Faction);
+            bool targetEnemy = power.autocasting.targetEnemy && isHostile;
+            bool targetNeutral = power.autocasting.targetNeutral && !isHostile;
+            
+            if (targetThing is Pawn targetPawn)
+            {
+                if (targetEnemy && enemyInvalidCondition(targetPawn))
+                {
+                    return false;
+                }
+
+                if (targetNeutral && neutralInvalidCondition(targetPawn, power))
+                {
+                    if (targetPawn.Downed || targetPawn.IsPrisoner)
+                    {
+                        return false;
+                    }
+                    if (power.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
+                    {
+                        return false;
+                    }
+                }
+            }
+            
+            bool targetFriendly = power.autocasting.targetFriendly && targetThing.Faction == abilityUser.Pawn.Faction;
+            return (targetEnemy || targetNeutral || targetFriendly) && power.autocasting.ValidConditions(abilityUser.Pawn, targetThing);
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -5853,38 +5853,14 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetThing) =>
+                                                {
+                                                    return targetThing.Downed || targetThing.IsPrisonerInPrisonCell();
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell())
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -5910,15 +5886,7 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         IntVec3 targetThing = localTarget.Cell;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing).LengthHorizontal)
+                                        if (this.IsCastInRange(mp, localTarget, ability))
                                         {
                                             continue;
                                         }
@@ -5939,38 +5907,14 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) =>
+                                                {
+                                                    return targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell();
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell())
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (castSuccess) goto AutoCastExit;
@@ -6449,38 +6393,14 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) =>
+                                                {
+                                                    return targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell();
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell())
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -6506,15 +6426,7 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         IntVec3 targetThing = localTarget.Cell;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing).LengthHorizontal)
+                                        if (this.IsCastInRange(mp, localTarget, ability))
                                         {
                                             continue;
                                         }
@@ -6531,38 +6443,14 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) =>
+                                                {
+                                                    return targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell();
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell())
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (castSuccess) goto AutoCastExit;
@@ -6891,58 +6779,18 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => { return targetPawn.Downed || targetPawn.IsPrisoner; },
+                                                (targetPawn, power) =>
+                                                {
+                                                    return (targetPawn.Downed || targetPawn.IsPrisoner) ||
+                                                           (power.abilityDef.MainVerb.isViolent
+                                                            && targetPawn.Faction != null
+                                                            && !targetPawn.InMentalState);
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if(TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if(targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        if (TN && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                            if (mp.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
-                                            {
-                                                continue;
-                                            }
-                                        }                                        
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        //if (targetThing is Pawn)
-                                        //{
-                                        //    Pawn targetPawn = targetThing as Pawn;
-                                        //    if (targetPawn.IsPrisoner)
-                                        //    {
-                                        //        continue;
-                                        //    }
-                                        //}
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -6968,15 +6816,7 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         IntVec3 targetThing = localTarget.Cell;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing).LengthHorizontal)
+                                        if (this.IsCastInRange(mp, localTarget, ability))
                                         {
                                             continue;
                                         }
@@ -6993,58 +6833,18 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetThing) => { return targetThing.Downed || targetThing.IsPrisoner;}, 
+                                                (targetThing, power) =>
+                                                {
+                                                    return (targetThing.Downed || targetThing.IsPrisoner) ||
+                                                           (power.abilityDef.MainVerb.isViolent &&
+                                                            targetThing.Faction != null && !targetThing.InMentalState);
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        if (TN && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                            if (mp.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        //if (targetThing is Pawn)
-                                        //{
-                                        //    Pawn targetPawn = targetThing as Pawn;
-                                        //    if (targetPawn.IsPrisoner)
-                                        //    {
-                                        //        continue;
-                                        //    }
-                                        //}
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
+                                        
                                     }
                                 }
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -5854,9 +5854,9 @@ namespace TorannMagic
                                     {
                                         Thing targetThing = localTarget.Thing;
                                         if (this.CanTargetOtherPawn(mp, localTarget, ability,
-                                                (targetThing) =>
+                                                (targetPawn) =>
                                                 {
-                                                    return targetThing.Downed || targetThing.IsPrisonerInPrisonCell();
+                                                    return targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell();
                                                 }))
                                         {
                                             AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
@@ -6834,12 +6834,12 @@ namespace TorannMagic
                                     {
                                         Thing targetThing = localTarget.Thing;
                                         if (this.CanTargetOtherPawn(mp, localTarget, ability,
-                                                (targetThing) => { return targetThing.Downed || targetThing.IsPrisoner;}, 
-                                                (targetThing, power) =>
+                                                (targetPawn) => { return targetPawn.Downed || targetPawn.IsPrisoner;}, 
+                                                (targetPawn, power) =>
                                                 {
-                                                    return (targetThing.Downed || targetThing.IsPrisoner) ||
+                                                    return (targetPawn.Downed || targetPawn.IsPrisoner) ||
                                                            (power.abilityDef.MainVerb.isViolent &&
-                                                            targetThing.Faction != null && !targetThing.InMentalState);
+                                                            targetPawn.Faction != null && !targetPawn.InMentalState);
                                                 }))
                                         {
                                             AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
@@ -4159,7 +4159,7 @@ namespace TorannMagic
                                                 {
                                                     return (targetPawn.Downed || targetPawn.IsPrisoner) ||
                                                            (power.abilityDef.MainVerb.isViolent &&
-                                                            targetThing.Faction != null && !targetPawn.InMentalState)
+                                                            targetThing.Faction != null && !targetPawn.InMentalState);
                                                 }))
                                         {
                                             AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
@@ -4215,15 +4215,15 @@ namespace TorannMagic
                                     {
                                         Thing targetThing = localTarget.Thing;
                                         if (this.CanTargetOtherPawn(mp, localTarget, ability,
-                                                (targetPawn) => targetPawn.Downed),
-                                                (targetPawn, ability) =>
+                                                (targetPawn) => targetPawn.Downed,
+                                                (targetPawn, mpAbility) =>
                                                     {
                                                         return (targetPawn.Downed || targetPawn.IsPrisoner) ||
-                                                               (mp.abilityDef.MainVerb.isViolent 
-                                                                && targetThing.Faction != null 
+                                                               (mpAbility.abilityDef.MainVerb.isViolent
+                                                                && targetThing.Faction != null
                                                                 && !targetPawn.InMentalState);
                                                     }
-                                            )
+                                            ))
                                         {
                                             AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
@@ -3413,38 +3413,11 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed ))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if(mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -3496,38 +3469,11 @@ namespace TorannMagic
                                     if(localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
-                                        {                                            
-                                            continue;
-                                        }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {                                            
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {                                            
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {                                            
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (castSuccess) goto AutoCastExit;
@@ -3807,38 +3753,11 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -3889,38 +3808,11 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (castSuccess) goto AutoCastExit;
@@ -4261,58 +4153,17 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed,
+                                                (targetPawn, power) =>
+                                                {
+                                                    return (targetPawn.Downed || targetPawn.IsPrisoner) ||
+                                                           (power.abilityDef.MainVerb.isViolent &&
+                                                            targetThing.Faction != null && !targetPawn.InMentalState)
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        if (TN && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                            if (mp.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        //if(targetThing is Pawn)
-                                        //{
-                                        //    Pawn targetPawn = targetThing as Pawn;
-                                        //    if(targetPawn.IsPrisoner)
-                                        //    {
-                                        //        continue;
-                                        //    }
-                                        //}
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -4363,58 +4214,19 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed),
+                                                (targetPawn, ability) =>
+                                                    {
+                                                        return (targetPawn.Downed || targetPawn.IsPrisoner) ||
+                                                               (mp.abilityDef.MainVerb.isViolent 
+                                                                && targetThing.Faction != null 
+                                                                && !targetPawn.InMentalState);
+                                                    }
+                                            )
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        if (TN && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                            if (mp.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        //if (targetThing is Pawn)
-                                        //{
-                                        //    Pawn targetPawn = targetThing as Pawn;
-                                        //    if (targetPawn.IsPrisoner)
-                                        //    {
-                                        //        continue;
-                                        //    }
-                                        //}
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/MagicPower.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MagicPower.cs
@@ -1,126 +1,12 @@
 ﻿using AbilityUser;
 using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
 using Verse;
 
 namespace TorannMagic 
 {
-    public class MagicPower : IExposable
+    public class MagicPower : Power
     {
-        public List<AbilityDef> TMabilityDefs;
-        public TMDefs.TM_Autocast autocasting;
-
-        public int ticksUntilNextCast = -1;
-
-        public int level = 0;
-        public bool learned = false;
-        public bool autocast = false;
-        public int learnCost = 2;
-        private int interactionTick = 0;
         public bool requiresScroll = false;
-        public int maxLevel = 3;
-        public int costToLevel = 1;
-        
-        public bool AutoCast
-        {
-            get
-            {
-                return autocast;
-            }
-            set
-            {
-                if (interactionTick < Find.TickManager.TicksGame)
-                {
-                    autocast = value;
-                    interactionTick = Find.TickManager.TicksGame + 5;
-                }
-            }
-
-        }
-
-        private void SetMaxLevel()
-        {
-            this.maxLevel = this.TMabilityDefs.Count - 1;
-        }
-
-        public AbilityDef abilityDescDef
-        {
-            get
-            {
-                return this.abilityDef;                
-            }
-        }
-
-        public AbilityDef nextLevelAbilityDescDef
-        {
-            get
-            {
-                return this.nextLevelAbilityDef;                
-            }
-        }
-
-        public AbilityDef abilityDef
-        {
-            get
-            {
-                SetMaxLevel();
-                if (TMabilityDefs != null && TMabilityDefs.Count > 0)
-                {
-                    if (level <= 0)
-                    {
-                        return this.TMabilityDefs[0];
-                    }
-                    else if (level >= maxLevel)
-                    {
-                        return this.TMabilityDefs[maxLevel];
-                    }
-                    return this.TMabilityDefs[level];
-                }
-                return null;
-            }
-        }
-
-        public AbilityDef nextLevelAbilityDef
-        {
-            get
-            {
-                SetMaxLevel();
-                if ((this.level + 1) >= this.maxLevel)
-                {
-                    return this.TMabilityDefs[maxLevel];
-                }
-                else
-                {
-                    return this.TMabilityDefs[level + 1];
-                }               
-            }
-        }
-
-        public Texture2D Icon
-        {
-            get
-            {
-                return this.abilityDef.uiIcon;
-            }
-        }
-
-        public AbilityDef GetAbilityDef(int index)
-        {
-            try
-            {
-                return this.TMabilityDefs[index];
-            }
-            catch
-            {
-                return this.TMabilityDefs[0];
-            }            
-        }
-
-        public AbilityDef HasAbilityDef(AbilityDef defToFind)
-        {
-            return this.TMabilityDefs.FirstOrDefault((AbilityDef x) => x == defToFind);
-        }
 
         public MagicPower()
         {
@@ -158,18 +44,10 @@ namespace TorannMagic
             }
         }
 
-        public void ExposeData()
+        public override void ExposeData()
         {
-            Scribe_Values.Look<bool>(ref this.learned, "learned", true, false);
-            Scribe_Values.Look<bool>(ref this.autocast, "autocast", false, false);
+            base.ExposeData();
             Scribe_Values.Look<bool>(ref this.requiresScroll, "requiresScroll", false, false);
-            Scribe_Values.Look<int>(ref this.learnCost, "learnCost", 2, false);
-            Scribe_Values.Look<int>(ref this.costToLevel, "costToLevel", 1, false);
-            Scribe_Values.Look<int>(ref this.level, "level", 0, false);
-            Scribe_Values.Look<int>(ref this.maxLevel, "maxLevel", 3, false);
-            Scribe_Values.Look<int>(ref this.ticksUntilNextCast, "ticksUntilNextCast", -1, false);
-            Scribe_Collections.Look<AbilityDef>(ref this.TMabilityDefs, "TMabilityDefs", LookMode.Def, null);
-            Scribe_Deep.Look<TMDefs.TM_Autocast>(ref this.autocasting, "autocasting", new object[0]);
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/MightPower.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MightPower.cs
@@ -1,147 +1,10 @@
 ﻿using AbilityUser;
 using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
-using Verse;
 
 namespace TorannMagic 
 {
-    public class MightPower : IExposable
+    public class MightPower : Power
     {
-        public List<AbilityDef> TMabilityDefs;
-        public TMDefs.TM_Autocast autocasting;
-
-        public int ticksUntilNextCast = -1;
-
-        public int level;
-
-        public bool learned = false;
-        public bool autocast = false;
-        public int learnCost = 2;
-        private int interactionTick = 0;
-        public int maxLevel = 3;
-        public int costToLevel = 1;
-
-        public bool AutoCast
-        {
-            get
-            {
-                return autocast;
-            }
-            set
-            {
-                if (interactionTick < Find.TickManager.TicksGame)
-                {
-                    autocast = value;
-                    interactionTick = Find.TickManager.TicksGame + 5;
-                }
-            }
-        }
-
-        private void SetMaxLevel()
-        {
-            this.maxLevel = this.TMabilityDefs.Count - 1;
-        }
-
-        public AbilityDef abilityDescDef
-        {
-            get
-            {                
-                return this.abilityDef;
-            }
-        }
-
-        public AbilityDef nextLevelAbilityDescDef
-        {
-            get
-            {
-                return this.nextLevelAbilityDef;                
-            }
-        }
-
-        public AbilityDef abilityDef
-        {
-            get
-            {
-                if (TMabilityDefs != null && TMabilityDefs.Count > 0)
-                {
-                    SetMaxLevel();
-                    if (level <= 0)
-                    {
-                        return this.TMabilityDefs[0];
-                    }
-                    else if (level >= maxLevel)
-                    {
-                        return this.TMabilityDefs[maxLevel];
-                    }
-                    return this.TMabilityDefs[level];                    
-                }
-                return null;
-            }
-        }
-
-        public AbilityDef nextLevelAbilityDef
-        {
-            get
-            {
-                SetMaxLevel();
-                if ((this.level + 1) >= this.maxLevel)
-                {
-                    return this.TMabilityDefs[maxLevel];
-                }
-                else
-                {
-                    return this.TMabilityDefs[level + 1];
-                }                
-            }
-        }
-
-        public Texture2D Icon
-        {
-            get
-            {
-                return this.abilityDef.uiIcon;
-            }
-        }
-
-        public AbilityDef GetAbilityDef(int index)
-        {
-            try
-            {
-                return this.TMabilityDefs[index];
-            }
-            catch
-            {
-                return this.TMabilityDefs[0];
-            }
-            //
-            AbilityDef result = null;
-            bool flag = this.TMabilityDefs != null && this.TMabilityDefs.Count > 0;
-            if (flag)
-            {
-                result = this.TMabilityDefs[0];
-                bool flag2 = index > -1 && index < this.TMabilityDefs.Count;
-                if (flag2)
-                {
-                    result = this.TMabilityDefs[index];
-                }
-                else
-                {
-                    bool flag3 = index >= this.TMabilityDefs.Count;
-                    if (flag3)
-                    {
-                        result = this.TMabilityDefs[this.TMabilityDefs.Count - 1];
-                    }
-                }
-            }
-            return result;
-        }
-
-        public AbilityDef HasAbilityDef(AbilityDef defToFind)
-        {
-            return this.TMabilityDefs.FirstOrDefault((AbilityDef x) => x == defToFind);
-        }
-
         public MightPower()
         {
         }
@@ -163,19 +26,6 @@ namespace TorannMagic
             {
                 this.learnCost = 0;
             }
-        }
-
-        public void ExposeData()
-        {
-            Scribe_Values.Look<bool>(ref this.learned, "learned", true, false);
-            Scribe_Values.Look<bool>(ref this.autocast, "autocast", false, false);
-            Scribe_Values.Look<int>(ref this.learnCost, "learnCost", 2, false);
-            Scribe_Values.Look<int>(ref this.costToLevel, "costToLevel", 1, false);
-            Scribe_Values.Look<int>(ref this.level, "level", 0, false);
-            Scribe_Values.Look<int>(ref this.maxLevel, "maxLevel", 3, false);
-            Scribe_Values.Look<int>(ref this.ticksUntilNextCast, "ticksUntilNextCast", -1, false);
-            Scribe_Collections.Look<AbilityDef>(ref this.TMabilityDefs, "TMabilityDefs", (LookMode)4, null);
-            Scribe_Deep.Look<TMDefs.TM_Autocast>(ref this.autocasting, "autocasting", new object[0]);
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Power.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Power.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Linq;
+using AbilityUser;
+using UnityEngine;
+using Verse;
+
+namespace TorannMagic
+{
+    public class Power : IExposable
+    {
+        public List<AbilityDef> TMabilityDefs;
+        public TMDefs.TM_Autocast autocasting;
+
+        public int ticksUntilNextCast = -1;
+
+        public int level;
+        public bool learned = false;
+        public bool autocast = false;
+        public int learnCost = 2;
+        protected int interactionTick = 0;
+        public int maxLevel = 3;
+        public int costToLevel = 1;
+
+        protected Power()
+        {
+
+        }
+        
+        public bool AutoCast
+        {
+            get
+            {
+                return autocast;
+            }
+            set
+            {
+                if (interactionTick < Find.TickManager.TicksGame)
+                {
+                    autocast = value;
+                    interactionTick = Find.TickManager.TicksGame + 5;
+                }
+            }
+        }
+        
+        private void SetMaxLevel()
+        {
+            this.maxLevel = this.TMabilityDefs.Count - 1;
+        }
+        
+        public AbilityDef abilityDescDef
+        {
+            get
+            {                
+                return this.abilityDef;
+            }
+        }
+        
+        public AbilityDef nextLevelAbilityDescDef
+        {
+            get
+            {
+                return this.nextLevelAbilityDef;                
+            }
+        }
+        
+        public AbilityDef abilityDef
+        {
+            get
+            {
+                if (TMabilityDefs != null && TMabilityDefs.Count > 0)
+                {
+                    SetMaxLevel();
+                    if (level <= 0)
+                    {
+                        return this.TMabilityDefs[0];
+                    }
+                    else if (level >= maxLevel)
+                    {
+                        return this.TMabilityDefs[maxLevel];
+                    }
+                    return this.TMabilityDefs[level];                    
+                }
+                return null;
+            }
+        }
+        
+        public AbilityDef nextLevelAbilityDef
+        {
+            get
+            {
+                SetMaxLevel();
+                if ((this.level + 1) >= this.maxLevel)
+                {
+                    return this.TMabilityDefs[maxLevel];
+                }
+                return this.TMabilityDefs[level + 1];
+            }
+        }
+        
+        public Texture2D Icon
+        {
+            get
+            {
+                return this.abilityDef.uiIcon;
+            }
+        }
+        
+        public AbilityDef GetAbilityDef(int index)
+        {
+            try
+            {
+                return this.TMabilityDefs[index];
+            }
+            catch
+            {
+                return this.TMabilityDefs[0];
+            }
+        }
+        
+        public AbilityDef HasAbilityDef(AbilityDef defToFind)
+        {
+            return this.TMabilityDefs.FirstOrDefault((AbilityDef x) => x == defToFind);
+        }
+        
+        public virtual void ExposeData()
+        {
+            Scribe_Values.Look<bool>(ref this.learned, "learned", true, false);
+            Scribe_Values.Look<bool>(ref this.autocast, "autocast", false, false);
+            Scribe_Values.Look<int>(ref this.learnCost, "learnCost", 2, false);
+            Scribe_Values.Look<int>(ref this.costToLevel, "costToLevel", 1, false);
+            Scribe_Values.Look<int>(ref this.level, "level", 0, false);
+            Scribe_Values.Look<int>(ref this.maxLevel, "maxLevel", 3, false);
+            Scribe_Values.Look<int>(ref this.ticksUntilNextCast, "ticksUntilNextCast", -1, false);
+            Scribe_Collections.Look<AbilityDef>(ref this.TMabilityDefs, "TMabilityDefs", LookMode.Def, null);
+            Scribe_Deep.Look<TMDefs.TM_Autocast>(ref this.autocasting, "autocasting", new object[0]);
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -132,8 +132,10 @@
     <Compile Include="Building_TMTotem_Healing.cs" />
     <Compile Include="Building_TMTotem_Lightning.cs" />
     <Compile Include="Building_TM_DMP.cs" />
+    <Compile Include="CompAbilityUserExtensions.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
+    <Compile Include="Power.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />
     <Compile Include="TMDefs\TM_Branding.cs" />


### PR DESCRIPTION
This allows for a bunch of code reuse which can help in larger changes later on.

An example of code reuse is used with the IsCastInRange and CanTargetOtherPawn. While I'm not the biggest fan of the latter's use of delgates, it is the least performance impacting way of achieving the same code that was replaced (this PR should be negligible for performance). I'm not 100% convinced these functions should be on CompAbilityUser, but i still find it easier to manage than them all being separate outside of any function.