### PR TITLE
Stop iterating through the array multiple times and fix what appears to be a rare bug in PhaseStrike SearchForTargets

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
@@ -175,29 +175,24 @@ namespace TorannMagic
 
         public void SearchForTargets(IntVec3 center, float radius, Map map, Pawn pawn)
         {
-            Pawn victim = null;
-            IntVec3 curCell;            
             IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(center, radius, true);
-            for (int i = 0; i < targets.Count(); i++)
+            foreach (IntVec3 curCell in targets)
             {
-                curCell = targets.ToArray<IntVec3>()[i];
                 FleckMaker.ThrowDustPuff(curCell, map, .2f);
                 if (curCell.InBounds(map) && curCell.IsValid)
                 {
-                    victim = curCell.GetFirstPawn(map);
-                }
-
-                if (victim != null && victim.Faction != pawn.Faction)
-                {
-                    if(Rand.Chance(.1f + .15f*pwrVal))
+                    Pawn victim = curCell.GetFirstPawn(map);
+                    if (victim != null && victim.Faction != pawn.Faction)
                     {
-                        this.dmgNum *= 3;
-                        MoteMaker.ThrowText(victim.DrawPos, victim.Map, "Critical Hit", -1f);
+                        if(Rand.Chance(.1f + .15f*pwrVal))
+                        {
+                            this.dmgNum *= 3;
+                            MoteMaker.ThrowText(victim.DrawPos, victim.Map, "Critical Hit", -1f);
+                        }
+                        DrawStrike(center, victim.Position.ToVector3(), map);
+                        damageEntities(victim, null, this.dmgNum, TMDamageDefOf.DamageDefOf.TM_PhaseStrike);
                     }
-                    DrawStrike(center, victim.Position.ToVector3(), map);
-                    damageEntities(victim, null, this.dmgNum, TMDamageDefOf.DamageDefOf.TM_PhaseStrike);
                 }
-                targets.GetEnumerator().MoveNext();
             }
         }
 


### PR DESCRIPTION
Currently the for loop is iterating every time the condition is checked, every time curCell is set, and once at the end of the for loop unnecessarily. 

I also moved the second if statement inside of the first one as I assume it should only check if victim is valid if it attempted to find a victim that step of the iteration, rather than just using the last victim that was in bounds.