### PR TITLE
Avoid a possible Invalid Cast Exception in TM_Calc.cs

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -2270,9 +2270,9 @@ namespace TorannMagic
             }
             else if (pawn.ParentHolder.ToString().Contains("Caravan"))
             {
-                foreach (Pawn current in pawn.holdingOwner)
+                foreach (Thing currentThing in pawn.holdingOwner)
                 {
-                    if (current != null)
+                    if (currentThing is Pawn current)
                     {
                         if (current.RaceProps.Humanlike && current.Faction == pawn.Faction && current.apparel != null && current.apparel.WornApparelCount > 0)
                         {


### PR DESCRIPTION
pawn.holdingOwner is a ThingOwner (essentially a list) of Things. The cast to a Pawn is not guaranteed to succeed, so put the cast inside the for loop. I use pattern matching instead of as statement or try/catch.