### PR TITLE
Make Get_Staggered use HashSets instead of performing multiple checks per if statement

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2772,20 +2772,35 @@ namespace TorannMagic
                 }
             }
         }
+        
+        // Keep these two HashSets in memory to have faster checking for the below method since it is called often.
+        private static readonly HashSet<ThingDef> staggerExemptPawnDefs = new HashSet<ThingDef>{
+            TorannMagicDefOf.TM_DemonR, 
+            TorannMagicDefOf.TM_HollowGolem
+        };
+        private static readonly HashSet<HediffDef> staggerExemptHediffs = new HashSet<HediffDef>{
+            TorannMagicDefOf.TM_BurningFuryHD,
+            TorannMagicDefOf.TM_MoveOutHD,
+            TorannMagicDefOf.TM_EnrageHD
+        };
 
         public static bool Get_Staggered(Pawn_StanceTracker __instance, ref bool __result)
         {
-            if (__instance.pawn.def == TorannMagicDefOf.TM_DemonR || __instance.pawn.def == TorannMagicDefOf.TM_HollowGolem)
+            if (staggerExemptPawnDefs.Contains(__instance.pawn.def))
             {
                 __result = false;
                 return false;
             }
             if (__instance.pawn.health != null && __instance.pawn.health.hediffSet != null)
             {
-                if (__instance.pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_BurningFuryHD) || __instance.pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_MoveOutHD) || __instance.pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EnrageHD))
+                var hediffs = __instance.pawn.health.hediffSet.hediffs;
+                for (int i = 0; i < hediffs.Count; i++)
                 {
-                    __result = false;
-                    return false;
+                    if (staggerExemptHediffs.Contains(hediffs[i].def))
+                    {
+                        __result = false;
+                        return false;
+                    }
                 }
             }
             return true;
@@ -2793,7 +2808,7 @@ namespace TorannMagic
 
         public static bool StaggerFor_Patch(Pawn_StanceTracker __instance, int ticks)
         {
-            if (__instance.pawn.def == TorannMagicDefOf.TM_DemonR || __instance.pawn.def == TorannMagicDefOf.TM_HollowGolem)
+            if (staggerExemptPawnDefs.Contains(__instance.pawn.def))
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -79,7 +79,7 @@ namespace TorannMagic
 
             harmonyInstance.Patch(AccessTools.Method(typeof(Pawn), "get_IsColonist", null, null), new HarmonyMethod(typeof(TorannMagicMod), "Get_IsColonist_Polymorphed", null), null);
             harmonyInstance.Patch(AccessTools.Method(typeof(Caravan), "get_NightResting", null, null), new HarmonyMethod(typeof(TorannMagicMod), "Get_NightResting_Undead", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(Pawn_StanceTracker), "get_Staggered", null, null), new HarmonyMethod(typeof(TorannMagicMod), "Get_Staggered", null), null);
+            harmonyInstance.Patch(AccessTools.Method(typeof(Pawn_StanceTracker), "get_Staggered", null, null), null, new HarmonyMethod(typeof(TorannMagicMod), "Get_Staggered", null));
             harmonyInstance.Patch(AccessTools.Method(typeof(Verb_LaunchProjectile), "get_Projectile", null, null), new HarmonyMethod(typeof(TorannMagicMod), "Get_Projectile_ES", null), null);
             harmonyInstance.Patch(AccessTools.Method(typeof(WindManager), "get_WindSpeed", null, null), new HarmonyMethod(typeof(TorannMagicMod), "Get_WindSpeed", null), null);
             harmonyInstance.Patch(AccessTools.Method(typeof(MentalBreaker), "get_CanDoRandomMentalBreaks", null, null), null, new HarmonyMethod(typeof(TorannMagicMod), "Get_CanDoRandomMentalBreaks", null), null);
@@ -2773,21 +2773,19 @@ namespace TorannMagic
             }
         }
 
-        public static bool Get_Staggered(Pawn_StanceTracker __instance, ref bool __result)
+        public static void Get_Staggered(Pawn_StanceTracker __instance, ref bool __result)
         {
+            if (!__result) return;
             if (
-                __instance.pawn.def != TorannMagicDefOf.TM_DemonR 
-                && __instance.pawn.def != TorannMagicDefOf.TM_HollowGolem
-                && !__instance.pawn.health.hediffSet.hediffs.Any(hd => 
+                __instance.pawn.def == TorannMagicDefOf.TM_DemonR
+                || __instance.pawn.def == TorannMagicDefOf.TM_HollowGolem
+                || __instance.pawn.health.hediffSet.hediffs.Any(hd =>
                     hd.def == TorannMagicDefOf.TM_BurningFuryHD
                     || hd.def == TorannMagicDefOf.TM_MoveOutHD
                     || hd.def == TorannMagicDefOf.TM_EnrageHD
                 )
             )
-                return true;
-            
-            __result = false;
-            return false;
+                __result = false;
         }
 
         public static bool StaggerFor_Patch(Pawn_StanceTracker __instance, int ticks)

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2772,23 +2772,17 @@ namespace TorannMagic
                 }
             }
         }
-        
-        // Keep these two HashSets in memory to have faster checking for the below method since it is called often.
-        private static readonly HashSet<ThingDef> staggerExemptPawnDefs = new HashSet<ThingDef>{
-            TorannMagicDefOf.TM_DemonR, 
-            TorannMagicDefOf.TM_HollowGolem
-        };
-        private static readonly HashSet<HediffDef> staggerExemptHediffs = new HashSet<HediffDef>{
-            TorannMagicDefOf.TM_BurningFuryHD,
-            TorannMagicDefOf.TM_MoveOutHD,
-            TorannMagicDefOf.TM_EnrageHD
-        };
 
         public static bool Get_Staggered(Pawn_StanceTracker __instance, ref bool __result)
         {
             if (
-                !staggerExemptPawnDefs.Contains(__instance.pawn.def)
-                && !__instance.pawn.health.hediffSet.hediffs.Any(hd => staggerExemptHediffs.Contains(hd.def))
+                __instance.pawn.def != TorannMagicDefOf.TM_DemonR 
+                && __instance.pawn.def != TorannMagicDefOf.TM_HollowGolem
+                && !__instance.pawn.health.hediffSet.hediffs.Any(hd => 
+                    hd.def == TorannMagicDefOf.TM_BurningFuryHD
+                    || hd.def == TorannMagicDefOf.TM_MoveOutHD
+                    || hd.def == TorannMagicDefOf.TM_EnrageHD
+                )
             )
                 return true;
             
@@ -2798,15 +2792,9 @@ namespace TorannMagic
 
         public static bool StaggerFor_Patch(Pawn_StanceTracker __instance, int ticks)
         {
-            if (staggerExemptPawnDefs.Contains(__instance.pawn.def))
-            {
-                return false;
-            }
-            if (__instance.pawn.health != null && __instance.pawn.health.hediffSet != null && __instance.pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_BurningFuryHD))
-            {
-                return false;
-            }
-            return true;
+            return __instance.pawn.def != TorannMagicDefOf.TM_DemonR 
+                && __instance.pawn.def != TorannMagicDefOf.TM_HollowGolem 
+                && !__instance.pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_BurningFuryHD);
         }
 
         public static bool Get_Projectile_ES(Verb_LaunchProjectile __instance, ref ThingDef __result)

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2786,24 +2786,14 @@ namespace TorannMagic
 
         public static bool Get_Staggered(Pawn_StanceTracker __instance, ref bool __result)
         {
-            if (staggerExemptPawnDefs.Contains(__instance.pawn.def))
-            {
-                __result = false;
-                return false;
-            }
-            if (__instance.pawn.health != null && __instance.pawn.health.hediffSet != null)
-            {
-                var hediffs = __instance.pawn.health.hediffSet.hediffs;
-                for (int i = 0; i < hediffs.Count; i++)
-                {
-                    if (staggerExemptHediffs.Contains(hediffs[i].def))
-                    {
-                        __result = false;
-                        return false;
-                    }
-                }
-            }
-            return true;
+            if (
+                !staggerExemptPawnDefs.Contains(__instance.pawn.def)
+                && !__instance.pawn.health.hediffSet.hediffs.Any(hd => staggerExemptHediffs.Contains(hd.def))
+            )
+                return true;
+            
+            __result = false;
+            return false;
         }
 
         public static bool StaggerFor_Patch(Pawn_StanceTracker __instance, int ticks)


### PR DESCRIPTION
Does 2 things to optimize the Get_Staggered Prefix:
1. Instead of checking each PawnDef individually, make that one check by using a HashSet.
2. The actual big speedup is by instead of calling HasHediff 3 times (loops through a list 3 times), just go through the hediffs List and check if the hediff is inside of a predefined HashSet like point 1 (edit since pound 1 links to PR). This way we only go through the list once on the very likely chance that none of the hediffs are on the pawn.

From my testing on a somewhat new colony when colonists are awake, the prefix went down from a max of .6ms to a max of .3ms