### PR TITLE
Optimize colonist bar colonist drawer patch

### DIFF
--- a/RimWorldOfMagic/.gitignore
+++ b/RimWorldOfMagic/.gitignore
@@ -1,4 +1,6 @@
 # Ignore Rider generated folder (Main Dev uses Visual Studio and Rider can auto generate this folder)
 **/.idea/
+# Assembly references are located in different locations per user
 *.csproj
+# Caches are generated and should not be in source control
 **/*.cache

--- a/RimWorldOfMagic/.gitignore
+++ b/RimWorldOfMagic/.gitignore
@@ -1,6 +1,7 @@
 # Ignore Rider generated folder (Main Dev uses Visual Studio and Rider can auto generate this folder)
 **/.idea/
-# Assembly references are located in different locations per user
-*.csproj
-# Caches are generated and should not be in source control
-**/*.cache
+
+# ReSharper/Rider settings
+*.DotSettings.user
+
+*.cache

--- a/RimWorldOfMagic/.gitignore
+++ b/RimWorldOfMagic/.gitignore
@@ -1,0 +1,4 @@
+# Ignore Rider generated folder (Main Dev uses Visual Studio and Rider can auto generate this folder)
+**/.idea/
+*.csproj
+**/*.cache

--- a/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
@@ -40,7 +40,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(pawn.Map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(pawn.Map) && curCell.IsValid)
                 {
                     List<Thing> thingList;
                     thingList = curCell.GetThingList(pawn.Map);
@@ -64,7 +64,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(pawn.Map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(pawn.Map) && curCell.IsValid)
                 {
                     List<Thing> thingList;
                     thingList = curCell.GetThingList(pawn.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
@@ -112,7 +112,7 @@ namespace TorannMagic.AutoCast
                             //Log.Warning("failed path check");
                         }
                         //Log.Message("can reach after phase: " + canReach);
-                        if (canReach && phaseToCell.IsValid && phaseToCell.InBounds(caster.Map) && phaseToCell.Walkable(caster.Map) && !phaseToCell.Fogged(caster.Map))// && ((phaseToCell - caster.Position).LengthHorizontal < distanceToTarget))
+                        if (canReach && phaseToCell.IsValid && phaseToCell.InBoundsWithNullCheck(caster.Map) && phaseToCell.Walkable(caster.Map) && !phaseToCell.Fogged(caster.Map))// && ((phaseToCell - caster.Position).LengthHorizontal < distanceToTarget))
                         {
 
                             PawnPath ppc = caster.Map.pathFinder.FindPath(caster.Position, jobTarget.Cell, TraverseParms.For(TraverseMode.PassDoors, Danger.Deadly), PathEndMode.ClosestTouch);
@@ -386,7 +386,7 @@ namespace TorannMagic.AutoCast
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = target;
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;
-                if (distanceToTarget >= minRange && jobTarget != null && jobTarget.Cell.IsValid && jobTarget.Cell.InBounds(casterComp.Pawn.Map) && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range)) //&& distanceToTarget < (abilitydef.MainVerb.range * .9f)
+                if (distanceToTarget >= minRange && jobTarget != null && jobTarget.Cell.IsValid && jobTarget.Cell.InBoundsWithNullCheck(casterComp.Pawn.Map) && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range)) //&& distanceToTarget < (abilitydef.MainVerb.range * .9f)
                 {
                     Job job = ability.GetJob(AbilityContext.AI, jobTarget);
                     job.endIfCantShootTargetFromCurPos = true;
@@ -407,7 +407,7 @@ namespace TorannMagic.AutoCast
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = target;
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;
-                if (distanceToTarget >= minRange && jobTarget != null && jobTarget.Cell.IsValid && jobTarget.Cell.InBounds(casterComp.Pawn.Map) && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range)) //&& distanceToTarget < (abilitydef.MainVerb.range * .9f)
+                if (distanceToTarget >= minRange && jobTarget != null && jobTarget.Cell.IsValid && jobTarget.Cell.InBoundsWithNullCheck(casterComp.Pawn.Map) && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range)) //&& distanceToTarget < (abilitydef.MainVerb.range * .9f)
                 {
                     Job job = ability.GetJob(AbilityContext.AI, jobTarget);
                     job.endIfCantShootTargetFromCurPos = true;
@@ -1190,7 +1190,7 @@ namespace TorannMagic.AutoCast
                                 Log.Warning("failed path check");
                             }
 
-                            if (canReach && blinkToCell.IsValid && blinkToCell.InBounds(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map))// && ((blinkToCell - caster.Position).LengthHorizontal < distanceToTarget))
+                            if (canReach && blinkToCell.IsValid && blinkToCell.InBoundsWithNullCheck(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map))// && ((blinkToCell - caster.Position).LengthHorizontal < distanceToTarget))
                             {
                                 PawnPath ppc = caster.Map.pathFinder.FindPath(caster.Position, jobTarget.Cell, TraverseParms.For(TraverseMode.PassDoors, Danger.Deadly), PathEndMode.ClosestTouch);
                                 float currentCost = ppc.TotalCost;
@@ -1369,7 +1369,7 @@ namespace TorannMagic.AutoCast
                         IntVec3 blinkToCell = caster.Position + (directionToTarget * maxDistance).ToIntVec3();
                         //Log.Message("doing partial blink to cell " + blinkToCell);
                         //FleckMaker.ThrowHeatGlow(blinkToCell, caster.Map, 1f);
-                        if (blinkToCell.IsValid && blinkToCell.InBounds(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map) && ((blinkToCell - caster.Position).LengthHorizontal < distanceToTarget))
+                        if (blinkToCell.IsValid && blinkToCell.InBoundsWithNullCheck(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map) && ((blinkToCell - caster.Position).LengthHorizontal < distanceToTarget))
                         {
                             DoBlink(caster, blinkToCell, carriedThing);
                             success = true;
@@ -1532,7 +1532,7 @@ namespace TorannMagic.AutoCast
                             Log.Warning("failed path check");
                         }
 
-                        if (canReach && blinkToCell.IsValid && blinkToCell.InBounds(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map))
+                        if (canReach && blinkToCell.IsValid && blinkToCell.InBoundsWithNullCheck(caster.Map) && blinkToCell.Walkable(caster.Map) && !blinkToCell.Fogged(caster.Map))
                         {
                             PawnPath ppc = caster.Map.pathFinder.FindPath(caster.Position, jobTarget.Cell, TraverseParms.For(TraverseMode.PassDoors, Danger.Deadly), PathEndMode.ClosestTouch);
                             float currentCost = ppc.TotalCost;

--- a/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
@@ -593,10 +593,9 @@ namespace TorannMagic.AutoCast
                 if (pwr.level >= 2)
                 {
                     jobTarget = TM_Calc.FindNearbyAfflictedPawnAny(caster, (int)(abilitydef.MainVerb.range * .9f));
-                    if(jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn)
+                    if(jobTarget != null && jobTarget.Thing is Pawn jobPawn)
                     {
-                        Pawn jobPawn = jobTarget.Thing as Pawn;
-                        if(jobPawn.health != null && jobPawn.health.hediffSet != null && !(jobPawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_DiseaseImmunityHD) || jobPawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_DiseaseImmunity2HD)))
+                        if(jobPawn.health != null && jobPawn.health?.hediffSet != null && !(jobPawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_DiseaseImmunityHD) || jobPawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_DiseaseImmunity2HD)))
                         {
 
                         }
@@ -673,9 +672,8 @@ namespace TorannMagic.AutoCast
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;                
                 if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing != null)
                 {
-                    if (abilitydef == TorannMagicDefOf.TM_CauterizeWound && jobTarget.Thing is Pawn)
+                    if (abilitydef == TorannMagicDefOf.TM_CauterizeWound && jobTarget.Thing is Pawn targetPawn)
                     {
-                        Pawn targetPawn = jobTarget.Thing as Pawn;
                         if (targetPawn.health.HasHediffsNeedingTend(false))
                         {
                             Job job = ability.GetJob(AbilityContext.AI, jobTarget);
@@ -713,15 +711,14 @@ namespace TorannMagic.AutoCast
                 if (jobTarget != null)
                 {
                     float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;
-                    if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget.Thing != null && jobTarget.Thing is Pawn)
+                    if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget.Thing is Pawn targetPawn)
                     {
-                        Pawn targetPawn = jobTarget.Thing as Pawn;
                         if (targetPawn.health != null && targetPawn.health.hediffSet != null && !targetPawn.health.hediffSet.HasHediff(hediffDef, false))
                         {
                             Job job = ability.GetJob(AbilityContext.AI, jobTarget);
                             DoJob.Execute(job, caster);
                             success = true;
-                            TM_Action.TM_Toils.GotoAndWait(jobTarget.Thing as Pawn, caster, Mathf.RoundToInt(ability.Def.MainVerb.warmupTime * 60));
+                            TM_Action.TM_Toils.GotoAndWait(targetPawn, caster, Mathf.RoundToInt(ability.Def.MainVerb.warmupTime * 60));
                         }
                     }
                 }
@@ -772,9 +769,9 @@ namespace TorannMagic.AutoCast
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = TM_Calc.FindNearbyEnemy(caster, (int)(abilitydef.MainVerb.range * .9f));
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;
-                if (distanceToTarget > minRange && distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range))
+                if (
+                    distanceToTarget > minRange && distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing is Pawn targetPawn && TM_Calc.HasLoSFromTo(caster.Position, jobTarget, caster, 0, abilitydef.MainVerb.range))
                 {
-                    Pawn targetPawn = jobTarget.Thing as Pawn;
                     if (!targetPawn.health.hediffSet.HasHediff(hediffDef, false))
                     {
                         Job job = ability.GetJob(AbilityContext.AI, jobTarget);
@@ -976,9 +973,8 @@ namespace TorannMagic.AutoCast
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = TM_Calc.FindNearbyPawn(caster, (int)(abilitydef.MainVerb.range * .9f));
                 float distanceToTarget = (jobTarget.Cell - caster.Position).LengthHorizontal;                
-                if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn)
+                if (distanceToTarget < (abilitydef.MainVerb.range * .9f) && jobTarget != null && jobTarget.Thing is Pawn targetPawn)
                 {
-                    Pawn targetPawn = jobTarget.Thing as Pawn;
                     if (targetPawn.RaceProps.Humanlike && targetPawn.IsColonist)
                     {
                         bool tatteredApparel = false;
@@ -1049,9 +1045,8 @@ namespace TorannMagic.AutoCast
             {
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = TM_Calc.FindNearbyMage(caster, (int)(abilitydef.MainVerb.range * 1.5f), false);
-                if (jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
+                if (jobTarget != null && jobTarget.Thing is Pawn targetPawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
                 {
-                    Pawn targetPawn = jobTarget.Thing as Pawn;
                     CompAbilityUserMagic targetPawnComp = targetPawn.GetComp<CompAbilityUserMagic>();
                     if (targetPawn.CurJobDef.joyKind != null || targetPawn.CurJobDef == JobDefOf.Wait_Wander || targetPawn.CurJobDef == JobDefOf.GotoWander)
                     {
@@ -1083,9 +1078,8 @@ namespace TorannMagic.AutoCast
             {
                 Pawn caster = casterComp.Pawn;
                 LocalTargetInfo jobTarget = TM_Calc.FindNearbyFighter(caster, (int)(abilitydef.MainVerb.range * 1.5f), false);
-                if (jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
+                if (jobTarget != null && jobTarget.Thing is Pawn targetPawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
                 {
-                    Pawn targetPawn = jobTarget.Thing as Pawn;
                     CompAbilityUserMight targetPawnComp = targetPawn.GetComp<CompAbilityUserMight>();
                     if ((targetPawn.CurJobDef.joyKind != null && targetPawn.CurJobDef != TorannMagicDefOf.JobDriver_TM_Meditate) || targetPawn.CurJobDef == JobDefOf.Wait_Wander || targetPawn.CurJobDef == JobDefOf.GotoWander)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_60mmMortar.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_60mmMortar.cs
@@ -200,7 +200,7 @@ namespace TorannMagic
         {
             List<IntVec3> cellRange = new List<IntVec3>();
             cellRange.Clear();
-            if (!pos.InBounds(map))
+            if (!pos.InBoundsWithNullCheck(map))
             {
                 return null;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
@@ -141,7 +141,7 @@ namespace TorannMagic
             for (int i = 0; i < num; i++)
             {
                 IntVec3 intVec = center + GenRadial.RadialPattern[i];
-                if (intVec.InBounds(map))
+                if (intVec.InBoundsWithNullCheck(map))
                 {
                     float lengthHorizontal = (center - intVec).LengthHorizontal;
                     float num2 = 1f - lengthHorizontal / radius;

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
@@ -85,7 +85,7 @@ namespace TorannMagic
                         {
                             curCell = targets.ToArray<IntVec3>()[i];
 
-                            if (curCell.InBounds(base.Map) && curCell.IsValid)
+                            if (curCell.InBoundsWithNullCheck(base.Map) && curCell.IsValid)
                             {
                                 Pawn victim = curCell.GetFirstPawn(base.Map);
                                 if (victim != null && !victim.Dead && victim.RaceProps.IsFlesh)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMArcaneCapacitor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMArcaneCapacitor.cs
@@ -91,7 +91,7 @@ namespace TorannMagic
         public static List<IntVec3> PortableCellsAround(IntVec3 pos, Map map)
         {
             Building_TMArcaneCapacitor.portableCells.Clear();
-            if (!pos.InBounds(map))
+            if (!pos.InBoundsWithNullCheck(map))
             {
                 return Building_TMArcaneCapacitor.portableCells;
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift.cs
@@ -223,7 +223,7 @@ namespace TorannMagic
 
         private bool IsGoodLocationForStrike(IntVec3 loc)
         {
-            bool flag1 = loc.InBounds(base.Map);
+            bool flag1 = loc.InBoundsWithNullCheck(base.Map);
             bool flag2 = loc.IsValid;
             bool flag3 = !loc.Fogged(base.Map);
             bool flag4 = loc.DistanceToEdge(base.Map) > 2;
@@ -413,7 +413,7 @@ namespace TorannMagic
             for (int j = 0; j < targets.Count(); j++)
             {
                 curCell = targets.ToArray<IntVec3>()[j];
-                if (curCell.InBounds(this.Map) && curCell.IsValid && curCell.Walkable(this.Map))
+                if (curCell.InBoundsWithNullCheck(this.Map) && curCell.IsValid && curCell.Walkable(this.Map))
                 {
                     SpawnThings rogueElemental = new SpawnThings();
                     if (rnd < 2)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift_Defenders.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift_Defenders.cs
@@ -227,7 +227,7 @@ namespace TorannMagic
 
         private bool IsGoodLocationForStrike(IntVec3 loc)
         {
-            bool flag1 = loc.InBounds(base.Map);
+            bool flag1 = loc.InBoundsWithNullCheck(base.Map);
             bool flag2 = loc.IsValid;
             bool flag3 = !loc.Fogged(base.Map);
             bool flag4 = loc.DistanceToEdge(base.Map) > 2;
@@ -433,7 +433,7 @@ namespace TorannMagic
             for (int j = 0; j < targets.Count(); j++)
             {
                 curCell = targets.ToArray<IntVec3>()[j];
-                if (curCell.InBounds(this.Map) && curCell.IsValid && curCell.Walkable(this.Map))
+                if (curCell.InBoundsWithNullCheck(this.Map) && curCell.IsValid && curCell.Walkable(this.Map))
                 {
                     SpawnThings rogueElemental = new SpawnThings();
                     if (rnd < 2)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMPortal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMPortal.cs
@@ -260,7 +260,7 @@ namespace TorannMagic
         public static List<IntVec3> PortableCellsAround(IntVec3 pos, Map map)
         {
             Building_TMPortal.portableCells.Clear();
-            if (!pos.InBounds(map))
+            if (!pos.InBoundsWithNullCheck(map))
             {
                 return Building_TMPortal.portableCells;
 
@@ -298,7 +298,7 @@ namespace TorannMagic
                 for (int i = 0; i < targets.Count(); i++)
                 {
                     curCell = targets.ToArray<IntVec3>()[i];
-                    if (curCell.InBounds(this.Map) && curCell.IsValid)
+                    if (curCell.InBoundsWithNullCheck(this.Map) && curCell.IsValid)
                     {
                         Pawn interactingPawn = curCell.GetFirstPawn(this.Map);
                         if (interactingPawn != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMTotem_Earth.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMTotem_Earth.cs
@@ -43,7 +43,7 @@ namespace TorannMagic
                     for (int i = 0; i < targetCells.Count(); i++)
                     {
                         curCell = targetCells[i];
-                        if (curCell.IsValid && curCell.InBounds(this.Map))
+                        if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Map))
                         {
                             List<Thing> thingList = curCell.GetThingList(this.Map);
                             for (int j = 0; j < thingList.Count(); j++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TM_DMP.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TM_DMP.cs
@@ -104,7 +104,7 @@ namespace TorannMagic
         public static List<IntVec3> PortableCellsAround(IntVec3 pos, Map map)
         {
             Building_TM_DMP.portableCells.Clear();
-            if (!pos.InBounds(map))
+            if (!pos.InBoundsWithNullCheck(map))
             {
                 return Building_TM_DMP.portableCells;
 

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
@@ -98,7 +98,7 @@ namespace TorannMagic
             for (int i = 0; i < targetCells.Count(); i++)
             {
                 curCell = targetCells[i];
-                if (curCell.IsValid && curCell.InBounds(this.Pawn.Map))
+                if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Pawn.Map))
                 {
                     if(isExplosion)
                     {
@@ -139,7 +139,7 @@ namespace TorannMagic
             for (int i = 0; i < targetCells.Count(); i++)
             {
                 curCell = targetCells[i];
-                if (curCell.IsValid && curCell.InBounds(this.Pawn.Map))
+                if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Pawn.Map))
                 {
                     Vector3 launchVector = GetVector(this.Pawn.Position, curCell);
                     Pawn knockbackPawn = curCell.GetFirstPawn(this.Pawn.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
@@ -476,15 +476,11 @@ namespace TorannMagic
         public override void PostPreApplyDamage(DamageInfo dinfo, out bool absorbed)
         {
             base.PostPreApplyDamage(dinfo, out absorbed);
-            if(dinfo.Instigator != null)
+            if (dinfo.Instigator is Building instigatorThing)
             {
-                Thing instigatorThing = dinfo.Instigator;
-                if(instigatorThing is Building)
+                if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
                 {
-                    if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
-                    {
-                        this.buildingThreats.AddDistinct(instigatorThing as Building);
-                    }
+                    this.buildingThreats.AddDistinct(instigatorThing);
                 }
             }
         }
@@ -593,9 +589,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserExtensions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserExtensions.cs
@@ -1,0 +1,102 @@
+using System;
+using AbilityUser;
+using RimWorld;
+using Verse;
+
+namespace TorannMagic
+{
+    public static class CompAbilityUserExtensions
+    {
+        public static bool IsCastInRange(this CompAbilityUser abilityUser, Power power, LocalTargetInfo localTarget, PawnAbility ability)
+        {
+            if (!power.autocasting.ValidType(power.autocasting.GetTargetType, localTarget))
+            {
+                return false;
+            }
+            if (power.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(abilityUser.Pawn.Position, localTarget.Thing, abilityUser.Pawn, power.autocasting.minRange, ability.Def.MainVerb.range))
+            {
+                return false;
+            }
+            if (power.autocasting.maxRange != 0f && power.autocasting.maxRange < (abilityUser.Pawn.Position - localTarget.Thing.Position).LengthHorizontal)
+            {
+                return false;
+            }
+      
+            return true;
+        }
+            
+        //I'm not particularly thrilled with this delegate approach, but it seems to be the best performance with
+        //the least amount of repeated code I can think of
+        public static bool CanTargetOtherPawn(
+            this CompAbilityUser abilityUser, 
+            Power power, 
+            LocalTargetInfo localTarget, 
+            PawnAbility ability, 
+            Func<Pawn, bool> enemyInvalidCondition
+            )
+        { 
+            if (!abilityUser.IsCastInRange(power, localTarget, ability))
+            {
+                return false;
+            }
+            
+            Thing targetThing = localTarget.Thing;
+            bool isHostile = targetThing.Faction != null && targetThing.Faction.HostileTo(abilityUser.Pawn.Faction);
+            bool targetEnemy = power.autocasting.targetEnemy && isHostile;
+            
+            if (targetThing is Pawn targetPawn)
+            {
+                if (targetEnemy && enemyInvalidCondition(targetPawn))
+                {
+                    return false;
+                }
+            }
+            
+            bool targetNeutral = power.autocasting.targetNeutral && !isHostile;
+            bool targetFriendly = power.autocasting.targetFriendly && targetThing.Faction == abilityUser.Pawn.Faction;
+            return (targetEnemy || targetNeutral || targetFriendly) && power.autocasting.ValidConditions(abilityUser.Pawn, targetThing);
+        }
+
+        public static bool CanTargetOtherPawn(
+            this CompAbilityUser abilityUser, 
+            Power power, 
+            LocalTargetInfo localTarget, 
+            PawnAbility ability,
+            Func<Pawn, bool> enemyInvalidCondition,
+            Func<Pawn, Power, bool> neutralInvalidCondition)
+        {
+            if (!abilityUser.IsCastInRange(power, localTarget, ability))
+            {
+                return false;
+            }
+            
+            Thing targetThing = localTarget.Thing;
+            bool isHostile = targetThing.Faction != null && targetThing.Faction.HostileTo(abilityUser.Pawn.Faction);
+            bool targetEnemy = power.autocasting.targetEnemy && isHostile;
+            bool targetNeutral = power.autocasting.targetNeutral && !isHostile;
+            
+            if (targetThing is Pawn targetPawn)
+            {
+                if (targetEnemy && enemyInvalidCondition(targetPawn))
+                {
+                    return false;
+                }
+
+                if (targetNeutral && neutralInvalidCondition(targetPawn, power))
+                {
+                    if (targetPawn.Downed || targetPawn.IsPrisoner)
+                    {
+                        return false;
+                    }
+                    if (power.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
+                    {
+                        return false;
+                    }
+                }
+            }
+            
+            bool targetFriendly = power.autocasting.targetFriendly && targetThing.Faction == abilityUser.Pawn.Faction;
+            return (targetEnemy || targetNeutral || targetFriendly) && power.autocasting.ValidConditions(abilityUser.Pawn, targetThing);
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -5853,38 +5853,14 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetThing) =>
+                                                {
+                                                    return targetThing.Downed || targetThing.IsPrisonerInPrisonCell();
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell())
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -5910,15 +5886,7 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         IntVec3 targetThing = localTarget.Cell;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing).LengthHorizontal)
+                                        if (this.IsCastInRange(mp, localTarget, ability))
                                         {
                                             continue;
                                         }
@@ -5939,38 +5907,14 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) =>
+                                                {
+                                                    return targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell();
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell())
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (castSuccess) goto AutoCastExit;
@@ -6449,38 +6393,14 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) =>
+                                                {
+                                                    return targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell();
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell())
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -6506,15 +6426,7 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         IntVec3 targetThing = localTarget.Cell;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing).LengthHorizontal)
+                                        if (this.IsCastInRange(mp, localTarget, ability))
                                         {
                                             continue;
                                         }
@@ -6531,38 +6443,14 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) =>
+                                                {
+                                                    return targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell();
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell())
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (castSuccess) goto AutoCastExit;
@@ -6891,58 +6779,18 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => { return targetPawn.Downed || targetPawn.IsPrisoner; },
+                                                (targetPawn, power) =>
+                                                {
+                                                    return (targetPawn.Downed || targetPawn.IsPrisoner) ||
+                                                           (power.abilityDef.MainVerb.isViolent
+                                                            && targetPawn.Faction != null
+                                                            && !targetPawn.InMentalState);
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if(TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if(targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        if (TN && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                            if (mp.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
-                                            {
-                                                continue;
-                                            }
-                                        }                                        
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        //if (targetThing is Pawn)
-                                        //{
-                                        //    Pawn targetPawn = targetThing as Pawn;
-                                        //    if (targetPawn.IsPrisoner)
-                                        //    {
-                                        //        continue;
-                                        //    }
-                                        //}
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -6968,15 +6816,7 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         IntVec3 targetThing = localTarget.Cell;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing).LengthHorizontal)
+                                        if (this.IsCastInRange(mp, localTarget, ability))
                                         {
                                             continue;
                                         }
@@ -6993,58 +6833,18 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetThing) => { return targetThing.Downed || targetThing.IsPrisoner;}, 
+                                                (targetThing, power) =>
+                                                {
+                                                    return (targetThing.Downed || targetThing.IsPrisoner) ||
+                                                           (power.abilityDef.MainVerb.isViolent &&
+                                                            targetThing.Faction != null && !targetThing.InMentalState);
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        if (TN && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                            if (mp.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        //if (targetThing is Pawn)
-                                        //{
-                                        //    Pawn targetPawn = targetThing as Pawn;
-                                        //    if (targetPawn.IsPrisoner)
-                                        //    {
-                                        //        continue;
-                                        //    }
-                                        //}
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
+                                        
                                     }
                                 }
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -5854,9 +5854,9 @@ namespace TorannMagic
                                     {
                                         Thing targetThing = localTarget.Thing;
                                         if (this.CanTargetOtherPawn(mp, localTarget, ability,
-                                                (targetThing) =>
+                                                (targetPawn) =>
                                                 {
-                                                    return targetThing.Downed || targetThing.IsPrisonerInPrisonCell();
+                                                    return targetPawn.Downed || targetPawn.IsPrisonerInPrisonCell();
                                                 }))
                                         {
                                             AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
@@ -6834,12 +6834,12 @@ namespace TorannMagic
                                     {
                                         Thing targetThing = localTarget.Thing;
                                         if (this.CanTargetOtherPawn(mp, localTarget, ability,
-                                                (targetThing) => { return targetThing.Downed || targetThing.IsPrisoner;}, 
-                                                (targetThing, power) =>
+                                                (targetPawn) => { return targetPawn.Downed || targetPawn.IsPrisoner;}, 
+                                                (targetPawn, power) =>
                                                 {
-                                                    return (targetThing.Downed || targetThing.IsPrisoner) ||
+                                                    return (targetPawn.Downed || targetPawn.IsPrisoner) ||
                                                            (power.abilityDef.MainVerb.isViolent &&
-                                                            targetThing.Faction != null && !targetThing.InMentalState);
+                                                            targetPawn.Faction != null && !targetPawn.InMentalState);
                                                 }))
                                         {
                                             AutoCast.MagicAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -7201,7 +7201,7 @@ namespace TorannMagic
                         GenPlace.TryPlaceThing(thing, this.earthSprites, this.earthSpriteMap, ThingPlaceMode.Near, null);
                     }
                 }
-                if (curCell.InBounds(map) && curCell.IsValid && terrain != null)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid && terrain != null)
                 {
                     if (terrain.defName == "MarshyTerrain" || terrain.defName == "Mud" || terrain.defName == "Marsh")
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
@@ -4159,7 +4159,7 @@ namespace TorannMagic
                                                 {
                                                     return (targetPawn.Downed || targetPawn.IsPrisoner) ||
                                                            (power.abilityDef.MainVerb.isViolent &&
-                                                            targetThing.Faction != null && !targetPawn.InMentalState)
+                                                            targetThing.Faction != null && !targetPawn.InMentalState);
                                                 }))
                                         {
                                             AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
@@ -4215,15 +4215,15 @@ namespace TorannMagic
                                     {
                                         Thing targetThing = localTarget.Thing;
                                         if (this.CanTargetOtherPawn(mp, localTarget, ability,
-                                                (targetPawn) => targetPawn.Downed),
-                                                (targetPawn, ability) =>
+                                                (targetPawn) => targetPawn.Downed,
+                                                (targetPawn, mpAbility) =>
                                                     {
                                                         return (targetPawn.Downed || targetPawn.IsPrisoner) ||
-                                                               (mp.abilityDef.MainVerb.isViolent 
-                                                                && targetThing.Faction != null 
+                                                               (mpAbility.abilityDef.MainVerb.isViolent
+                                                                && targetThing.Faction != null
                                                                 && !targetPawn.InMentalState);
                                                     }
-                                            )
+                                            ))
                                         {
                                             AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
@@ -3413,38 +3413,11 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed ))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if(mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -3496,38 +3469,11 @@ namespace TorannMagic
                                     if(localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
-                                        {                                            
-                                            continue;
-                                        }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {                                            
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {                                            
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {                                            
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (castSuccess) goto AutoCastExit;
@@ -3807,38 +3753,11 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -3889,38 +3808,11 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (castSuccess) goto AutoCastExit;
@@ -4261,58 +4153,17 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed,
+                                                (targetPawn, power) =>
+                                                {
+                                                    return (targetPawn.Downed || targetPawn.IsPrisoner) ||
+                                                           (power.abilityDef.MainVerb.isViolent &&
+                                                            targetThing.Faction != null && !targetPawn.InMentalState)
+                                                }))
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        if (TN && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                            if (mp.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        //if(targetThing is Pawn)
-                                        //{
-                                        //    Pawn targetPawn = targetThing as Pawn;
-                                        //    if(targetPawn.IsPrisoner)
-                                        //    {
-                                        //        continue;
-                                        //    }
-                                        //}
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                                 if (mp.autocasting.type == TMDefs.AutocastType.OnSelf)
@@ -4363,58 +4214,19 @@ namespace TorannMagic
                                     if (localTarget != null && localTarget.IsValid)
                                     {
                                         Thing targetThing = localTarget.Thing;
-                                        if (!mp.autocasting.ValidType(mp.autocasting.GetTargetType, localTarget))
+                                        if (this.CanTargetOtherPawn(mp, localTarget, ability,
+                                                (targetPawn) => targetPawn.Downed),
+                                                (targetPawn, ability) =>
+                                                    {
+                                                        return (targetPawn.Downed || targetPawn.IsPrisoner) ||
+                                                               (mp.abilityDef.MainVerb.isViolent 
+                                                                && targetThing.Faction != null 
+                                                                && !targetPawn.InMentalState);
+                                                    }
+                                            )
                                         {
-                                            continue;
+                                            AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                         }
-                                        if (mp.autocasting.requiresLoS && !TM_Calc.HasLoSFromTo(this.Pawn.Position, targetThing, this.Pawn, mp.autocasting.minRange, ability.Def.MainVerb.range))
-                                        {
-                                            continue;
-                                        }
-                                        if (mp.autocasting.maxRange != 0f && mp.autocasting.maxRange < (this.Pawn.Position - targetThing.Position).LengthHorizontal)
-                                        {
-                                            continue;
-                                        }
-                                        bool TE = mp.autocasting.targetEnemy && targetThing.Faction != null && targetThing.Faction.HostileTo(this.Pawn.Faction);
-                                        if (TE && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TN = mp.autocasting.targetNeutral && (targetThing.Faction == null || !targetThing.Faction.HostileTo(this.Pawn.Faction));
-                                        if (TN && targetThing is Pawn)
-                                        {
-                                            Pawn targetPawn = targetThing as Pawn;
-                                            if (targetPawn.Downed || targetPawn.IsPrisoner)
-                                            {
-                                                continue;
-                                            }
-                                            if (mp.abilityDef.MainVerb.isViolent && targetThing.Faction != null && !targetPawn.InMentalState)
-                                            {
-                                                continue;
-                                            }
-                                        }
-                                        bool TF = mp.autocasting.targetFriendly && targetThing.Faction == this.Pawn.Faction;
-                                        if (!(TE || TN || TF))
-                                        {
-                                            continue;
-                                        }
-                                        //if (targetThing is Pawn)
-                                        //{
-                                        //    Pawn targetPawn = targetThing as Pawn;
-                                        //    if (targetPawn.IsPrisoner)
-                                        //    {
-                                        //        continue;
-                                        //    }
-                                        //}
-                                        if (!mp.autocasting.ValidConditions(this.Pawn, targetThing))
-                                        {
-                                            continue;
-                                        }
-                                        AutoCast.CombatAbility_OnTarget.TryExecute(this, tmad, ability, mp, targetThing, mp.autocasting.minRange, out castSuccess);
                                     }
                                 }
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
@@ -271,7 +271,7 @@ namespace TorannMagic
                 {
                     tmpPos.z++;
                 }
-                if (tmpPos.IsValid && tmpPos.InBounds(map) && tmpPos.Walkable(map))
+                if (tmpPos.IsValid && tmpPos.InBoundsWithNullCheck(map) && tmpPos.Walkable(map))
                 {
                     targetPos = tmpPos;
                     this.Pawn.DeSpawn();

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
@@ -252,18 +252,17 @@ namespace TorannMagic
             Map map = this.Pawn.Map;
             IntVec3 targetPos = target.Position;
             IntVec3 tmpPos = targetPos;
-            if (!target.DestroyedOrNull() && target is Pawn)
+            if (!target.DestroyedOrNull() && target is Pawn targetPawn)
             {
-                Pawn p = target as Pawn;
-                if (p.Rotation == Rot4.East)
+                if (targetPawn.Rotation == Rot4.East)
                 {
                     tmpPos.x--;
                 }
-                else if (p.Rotation == Rot4.West)
+                else if (targetPawn.Rotation == Rot4.West)
                 {
                     tmpPos.x++;
                 }
-                else if (p.Rotation == Rot4.North)
+                else if (targetPawn.Rotation == Rot4.North)
                 {
                     tmpPos.z--;
                 }
@@ -284,32 +283,31 @@ namespace TorannMagic
 
         public void DoStrike(Thing target)
         {
-            if (target != null && target is Pawn)
+            if (target != null && target is Pawn targetPawn)
             {
-                Pawn t = target as Pawn;
-                if (t.Faction == null || (t.Faction != null && t.Faction != this.Pawn.Faction))
+                if (targetPawn.Faction == null || (targetPawn.Faction != null && targetPawn.Faction != this.Pawn.Faction))
                 {
                     for (int i = 0; i < 4; i++)
                     {
-                        if (!t.DestroyedOrNull() && !t.Dead && t.Map != null)
+                        if (!targetPawn.DestroyedOrNull() && !targetPawn.Dead && targetPawn.Map != null)
                         {
                             int dmg = shadowStrikeDamage + pwrVal;
                             if (Rand.Chance(shadowStrikeCritChance))
                             {
                                 dmg *= 3;
                             }
-                            BodyPartRecord bpr = t.health.hediffSet.GetRandomNotMissingPart(DamageDefOf.Stab, BodyPartHeight.Undefined, BodyPartDepth.Outside);
-                            TM_Action.DamageEntities(target, bpr, dmg, Rand.Range(0f, .5f), DamageDefOf.Stab, this.Pawn);
-                            Vector3 rndPos = t.DrawPos;
+                            BodyPartRecord bpr = targetPawn.health.hediffSet.GetRandomNotMissingPart(DamageDefOf.Stab, BodyPartHeight.Undefined, BodyPartDepth.Outside);
+                            TM_Action.DamageEntities(targetPawn, bpr, dmg, Rand.Range(0f, .5f), DamageDefOf.Stab, this.Pawn);
+                            Vector3 rndPos = targetPawn.DrawPos;
                             rndPos.x += Rand.Range(-.2f, .2f);
                             rndPos.z += Rand.Range(-.2f, .2f);
-                            TM_MoteMaker.ThrowBloodSquirt(rndPos, t.Map, Rand.Range(.6f, 1f));
-                            TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_CrossStrike, rndPos, t.Map, Rand.Range(.6f, 1f), .4f, 0f, Rand.Range(.2f, .5f), 0, 0, 0, Rand.Range(0, 360));
+                            TM_MoteMaker.ThrowBloodSquirt(rndPos, targetPawn.Map, Rand.Range(.6f, 1f));
+                            TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_CrossStrike, rndPos, targetPawn.Map, Rand.Range(.6f, 1f), .4f, 0f, Rand.Range(.2f, .5f), 0, 0, 0, Rand.Range(0, 360));
                         }
                     }
-                    if (!t.DestroyedOrNull() && !t.Dead && !t.Downed)
+                    if (!targetPawn.DestroyedOrNull() && !targetPawn.Dead && !targetPawn.Downed)
                     {
-                        Job job = new Job(JobDefOf.AttackMelee, t);
+                        Job job = new Job(JobDefOf.AttackMelee, targetPawn);
                         this.Pawn.jobs.TryTakeOrderedJob(job);
                     }
                 }
@@ -419,9 +417,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSentinel.cs
@@ -95,9 +95,8 @@ namespace TorannMagic
 
                                 }
 
-                                if(this.target.Thing is Pawn)
+                                if(this.target.Thing is Pawn prisonerPawn)
                                 {
-                                    Pawn prisonerPawn = this.target.Thing as Pawn;
                                     if(prisonerPawn.IsPrisoner)
                                     {
                                         Job job = new Job(JobDefOf.AttackMelee, prisonerPawn);
@@ -240,9 +239,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
@@ -599,15 +599,11 @@ namespace TorannMagic
         public override void PostPreApplyDamage(DamageInfo dinfo, out bool absorbed)
         {
             base.PostPreApplyDamage(dinfo, out absorbed);
-            if(dinfo.Instigator != null)
+            if (dinfo.Instigator is Building instigatorThing)
             {
-                Thing instigatorThing = dinfo.Instigator;
-                if(instigatorThing is Building)
+                if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
                 {
-                    if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
-                    {
-                        this.buildingThreats.AddDistinct(instigatorThing as Building);
-                    }
+                    this.buildingThreats.AddDistinct(instigatorThing);
                 }
             }
         }
@@ -678,9 +674,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
@@ -216,7 +216,7 @@ namespace TorannMagic
                 for (int i = 0; i < targetCells.Count(); i++)
                 {
                     curCell = targetCells[i];
-                    if (curCell.IsValid && curCell.InBounds(this.Pawn.Map))
+                    if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Pawn.Map))
                     {
                         if (isExplosion)
                         {
@@ -262,7 +262,7 @@ namespace TorannMagic
             for (int i = 0; i < targetCells.Count(); i++)
             {
                 curCell = targetCells[i];
-                if (curCell.IsValid && curCell.InBounds(this.Pawn.Map))
+                if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Pawn.Map))
                 {
                     Vector3 launchVector = TM_Calc.GetVector(this.Pawn.Position, curCell);
                     Pawn knockbackPawn = curCell.GetFirstPawn(this.Pawn.Map);
@@ -700,7 +700,7 @@ namespace TorannMagic
             returnThings.Clear();
             for (int i = 0; i < searchCells.Count(); i++)
             {
-                if (searchCells[i].IsValid && searchCells[i].InBounds(this.Pawn.Map))
+                if (searchCells[i].IsValid && searchCells[i].InBoundsWithNullCheck(this.Pawn.Map))
                 {
                     List<Thing> cellList = searchCells[i].GetThingList(this.Pawn.Map);
                     for (int j = 0; j<cellList.Count(); j++)

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonLichController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonLichController.cs
@@ -264,7 +264,7 @@ namespace TorannMagic
         {
             this.nextChargeAttack = this.Props.chargeCooldownTicks + Find.TickManager.TicksGame;
             bool flag = t != null && t.DistanceToEdge(this.Pawn.Map) > 6;
-            if (flag && t.InBounds(this.Pawn.Map) && t.IsValid && t.Walkable(this.Pawn.Map) && Pawn.Position.DistanceTo(t) <= 60)
+            if (flag && t.InBoundsWithNullCheck(this.Pawn.Map) && t.IsValid && t.Walkable(this.Pawn.Map) && Pawn.Position.DistanceTo(t) <= 60)
             {
                 this.castingCompleteTick = Find.TickManager.TicksGame + this.Props.chargeAttackDelay;
                 this.flightTarget = t;
@@ -728,7 +728,7 @@ namespace TorannMagic
                         c.Destroy(DestroyMode.Vanish);
                     }
                 }
-                if (curCell.InBounds(map) && curCell.Walkable(map))
+                if (curCell.InBoundsWithNullCheck(map) && curCell.Walkable(map))
                 {
                     SpawnThings skeleton = new SpawnThings();
                     if (Rand.Chance(geChance + corpseMult))

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonLichController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonLichController.cs
@@ -606,16 +606,12 @@ namespace TorannMagic
         {
             base.PostPreApplyDamage(dinfo, out absorbed);
             //Log.Message("taking damage");
-            if (dinfo.Instigator != null)
+            if (dinfo.Instigator is Building instigatorThing)
             {
-                Thing instigatorThing = dinfo.Instigator;
-                if (instigatorThing is Building)
+                if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
                 {
-                    if (instigatorThing.Faction != null && instigatorThing.Faction != this.Pawn.Faction)
-                    {
-                        //Log.Message("adding building threat");
-                        this.buildingThreats.AddDistinct(instigatorThing as Building);
-                    }
+                    //Log.Message("adding building threat");
+                    this.buildingThreats.AddDistinct(instigatorThing);
                 }
             }
         }
@@ -689,9 +685,9 @@ namespace TorannMagic
             {
                 return false;
             }
-            if(target is Pawn)
+            if(target is Pawn targetPawn)
             {
-                return !(target as Pawn).Downed;
+                return !targetPawn.Downed;
             }
             if(target.Position.DistanceToEdge(this.Pawn.Map) < 8)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_DemonAssault.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_DemonAssault.cs
@@ -91,7 +91,7 @@ namespace TorannMagic.Conditions
             int accuracy = 5 - eventDifficulty;
             rndPos.x += Rand.Range(-accuracy, accuracy);
             rndPos.z += Rand.Range(-accuracy, accuracy);
-            if (rndPos.IsValid && rndPos.InBounds(this.SingleMap) && rndPos.DistanceToEdge(this.SingleMap) > 6)
+            if (rndPos.IsValid && rndPos.InBoundsWithNullCheck(this.SingleMap) && rndPos.DistanceToEdge(this.SingleMap) > 6)
             {
                 if (eventDifficulty > 2 && Rand.Chance(eventDifficulty * .05f))
                 {
@@ -349,7 +349,7 @@ namespace TorannMagic.Conditions
 
         private bool IsGoodLocationForSpawn(IntVec3 loc)
         {
-            return loc.InBounds(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
+            return loc.InBoundsWithNullCheck(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
         }
 
         private bool IsGoodCenterLocation(IntVec2 loc)

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_DivineBlessing.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_DivineBlessing.cs
@@ -33,13 +33,11 @@ namespace TorannMagic.Conditions
                 
                 for (int i = 0; i < allThings.Count; i++)
                 {
-                    Thing t = allThings[i];
-                    if(t != null && t is Corpse)
+                    if (allThings[i] is Corpse corpse)
                     {
-                        Corpse c = t as Corpse;
-                        if(c.InnerPawn.IsColonist && !c.IsDessicated())
+                        if(corpse.InnerPawn.IsColonist && !corpse.IsDessicated())
                         {
-                            potentialResurrection.Add(c);
+                            potentialResurrection.Add(corpse);
                         }
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_ElementalAssault.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_ElementalAssault.cs
@@ -129,7 +129,7 @@ namespace TorannMagic.Conditions
 
         private bool IsGoodLocationForSpawn(IntVec3 loc)
         {
-            return loc.InBounds(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
+            return loc.InBoundsWithNullCheck(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
         }
 
         private bool IsGoodCenterLocation(IntVec2 loc)

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_WanderingLich.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_WanderingLich.cs
@@ -363,7 +363,7 @@ namespace TorannMagic.Conditions
 
         private bool IsGoodLocationForSpawn(IntVec3 loc)
         {
-            return loc.InBounds(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
+            return loc.InBoundsWithNullCheck(base.SingleMap) && !loc.Roofed(base.SingleMap) && loc.Standable(base.SingleMap) && loc.IsValid && !loc.Fogged(base.SingleMap) && loc.Walkable(base.SingleMap);
         }
 
         private bool IsGoodCenterLocation(IntVec2 loc)
@@ -437,7 +437,7 @@ namespace TorannMagic.Conditions
             for (int j = 0; j < targets.Count(); j++)
             {
                 curCell = targets.ToArray<IntVec3>()[j];
-                if (curCell.InBounds(map) && curCell.IsValid && curCell.Walkable(map))
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid && curCell.Walkable(map))
                 {
                     SpawnThings skeleton = new SpawnThings();
                     if (Rand.Chance(geChance))

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/CompEnchantedItem.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/CompEnchantedItem.cs
@@ -174,10 +174,9 @@ namespace TorannMagic.Enchantment
 
         private void InitializeAbilities(ThingWithComps abilityThing)
         {
-            if (abilityThing is Apparel)
+            if (abilityThing is Apparel abilityApparel)
             {
-                Apparel abilityApparel = abilityThing as Apparel;
-                if (abilityApparel != null && abilityApparel.Wearer != null)
+                if (abilityApparel.Wearer != null)
                 {
                     CompAbilityItem comp = abilityApparel.TryGetComp<CompAbilityItem>();
                     if (comp != null)
@@ -231,9 +230,8 @@ namespace TorannMagic.Enchantment
                     }
                 }
                 Thing primary = this.parent as Thing;
-                if(primary != null && primary.ParentHolder is Pawn_EquipmentTracker)
-                {                    
-                    Pawn_EquipmentTracker pet = primary.ParentHolder as Pawn_EquipmentTracker;
+                if(primary != null && primary.ParentHolder is Pawn_EquipmentTracker pet)
+                {
                     if(pet.pawn != null && pet.pawn.equipment != null && pet.pawn.equipment.Primary == primary)
                     {
                         if (pet.pawn.health.hediffSet.GetFirstHediffOfDef(hediff, false) != null)
@@ -269,9 +267,8 @@ namespace TorannMagic.Enchantment
                     // abilities;
                 }
                 ThingWithComps primary = this.parent as ThingWithComps;
-                if (primary != null && primary.ParentHolder is Pawn_EquipmentTracker)
+                if (primary != null && primary.ParentHolder is Pawn_EquipmentTracker pet)
                 {
-                    Pawn_EquipmentTracker pet = primary.ParentHolder as Pawn_EquipmentTracker;
                     if (pet.pawn != null && pet.pawn.equipment != null && pet.pawn.equipment.Primary == primary)
                     {
                         this.InitializeAbilities(primary);

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitInfuse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitInfuse.cs
@@ -43,9 +43,8 @@ namespace TorannMagic.Enchantment
             
             if (this.currentTarget != null && base.CasterPawn != null)
             {
-                if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
+                if(this.currentTarget.Thing is Pawn victim)
                 {
-                    Pawn victim = this.currentTarget.Thing as Pawn;
                     if(victim.Faction != null && victim.RaceProps.Humanlike && victim.story != null && victim.story.traits != null && !TM_Calc.IsUndeadNotVamp(victim))
                     {
                         int traitsApplied = 0;

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitThief.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitThief.cs
@@ -42,9 +42,8 @@ namespace TorannMagic.Enchantment
             bool result = false;
             if (this.currentTarget != null && base.CasterPawn != null)
             {
-                if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
+                if(this.currentTarget.Thing is Pawn victim)
                 {
-                    Pawn victim = this.currentTarget.Thing as Pawn;
                     if(victim.Faction != null && victim.RaceProps.Humanlike && victim.story != null && victim.story.traits != null && victim.story.traits.allTraits.Count > 0 && !TM_Calc.IsUndead(victim))
                     {
                         if (Rand.Chance(TM_Calc.GetSpellSuccessChance(this.CasterPawn, victim, true)))

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitor.cs
@@ -39,9 +39,8 @@ namespace TorannMagic.Enchantment
             CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
             if (this.currentTarget != null && base.CasterPawn != null && comp != null)
             {
-                if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
+                if(this.currentTarget.Thing is Pawn traitor)
                 {
-                    Pawn traitor = this.currentTarget.Thing as Pawn;
                     if(traitor.Faction != null && traitor.Faction != this.CasterPawn.Faction && traitor.RaceProps.Humanlike)
                     {
                         if (Rand.Chance(TM_Calc.GetSpellSuccessChance(this.CasterPawn, traitor, true)))

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
@@ -394,18 +394,17 @@ namespace TorannMagic
                 hitThing.TakeDamage(this.impactDamage.Value);
             }
             ImpactOverride();
-            if (this.flyingThing is Pawn)
+            if (this.flyingThing is Pawn flyingPawn)
             {
                 try
                 {
                     SoundDefOf.Ambient_AltitudeWind.sustainFadeoutTime.Equals(30.0f);
 
-                    GenSpawn.Spawn(this.flyingThing, base.Position, base.Map);
-                    Pawn p = this.flyingThing as Pawn;
+                    GenSpawn.Spawn(flyingPawn, base.Position, base.Map);
                     if (this.earlyImpact)
                     {
-                        damageEntities(p, this.impactForce, DamageDefOf.Blunt);
-                        damageEntities(p, 2 * this.impactForce, DamageDefOf.Stun);
+                        damageEntities(flyingPawn, this.impactForce, DamageDefOf.Blunt);
+                        damageEntities(flyingPawn, 2 * this.impactForce, DamageDefOf.Stun);
                     }
                     this.Destroy(DestroyMode.Vanish);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
@@ -288,7 +288,7 @@ namespace TorannMagic
                         }
                         else
                         {
-                            bool flag3 = this.DestinationCell.InBounds(base.Map);
+                            bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                             if (flag3)
                             {
                                 base.Position = this.DestinationCell;
@@ -298,7 +298,7 @@ namespace TorannMagic
                     }
                     else
                     {
-                        bool flag3 = this.DestinationCell.InBounds(base.Map);
+                        bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                         if (flag3)
                         {
                             base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DeathBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DeathBolt.cs
@@ -252,7 +252,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0 && !impacted;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -268,14 +268,14 @@ namespace TorannMagic
                     CellRect cellRect = CellRect.CenteredOn(base.Position, 2);
                     cellRect.ClipInsideMap(base.Map);
                     IntVec3 spreadingDarknessCell;
-                    if(!(cellRect.CenterCell.GetTerrain(base.Map).passability == Traversability.Impassable) && !cellRect.CenterCell.IsValid || !cellRect.CenterCell.InBounds(base.Map))
+                    if(!(cellRect.CenterCell.GetTerrain(base.Map).passability == Traversability.Impassable) && !cellRect.CenterCell.IsValid || !cellRect.CenterCell.InBoundsWithNullCheck(base.Map))
                     {
                         this.ticksFollowingImpact = -1;
                     }
                     for (int i = 0; i < 2; i++)
                     {
                         spreadingDarknessCell = cellRect.RandomCell;
-                        if (spreadingDarknessCell.InBounds(base.Map) && spreadingDarknessCell.IsValid)
+                        if (spreadingDarknessCell.InBoundsWithNullCheck(base.Map) && spreadingDarknessCell.IsValid)
                         {
                             GenExplosion.DoExplosion(spreadingDarknessCell, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_DeathBolt, this.pawn, Mathf.RoundToInt((Rand.Range(.4f * this.def.projectile.GetDamageAmount(1, null), .8f * this.def.projectile.GetDamageAmount(1, null)) + (3f * pwrVal)) * this.arcaneDmg), 2, this.def.projectile.soundExplode, def, null, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
                             TM_MoteMaker.ThrowDiseaseMote(base.Position.ToVector3Shifted(), base.Map, .6f);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DemonFlight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DemonFlight.cs
@@ -194,7 +194,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DirtDevil.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DirtDevil.cs
@@ -259,7 +259,7 @@ namespace TorannMagic
                     }
                     else
                     {
-                        bool flag3 = this.DestinationCell.InBounds(base.Map);
+                        bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                         if (flag3)
                         {
                             base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DragonStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DragonStrike.cs
@@ -194,7 +194,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -292,7 +292,7 @@ namespace TorannMagic
                         {
                             Vector3 launchVector = TM_Calc.GetVector(this.origin, hitThing.Position.ToVector3());
                             IntVec3 projectedPosition = hitThing.Position + ((10f - distanceToTarget) * (1 + (.15f * verVal)) * launchVector).ToIntVec3();
-                            if (projectedPosition.IsValid && projectedPosition.InBounds(hitThing.Map))
+                            if (projectedPosition.IsValid && projectedPosition.InBoundsWithNullCheck(hitThing.Map))
                             {
                                 LaunchFlyingObect(projectedPosition, hitPawn, Mathf.RoundToInt(10f - distanceToTarget));
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_EyeOfTheStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_EyeOfTheStorm.cs
@@ -204,7 +204,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -404,7 +404,7 @@ namespace TorannMagic
             for (int i = 0; i < (15 + 4*pwrVal); i++)
             {
                 IntVec3 strikeCell = dissipationList.RandomElement();
-                if (strikeCell.InBounds(base.Map) && strikeCell.IsValid && !strikeCell.Fogged(this.Map))
+                if (strikeCell.InBoundsWithNullCheck(base.Map) && strikeCell.IsValid && !strikeCell.Fogged(this.Map))
                 {
                     DrawStrike(this.ExactPosition.ToIntVec3(), strikeCell.ToVector3Shifted());
                     for (int k = 0; k < Rand.Range(1, 8); k++)

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Flight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Flight.cs
@@ -175,7 +175,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Leap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Leap.cs
@@ -166,7 +166,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightLance.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightLance.cs
@@ -212,7 +212,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0 && !impacted;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightningTrap.cs
@@ -207,7 +207,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -352,7 +352,7 @@ namespace TorannMagic
             for (int i = 0; i < 4; i++)
             {
                 IntVec3 strikeCell = dissipationList.RandomElement();
-                if (strikeCell.InBounds(base.Map) && strikeCell.IsValid && !strikeCell.Fogged(this.Map))
+                if (strikeCell.InBoundsWithNullCheck(base.Map) && strikeCell.IsValid && !strikeCell.Fogged(this.Map))
                 {
                     DrawStrike(this.ExactPosition.ToIntVec3(), strikeCell.ToVector3Shifted());
                     for (int k = 0; k < Rand.Range(1, 8); k++)

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LivingWall.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LivingWall.cs
@@ -625,7 +625,7 @@ namespace TorannMagic
                                     }
                                     else
                                     {
-                                        bool flag3 = this.DestinationCell.InBounds(base.Map);
+                                        bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                                         if (flag3)
                                         {
                                             base.Position = this.DestinationCell;
@@ -636,7 +636,7 @@ namespace TorannMagic
                                 }
                                 else
                                 {
-                                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                                     if (flag3)
                                     {
                                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsiStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsiStorm.cs
@@ -117,7 +117,7 @@ namespace TorannMagic
             this.strikeCells = GenRadial.RadialCellsAround(this.centerLoc, 7, true).ToList();
             for(int i =0; i < this.strikeCells.Count(); i++)
             {
-                if(!this.strikeCells[i].InBounds(this.pawn.Map) || !this.strikeCells[i].IsValid)
+                if(!this.strikeCells[i].InBoundsWithNullCheck(this.pawn.Map) || !this.strikeCells[i].IsValid)
                 {
                     this.strikeCells.Remove(this.strikeCells[i]);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicDash.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicDash.cs
@@ -210,7 +210,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicLeap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicLeap.cs
@@ -185,7 +185,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -279,7 +279,7 @@ namespace TorannMagic
             {
                 victim = null;
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(this.Map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(this.Map) && curCell.IsValid)
                 {
                     victim = curCell.GetFirstPawn(map);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicStorm.cs
@@ -317,7 +317,7 @@ namespace TorannMagic
                     }
                     else
                     {
-                        bool flag3 = this.DestinationCell.InBounds(base.Map);
+                        bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                         if (flag3)
                         {
                             base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ShadowBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ShadowBolt.cs
@@ -220,7 +220,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -298,7 +298,7 @@ namespace TorannMagic
                 intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
                 //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f * this.def.projectile.GetDamageAmount(1,null), 1.1f * this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
 
-                if (intVec.IsValid && intVec.InBounds(this.Map))
+                if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
                 {
                     List<Thing> hitList = new List<Thing>();
                     hitList = intVec.GetThingList(base.Map);
@@ -314,7 +314,7 @@ namespace TorannMagic
                 intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
                 //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f * this.def.projectile.GetDamageAmount(1,null), 1.1f * this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
 
-                if (intVec.IsValid && intVec.InBounds(this.Map))
+                if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
                 {
                     List<Thing> hitList = new List<Thing>();
                     hitList = intVec.GetThingList(base.Map);
@@ -330,7 +330,7 @@ namespace TorannMagic
                 intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
                 //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f*this.def.projectile.GetDamageAmount(1,null), 1.1f*this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
 
-                if (intVec.IsValid && intVec.InBounds(this.Map))
+                if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
                 {
                     List<Thing> hitList = new List<Thing>();
                     hitList = intVec.GetThingList(base.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
@@ -349,17 +349,16 @@ namespace TorannMagic
                 if (this.flyingThing != null)
                 {
                     GenSpawn.Spawn(this.flyingThing, base.Position, base.Map);
-                    if (this.flyingThing is Pawn)
+                    if (this.flyingThing is Pawn flyingPawn)
                     {
-                        Pawn p = this.flyingThing as Pawn;
-                        if (p.IsColonist && this.drafted)
+                        if (flyingPawn.IsColonist && this.drafted)
                         {
-                            p.drafter.Drafted = true;
+                            flyingPawn.drafter.Drafted = true;
                         }
                         if (this.earlyImpact)
                         {
-                            damageEntities(p, this.impactForce, DamageDefOf.Blunt);
-                            damageEntities(p, this.impactForce, DamageDefOf.Stun);
+                            damageEntities(flyingPawn, this.impactForce, DamageDefOf.Blunt);
+                            damageEntities(flyingPawn, this.impactForce, DamageDefOf.Stun);
                         }
                     }
                     else if (flyingThing.def.thingCategories != null && (flyingThing.def.thingCategories.Contains(ThingCategoryDefOf.Chunks) || flyingThing.def.thingCategories.Contains(ThingCategoryDef.Named("StoneChunks"))))

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
@@ -187,7 +187,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -420,7 +420,7 @@ namespace TorannMagic
                         for (int i = 0; i < outsideRing.Count; i++)
                         {
                             IntVec3 intVec = outsideRing[i];
-                            if (intVec.IsValid && intVec.InBounds(base.Map))
+                            if (intVec.IsValid && intVec.InBoundsWithNullCheck(base.Map))
                             {
                                 Vector3 moteDirection = TM_Calc.GetVector(this.ExactPosition.ToIntVec3(), intVec);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Rubble, this.ExactPosition, base.Map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
@@ -504,7 +504,7 @@ namespace TorannMagic
                         for (int i = 0; i < outsideRing.Count; i++)
                         {
                             IntVec3 intVec = outsideRing[i];
-                            if (intVec.IsValid && intVec.InBounds(base.Map))
+                            if (intVec.IsValid && intVec.InBoundsWithNullCheck(base.Map))
                             {
                                 Vector3 moteDirection = TM_Calc.GetVector(this.ExactPosition.ToIntVec3(), intVec);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_BloodSquirt, this.ExactPosition, base.Map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(4f, 13f), (Quaternion.AngleAxis(Rand.Range(60, 120), Vector3.up) * moteDirection).ToAngleFlat(), 0);
@@ -575,7 +575,7 @@ namespace TorannMagic
                     for (int i = 0; i < outsideRing.Count; i++)
                     {
                         IntVec3 intVec = outsideRing[i];
-                        if (intVec.IsValid && intVec.InBounds(base.Map))
+                        if (intVec.IsValid && intVec.InBoundsWithNullCheck(base.Map))
                         {
                             Vector3 moteDirection = TM_Calc.GetVector(this.ExactPosition.ToIntVec3(), intVec);
                             TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Rubble, this.ExactPosition, base.Map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
@@ -838,11 +838,10 @@ namespace TorannMagic
             }
             else if(solAction == SoLAction.BrightenDay)
             {
-                if(this.assignedTarget != null && this.assignedTarget is Pawn)
+                if(this.assignedTarget is Pawn assignedPawn)
                 {
-                    Pawn p = this.assignedTarget as Pawn;
                     ActualLightCost(6f);
-                    p.needs.mood.thoughts.memories.TryGainMemory(TorannMagicDefOf.TM_BrightDayTD);
+                    assignedPawn.needs.mood.thoughts.memories.TryGainMemory(TorannMagicDefOf.TM_BrightDayTD);
                     Action_CircleTarget(this.assignedTarget, out destTarget);
                     queuedAction = SoLAction.Returning;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
@@ -628,7 +628,7 @@ namespace TorannMagic
                     {
                         if (this.shouldDismiss)
                         {
-                            bool flag3 = this.DestinationCell.InBounds(base.Map);
+                            bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                             if (flag3)
                             {
                                 base.Position = this.DestinationCell;
@@ -649,7 +649,7 @@ namespace TorannMagic
                                 }
                                 else
                                 {
-                                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                                     if (flag3)
                                     {
                                         base.Position = this.DestinationCell;
@@ -661,7 +661,7 @@ namespace TorannMagic
                             }
                             else
                             {
-                                bool flag3 = this.DestinationCell.InBounds(base.Map);
+                                bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                                 if (flag3)
                                 {
                                     base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritWolves.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritWolves.cs
@@ -176,7 +176,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;
@@ -240,7 +240,7 @@ namespace TorannMagic
                 if (lastRadial != null && lastRadial.Count() > 0)
                 {
                     curCell = lastRadial.RandomElement();
-                    if (curCell.InBounds(base.Map) && curCell.IsValid)
+                    if (curCell.InBoundsWithNullCheck(base.Map) && curCell.IsValid)
                     {
                         ThingDef moteSmoke = TorannMagicDefOf.Mote_Base_Smoke;
                         if (Rand.Chance(.5f))
@@ -270,7 +270,7 @@ namespace TorannMagic
                 for (int i = 0; i < effectRadial.Count(); i++)
                 {
                     curCell = effectRadial.ToArray<IntVec3>()[i];
-                    if (curCell.InBounds(base.Map) && curCell.IsValid)
+                    if (curCell.InBoundsWithNullCheck(base.Map) && curCell.IsValid)
                     {
                         hitList = curCell.GetThingList(base.Map);
                         for (int j = 0; j < hitList.Count; j++)

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_TimeDelay.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_TimeDelay.cs
@@ -328,12 +328,11 @@ namespace TorannMagic
             if (this.Map != null)
             {
                 GenPlace.TryPlaceThing(this.flyingThing, base.Position, base.Map, ThingPlaceMode.Direct);
-                if (this.flyingThing is Pawn)
+                if (this.flyingThing is Pawn flyingPawn)
                 {
-                    Pawn p = this.flyingThing as Pawn;
-                    if (p.IsColonist && this.drafted && p.drafter != null)
+                    if (flyingPawn.IsColonist && this.drafted && flyingPawn.drafter != null)
                     {
-                        p.drafter.Drafted = true;
+                        flyingPawn.drafter.Drafted = true;
                     }
                 }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ValiantCharge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ValiantCharge.cs
@@ -219,7 +219,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Whirlwind.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Whirlwind.cs
@@ -180,7 +180,7 @@ namespace TorannMagic
                 bool flag2 = this.ticksToImpact <= 0;
                 if (flag2)
                 {
-                    bool flag3 = this.DestinationCell.InBounds(base.Map);
+                    bool flag3 = this.DestinationCell.InBoundsWithNullCheck(base.Map);
                     if (flag3)
                     {
                         base.Position = this.DestinationCell;

--- a/RimWorldOfMagic/RimWorldOfMagic/GenGridExtensions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/GenGridExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Verse;
+
+namespace TorannMagic
+{
+    public static class GenGridExtensions
+    {
+        public static bool InBoundsWithNullCheck(this IntVec3 c, Map map)
+        {
+            return map != null && c.InBounds(map);
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/GenGridExtensions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/GenGridExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using System;
+using Verse;
 
 namespace TorannMagic
 {
@@ -6,7 +7,16 @@ namespace TorannMagic
     {
         public static bool InBoundsWithNullCheck(this IntVec3 c, Map map)
         {
-            return map != null && c.InBounds(map);
+            // Use try catch as there are only rare exceptions when c is deleted after call but before Inbounds is called
+            try
+            {
+                return c.InBounds(map);
+            }
+            catch (NullReferenceException e)
+            {
+                Log.Warning($"NullReference during InBounds call: {e.ToString()}");
+                return false;
+            }
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompGolem.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompGolem.cs
@@ -66,15 +66,11 @@ namespace TorannMagic.Golems
         {
             get
             {
-                if(threatTarget != null)
+                if (threatTarget is Pawn pawn)
                 {
-                    if (threatTarget is Pawn)
+                    if(pawn.DestroyedOrNull() || pawn.Dead || pawn.Downed || pawn.Map == null)
                     {
-                        Pawn p = threatTarget as Pawn;
-                        if(p.DestroyedOrNull() || p.Dead || p.Downed || p.Map == null)
-                        {
-                            threatTarget = null;
-                        }
+                        threatTarget = null;
                     }
                 }
                 return threatTarget;
@@ -98,14 +94,13 @@ namespace TorannMagic.Golems
                 {
                     return false;
                 }
-                if (targetThing is Pawn)
+                if (targetThing is Pawn targetPawn)
                 {
-                    Pawn p = targetThing as Pawn;
-                    if (p.Dead || p.Downed)
+                    if (targetPawn.Dead || targetPawn.Downed)
                     {
                         return false;
                     }
-                    if (checkThreatPath && p.CanReach(source, PathEndMode.ClosestTouch, Danger.Deadly, false, false, TraverseMode.PassDoors))
+                    if (checkThreatPath && targetPawn.CanReach(source, PathEndMode.ClosestTouch, Danger.Deadly, false, false, TraverseMode.PassDoors))
                     {
                         return false;
                     }
@@ -324,9 +319,9 @@ namespace TorannMagic.Golems
                 {
                     foreach(Thing t in innerContainer)
                     {
-                        if(t is Building_TMGolemBase)
+                        if(t is Building_TMGolemBase tmGolemBase)
                         {
-                            dormantThing = t as Building_TMGolemBase;
+                            dormantThing = tmGolemBase;
                         }
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ApplyDamage.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ApplyDamage.cs
@@ -30,9 +30,9 @@ namespace TorannMagic.Golems
         public override void Apply(LocalTargetInfo target, Pawn caster, TM_GolemAbilityDef ability, float effectLevel = 1f, float effectBonus = 1f)
         {
             base.Apply(target, caster, ability);
-            if (target.Thing != null && target.Thing is Pawn)
+            if (target.Thing is Pawn pawn)
             {
-                TM_Action.DamageEntities_AoE(damageType, damageAmount * LevelModifier * effectBonus, armorPenetration * effectBonus, caster, target.Thing as Pawn, caster.Map, splashRadius);
+                TM_Action.DamageEntities_AoE(damageType, damageAmount * LevelModifier * effectBonus, armorPenetration * effectBonus, caster, pawn, caster.Map, splashRadius);
             }
         }
 
@@ -42,24 +42,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (p.health == null)
-            {
-                return false;
-            }
-            if (p.health.hediffSet == null)
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || pawn.health == null || pawn.health.hediffSet == null)
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ApplyHediff.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ApplyHediff.cs
@@ -28,10 +28,9 @@ namespace TorannMagic.Golems
         public override void Apply(LocalTargetInfo target, Pawn caster, TM_GolemAbilityDef ability, float effectLevel = 1f, float effectBonus = 1f)
         {
             base.Apply(target, caster, ability);
-            if (target.Thing != null && target.Thing is Pawn)
+            if (target.Thing is Pawn pawn)
             {
-                Pawn p = target.Thing as Pawn;
-                HealthUtility.AdjustSeverity(p, hediff, severity * LevelModifier * effectBonus);
+                HealthUtility.AdjustSeverity(pawn, hediff, severity * LevelModifier * effectBonus);
             }
         }
 
@@ -41,30 +40,15 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (p.health == null)
-            {
-                return false;
-            }
-            if (p.health.hediffSet == null)
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || pawn.health == null || pawn.health.hediffSet == null)
             {
                 return false;
             }
             if (!canStack)
             {
-                Hediff hd = p.health.hediffSet.GetFirstHediffOfDef(hediff);
+                Hediff hd = pawn.health.hediffSet.GetFirstHediffOfDef(hediff);
                 if (hd != null)
                 {
                     return false;

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_Dismember.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_Dismember.cs
@@ -24,9 +24,8 @@ namespace TorannMagic.Golems
         public override void Apply(LocalTargetInfo target, Pawn caster, TM_GolemAbilityDef ability, float effectLevel = 1f, float effectBonus = 1f)
         {
             base.Apply(target, caster, ability);
-            if (target.Thing != null && target.Thing is Pawn)
+            if (target.Thing is Pawn victim)
             {
-                Pawn victim = target.Thing as Pawn;
                 List<BodyPartRecord> bprList = new List<BodyPartRecord>();
                 bprList.Clear();
                 List<BodyPartRecord> bprLegs = victim.health.hediffSet.GetNotMissingParts(BodyPartHeight.Undefined, BodyPartDepth.Outside, BodyPartTagDefOf.MovingLimbCore, null).ToList();
@@ -73,24 +72,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (p.health == null)
-            {
-                return false;
-            }
-            if (p.health.hediffSet == null)
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || pawn.health == null || pawn.health.hediffSet == null)
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_HealPawn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_HealPawn.cs
@@ -33,20 +33,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (!TM_Calc.IsPawnInjured(p))
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || !TM_Calc.IsPawnInjured(pawn))
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_LaunchThing.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_LaunchThing.cs
@@ -51,10 +51,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing != null && target.Thing is Pawn)
+            if (target.Thing is Pawn pawn)
             {
-                Pawn p = target.Thing as Pawn;
-                if (p.Dead || p.Downed)
+                if (pawn.Dead || pawn.Downed)
                 {
                     return false;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ShieldPawn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_ShieldPawn.cs
@@ -42,20 +42,9 @@ namespace TorannMagic.Golems
             {
                 return false;
             }
-            if (target.Thing == null)
-            {
-                return false;
-            }
-            if (!(target.Thing is Pawn))
-            {
-                return false;
-            }
-            Pawn p = target.Thing as Pawn;
-            if (p.Dead)
-            {
-                return false;
-            }
-            if (!TM_Calc.IsPawnInjured(p))
+
+            Pawn pawn = target.Thing as Pawn;
+            if (pawn == null || pawn.Dead || !TM_Calc.IsPawnInjured(pawn))
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/ITab_GolemPawn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/ITab_GolemPawn.cs
@@ -36,17 +36,12 @@ namespace TorannMagic.Golems
         {
             get
             {
-                Thing singleSelectedThing = Find.Selector.SingleSelectedThing;
-                if (singleSelectedThing != null && singleSelectedThing is TMPawnGolem)
+                if (Find.Selector.SingleSelectedThing is TMPawnGolem golemPawn)
                 {
-                    TMPawnGolem golem_pawn = singleSelectedThing as TMPawnGolem;
-                    if(golem_pawn != null)
+                    CompGolem cg = golemPawn.TryGetComp<CompGolem>();
+                    if (cg != null)
                     {
-                        CompGolem cg = golem_pawn.TryGetComp<CompGolem>();
-                        if (cg != null)
-                        {
-                            return cg.Upgrades;
-                        }
+                        return cg.Upgrades;
                     }
                 }
                 return null;

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/ITab_GolemWorkstation.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/ITab_GolemWorkstation.cs
@@ -23,14 +23,9 @@ namespace TorannMagic.Golems
         {
             get
             {
-                Thing singleSelectedThing = Find.Selector.SingleSelectedThing;
-                if (singleSelectedThing != null && singleSelectedThing is Building_TMGolemBase)
+                if (Find.Selector.SingleSelectedThing is Building_TMGolemBase golemBuilding)
                 {
-                    Building_TMGolemBase golem_building = singleSelectedThing as Building_TMGolemBase;
-                    if(golem_building != null)
-                    {
-                        return golem_building.Upgrades;
-                    }
+                    return golemBuilding.Upgrades;
                 }
                 return null;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/JobGiver_EngageThreatInRange.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/JobGiver_EngageThreatInRange.cs
@@ -30,9 +30,8 @@ namespace TorannMagic.Golems
             {
                 return null;
             }
-            if (meleeThreat is Pawn)
+            if (meleeThreat is Pawn meleeThreatPawn)
             {
-                Pawn meleeThreatPawn = meleeThreat as Pawn;
                 if (meleeThreatPawn.IsInvisible())
                 {
                     return null;

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/TMPawnGolem.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/TMPawnGolem.cs
@@ -522,7 +522,7 @@ namespace TorannMagic.Golems
                 IntVec3 cell = infoTarget.Cell;
                 FleckMaker.ThrowAirPuffUp(infoTarget.CenterVector3, this.Map);
                 FleckMaker.ThrowHeatGlow(infoTarget.Cell, this.Map, 1f);
-                if (cell.IsValid && cell.InBounds(this.Map) && !cell.Fogged(this.Map) && cell.Standable(this.Map) && ReachabilityUtility.CanReach(this, infoTarget, PathEndMode.OnCell, Danger.Deadly, false, false, TraverseMode.ByPawn))
+                if (cell.IsValid && cell.InBoundsWithNullCheck(this.Map) && !cell.Fogged(this.Map) && cell.Standable(this.Map) && ReachabilityUtility.CanReach(this, infoTarget, PathEndMode.OnCell, Danger.Deadly, false, false, TraverseMode.ByPawn))
                 {
                     Golem.dormantPosition = cell;
                     Golem.dormantMap = this.Map;

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/Verb_GolemSmash.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/Verb_GolemSmash.cs
@@ -26,7 +26,7 @@ namespace TorannMagic.Golems
                     for (int i = 0; i < targetCells.Count; i++)
                     {
                         curCell = targetCells[i];                        
-                        if (curCell.IsValid && curCell.InBounds(CasterPawn.Map))
+                        if (curCell.IsValid && curCell.InBoundsWithNullCheck(CasterPawn.Map))
                         {
                             float angle = (Quaternion.AngleAxis(90, Vector3.up) * TM_Calc.GetVector(target.Cell, curCell)).ToAngleFlat();
                             TM_MoteMaker.ThrowGenericFleck(FleckDefOf.DustPuffThick, target.CenterVector3, CasterPawn.Map, Rand.Range(.5f, .8f), Rand.Range(.3f, .5f), .1f, Rand.Range(.3f, .5f), 0, 1.5f, angle, Rand.Range(0, 360));

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -207,22 +207,12 @@ namespace TorannMagic
                     typeof(bool),
                     typeof(bool)
                 }, null), null, new HarmonyMethod(typeof(TorannMagicMod), "TryStartCastOn_Prefix", null), null);
-            harmonyInstance.Patch(AccessTools.Method(typeof(GenGrid), "InBounds", new Type[]
-                {
-                    typeof(IntVec3),
-                    typeof(Map)
-                }, null), new HarmonyMethod(typeof(TorannMagicMod), "IntVec3Inbounds_NullCheck_Prefix", null), null);
             harmonyInstance.Patch(AccessTools.Method(typeof(VerbProperties), "AdjustedCooldown", new Type[]
                 {
                     typeof(Tool),
                     typeof(Pawn),
                     typeof(Thing)
                 }, null), null, new HarmonyMethod(typeof(TorannMagicMod), "GolemVerb_AdjustedCooldown_Postfix", null), null);
-            //harmonyInstance.Patch(AccessTools.Method(typeof(GenGrid), "InBounds", new Type[]
-            //    {
-            //        typeof(IntVec3),
-            //        typeof(Map)
-            //    }, null), new HarmonyMethod(typeof(TorannMagicMod), "IntVec3Inbounds_NullCheck_Prefix", null), null);
             ////harmonyInstance.Patch(AccessTools.Method(typeof(AbilityUser.PawnAbility), "GetJob"),
             ////    new HarmonyMethod(typeof(TorannMagicMod), "PawnAbility_GetJob_Prefix"));
             ////harmonyInstance.Patch(AccessTools.Method(typeof(QuestNode_RaceProperty), "Matches", new Type[]
@@ -2260,16 +2250,6 @@ namespace TorannMagic
                     }
                 }
             }
-        }
-
-        public static bool IntVec3Inbounds_NullCheck_Prefix(IntVec3 c, Map map, ref bool __result)
-        {
-            if (c != null && map != null)
-            {
-                return true;
-            }
-            __result = false;
-            return false;
         }
 
         public static bool CompAbilityItem_Overlay_Prefix(CompAbilityItem __instance)

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6413,29 +6413,6 @@ namespace TorannMagic
                         // Early exit condition
                         if (!settingsRef.showClassIconOnColonistBar || colonist.story == null) return null;
                         
-                        // Check custom classes
-                        CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
-                        if (compMagic != null && compMagic.customClass != null)
-                        {
-                            Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
-                            if (compMagic.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMagic.customClass.classTexturePath, true);
-                            }
-
-                            return new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom");
-                        }
-                        CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
-                        if (compMight != null && compMight.customClass != null)
-                        {
-                            Texture2D customIcon = TM_MatPool.DefaultCustomFighterIcon;
-                            if (compMight.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMight.customClass.classTexturePath, true);
-                            }
-                            
-                            return new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom");
-                        }
                         for (int i = 0; i < colonist.story.traits.allTraits.Count; i++)
                         {
                             TraitDef trait = colonist.story.traits.allTraits[i].def;

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2772,20 +2772,35 @@ namespace TorannMagic
                 }
             }
         }
+        
+        // Keep these two HashSets in memory to have faster checking for the below method since it is called often.
+        private static readonly HashSet<ThingDef> staggerExemptPawnDefs = new HashSet<ThingDef>{
+            TorannMagicDefOf.TM_DemonR, 
+            TorannMagicDefOf.TM_HollowGolem
+        };
+        private static readonly HashSet<HediffDef> staggerExemptHediffs = new HashSet<HediffDef>{
+            TorannMagicDefOf.TM_BurningFuryHD,
+            TorannMagicDefOf.TM_MoveOutHD,
+            TorannMagicDefOf.TM_EnrageHD
+        };
 
         public static bool Get_Staggered(Pawn_StanceTracker __instance, ref bool __result)
         {
-            if (__instance.pawn.def == TorannMagicDefOf.TM_DemonR || __instance.pawn.def == TorannMagicDefOf.TM_HollowGolem)
+            if (staggerExemptPawnDefs.Contains(__instance.pawn.def))
             {
                 __result = false;
                 return false;
             }
             if (__instance.pawn.health != null && __instance.pawn.health.hediffSet != null)
             {
-                if (__instance.pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_BurningFuryHD) || __instance.pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_MoveOutHD) || __instance.pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EnrageHD))
+                var hediffs = __instance.pawn.health.hediffSet.hediffs;
+                for (int i = 0; i < hediffs.Count; i++)
                 {
-                    __result = false;
-                    return false;
+                    if (staggerExemptHediffs.Contains(hediffs[i].def))
+                    {
+                        __result = false;
+                        return false;
+                    }
                 }
             }
             return true;
@@ -2793,7 +2808,7 @@ namespace TorannMagic
 
         public static bool StaggerFor_Patch(Pawn_StanceTracker __instance, int ticks)
         {
-            if (__instance.pawn.def == TorannMagicDefOf.TM_DemonR || __instance.pawn.def == TorannMagicDefOf.TM_HollowGolem)
+            if (staggerExemptPawnDefs.Contains(__instance.pawn.def))
             {
                 return false;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6398,7 +6398,7 @@ namespace TorannMagic
                 if (colonist.Dead) return;
 
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                if (colonist.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
+                if (colonist.health.hediffSet.HasHediff(TorannMagicDefOf.TM_UndeadHD))
                 {
                     float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
                     Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6395,231 +6395,65 @@ namespace TorannMagic
         {
             public static void Postfix(ColonistBarColonistDrawer __instance, ref Rect rect, Pawn colonist)
             {
-                if (!colonist.Dead)
+                if (colonist.Dead) return;
+
+                ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
+                if (colonist.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
                 {
-                    ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                    if (colonist.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
+                    float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
+                    Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
+                    rect = new Rect(vector.x, vector.y, num, num);
+                    GUI.DrawTexture(rect, TM_MatPool.Icon_Undead);
+                    TooltipHandler.TipRegion(rect, "TM_Icon_Undead".Translate());
+                    vector.x += num;
+                }
+                else if (settingsRef.showClassIconOnColonistBar && colonist.story != null)
+                {
+                    // Create the shapes for the icon
+                    float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
+                    Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
+                    rect = new Rect(vector.x, vector.y, num, num);
+                    // Check for custom classes
+                    CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
+                    if (compMagic != null && compMagic.customClass != null)
                     {
-                        float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
-                        Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
-                        rect = new Rect(vector.x, vector.y, num, num);
-                        GUI.DrawTexture(rect, TM_MatPool.Icon_Undead);
-                        TooltipHandler.TipRegion(rect, "TM_Icon_Undead".Translate());
+                        Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
+                        if (compMagic.customClass.classTexturePath != "")
+                        {
+                            customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMagic.customClass.classTexturePath, true);
+                        }
+                        GUI.DrawTexture(rect, customIcon);
+                        TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
                         vector.x += num;
-                        //rect = new Rect(vector.x, vector.y, num, num);
+                        return;
                     }
-                    else if (settingsRef.showClassIconOnColonistBar && colonist.story != null)
+                    CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
+                    if (compMight != null && compMight.customClass != null)
                     {
-                        float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
-                        Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
-                        rect = new Rect(vector.x, vector.y, num, num);
-                        CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
-                        CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
-                        if (compMagic != null && compMagic.customClass != null)
+                        Texture2D customIcon = TM_MatPool.DefaultCustomFighterIcon;
+                        if (compMight.customClass.classTexturePath != "")
                         {
-                            Texture2D customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomMageMark", true);
-                            if (compMagic.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMagic.customClass.classTexturePath, true);
-                            }
-                            GUI.DrawTexture(rect, customIcon);
-                            TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
-                            vector.x += num;
+                            customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMight.customClass.classTexturePath, true);
                         }
-                        else if (compMight != null && compMight.customClass != null)
+                        GUI.DrawTexture(rect, customIcon);
+                        TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
+                        vector.x += num;
+                    }
+                    // Otherwise use dictionary TraitIconMapping to apply the material and shape
+                    else
+                    {
+                        for (int i = 0; i < colonist.story.traits.allTraits.Count; i++)
                         {
-                            Texture2D customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomFighterMark", true);
-                            if (compMight.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMight.customClass.classTexturePath, true);
-                            }
-                            GUI.DrawTexture(rect, customIcon);
-                            TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
-                            vector.x += num;
+                            TraitDef trait = colonist.story.traits.allTraits[i].def;
+                            if (!TraitIconMap.ContainsKey(trait)) continue;
 
+                            GUI.DrawTexture(rect, TraitIconMap.Get(trait).IconMaterial);
+                            TooltipHandler.TipRegion(rect, TraitIconMap.Get(trait).IconType.Translate());
+                            vector.x += num;
+                            return;
                         }
-                        else
-                        {
-
-                            if (colonist.story.traits.HasTrait(TorannMagicDefOf.InnerFire))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.fireIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.HeartOfFrost))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.iceIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.StormBorn))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.lightningIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Arcanist))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.arcanistIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Paladin))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.paladinIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Summoner))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.summonerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Druid))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.druidIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Necromancer) || colonist.story.traits.HasTrait(TorannMagicDefOf.Lich))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.necroIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Priest))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.priestIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Bard))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.bardIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Succubus) || colonist.story.traits.HasTrait(TorannMagicDefOf.Warlock))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.demonkinIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Geomancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.earthIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Technomancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.technoIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.BloodMage))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.bloodmageIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Enchanter))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.enchanterIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Chronomancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.chronoIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Gladiator))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.gladiatorIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Sniper))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.sniperIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Bladedancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.bladedancerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Ranger))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.rangerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Faceless))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.facelessIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Psionic))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.psiIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.DeathKnight))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.deathknightIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Monk))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.monkIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.wandererIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.wayfarerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.ChaosMage))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.chaosIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Commander))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.commanderIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_SuperSoldier))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.SSIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                        }
-                        //rect = new Rect(vector.x, vector.y, num, num);
                     }
                 }
-                //return true;
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -18,6 +18,7 @@ using TorannMagic.TMDefs;
 using TorannMagic.Golems;
 using RimWorld.QuestGen;
 using System.Diagnostics;
+using TorannMagic.Utils;
 
 namespace TorannMagic
 {

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Dominate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Dominate.cs
@@ -126,7 +126,7 @@ namespace TorannMagic
                     for (int i = 0; i < targets.Count(); i++)
                     {
                         curCell = targets.ToArray<IntVec3>()[i];
-                        if (curCell.InBounds(map) && curCell.IsValid)
+                        if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                         {
                             victim = curCell.GetFirstPawn(map);
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Hediff_ApothecaryHerbs.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Hediff_ApothecaryHerbs.cs
@@ -63,11 +63,10 @@ namespace TorannMagic
                 {
                     this.Severity += .4f * (1f + (.1f * herbVer));
                 }
-                if(this.pawn.Map == null && this.pawn.ParentHolder is Caravan)
+                if(this.pawn.Map == null && this.pawn.ParentHolder is Caravan caravan)
                 {
-                    Caravan car = this.pawn.ParentHolder as Caravan;
                     bool flag;
-                    if (!car.NightResting)
+                    if (!caravan.NightResting)
                     {
                         this.Severity += (ForagedFoodPerDayCalculator.GetBaseForagedNutritionPerDay(this.pawn, out flag)/50f) * (1f + (.05f * herbVer));
                     }                    

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PortalDestination.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PortalDestination.cs
@@ -109,7 +109,7 @@ namespace TorannMagic
                 portalTarget.canTargetFires = false;
                 portalTarget.canTargetBuildings = false;
                 portalTarget.canTargetItems = false;
-                portalTarget.validator = ((TargetInfo x) => x.IsValid && !x.Cell.Fogged(map) && x.Cell.InBounds(map) && x.Cell.Walkable(map));  //TargetingParameters.ForDropPodsDestination()
+                portalTarget.validator = ((TargetInfo x) => x.IsValid && !x.Cell.Fogged(map) && x.Cell.InBoundsWithNullCheck(map) && x.Cell.Walkable(map));  //TargetingParameters.ForDropPodsDestination()
                 Find.Targeter.BeginTargeting(portalTarget, delegate (LocalTargetInfo x)
                 {                    
                     portalBldg.PortalDestinationPosition = x.Cell;

--- a/RimWorldOfMagic/RimWorldOfMagic/MagicPower.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MagicPower.cs
@@ -1,126 +1,12 @@
 ﻿using AbilityUser;
 using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
 using Verse;
 
 namespace TorannMagic 
 {
-    public class MagicPower : IExposable
+    public class MagicPower : Power
     {
-        public List<AbilityDef> TMabilityDefs;
-        public TMDefs.TM_Autocast autocasting;
-
-        public int ticksUntilNextCast = -1;
-
-        public int level = 0;
-        public bool learned = false;
-        public bool autocast = false;
-        public int learnCost = 2;
-        private int interactionTick = 0;
         public bool requiresScroll = false;
-        public int maxLevel = 3;
-        public int costToLevel = 1;
-        
-        public bool AutoCast
-        {
-            get
-            {
-                return autocast;
-            }
-            set
-            {
-                if (interactionTick < Find.TickManager.TicksGame)
-                {
-                    autocast = value;
-                    interactionTick = Find.TickManager.TicksGame + 5;
-                }
-            }
-
-        }
-
-        private void SetMaxLevel()
-        {
-            this.maxLevel = this.TMabilityDefs.Count - 1;
-        }
-
-        public AbilityDef abilityDescDef
-        {
-            get
-            {
-                return this.abilityDef;                
-            }
-        }
-
-        public AbilityDef nextLevelAbilityDescDef
-        {
-            get
-            {
-                return this.nextLevelAbilityDef;                
-            }
-        }
-
-        public AbilityDef abilityDef
-        {
-            get
-            {
-                SetMaxLevel();
-                if (TMabilityDefs != null && TMabilityDefs.Count > 0)
-                {
-                    if (level <= 0)
-                    {
-                        return this.TMabilityDefs[0];
-                    }
-                    else if (level >= maxLevel)
-                    {
-                        return this.TMabilityDefs[maxLevel];
-                    }
-                    return this.TMabilityDefs[level];
-                }
-                return null;
-            }
-        }
-
-        public AbilityDef nextLevelAbilityDef
-        {
-            get
-            {
-                SetMaxLevel();
-                if ((this.level + 1) >= this.maxLevel)
-                {
-                    return this.TMabilityDefs[maxLevel];
-                }
-                else
-                {
-                    return this.TMabilityDefs[level + 1];
-                }               
-            }
-        }
-
-        public Texture2D Icon
-        {
-            get
-            {
-                return this.abilityDef.uiIcon;
-            }
-        }
-
-        public AbilityDef GetAbilityDef(int index)
-        {
-            try
-            {
-                return this.TMabilityDefs[index];
-            }
-            catch
-            {
-                return this.TMabilityDefs[0];
-            }            
-        }
-
-        public AbilityDef HasAbilityDef(AbilityDef defToFind)
-        {
-            return this.TMabilityDefs.FirstOrDefault((AbilityDef x) => x == defToFind);
-        }
 
         public MagicPower()
         {
@@ -158,18 +44,10 @@ namespace TorannMagic
             }
         }
 
-        public void ExposeData()
+        public override void ExposeData()
         {
-            Scribe_Values.Look<bool>(ref this.learned, "learned", true, false);
-            Scribe_Values.Look<bool>(ref this.autocast, "autocast", false, false);
+            base.ExposeData();
             Scribe_Values.Look<bool>(ref this.requiresScroll, "requiresScroll", false, false);
-            Scribe_Values.Look<int>(ref this.learnCost, "learnCost", 2, false);
-            Scribe_Values.Look<int>(ref this.costToLevel, "costToLevel", 1, false);
-            Scribe_Values.Look<int>(ref this.level, "level", 0, false);
-            Scribe_Values.Look<int>(ref this.maxLevel, "maxLevel", 3, false);
-            Scribe_Values.Look<int>(ref this.ticksUntilNextCast, "ticksUntilNextCast", -1, false);
-            Scribe_Collections.Look<AbilityDef>(ref this.TMabilityDefs, "TMabilityDefs", LookMode.Def, null);
-            Scribe_Deep.Look<TMDefs.TM_Autocast>(ref this.autocasting, "autocasting", new object[0]);
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/MightPower.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MightPower.cs
@@ -1,147 +1,10 @@
 ﻿using AbilityUser;
 using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
-using Verse;
 
 namespace TorannMagic 
 {
-    public class MightPower : IExposable
+    public class MightPower : Power
     {
-        public List<AbilityDef> TMabilityDefs;
-        public TMDefs.TM_Autocast autocasting;
-
-        public int ticksUntilNextCast = -1;
-
-        public int level;
-
-        public bool learned = false;
-        public bool autocast = false;
-        public int learnCost = 2;
-        private int interactionTick = 0;
-        public int maxLevel = 3;
-        public int costToLevel = 1;
-
-        public bool AutoCast
-        {
-            get
-            {
-                return autocast;
-            }
-            set
-            {
-                if (interactionTick < Find.TickManager.TicksGame)
-                {
-                    autocast = value;
-                    interactionTick = Find.TickManager.TicksGame + 5;
-                }
-            }
-        }
-
-        private void SetMaxLevel()
-        {
-            this.maxLevel = this.TMabilityDefs.Count - 1;
-        }
-
-        public AbilityDef abilityDescDef
-        {
-            get
-            {                
-                return this.abilityDef;
-            }
-        }
-
-        public AbilityDef nextLevelAbilityDescDef
-        {
-            get
-            {
-                return this.nextLevelAbilityDef;                
-            }
-        }
-
-        public AbilityDef abilityDef
-        {
-            get
-            {
-                if (TMabilityDefs != null && TMabilityDefs.Count > 0)
-                {
-                    SetMaxLevel();
-                    if (level <= 0)
-                    {
-                        return this.TMabilityDefs[0];
-                    }
-                    else if (level >= maxLevel)
-                    {
-                        return this.TMabilityDefs[maxLevel];
-                    }
-                    return this.TMabilityDefs[level];                    
-                }
-                return null;
-            }
-        }
-
-        public AbilityDef nextLevelAbilityDef
-        {
-            get
-            {
-                SetMaxLevel();
-                if ((this.level + 1) >= this.maxLevel)
-                {
-                    return this.TMabilityDefs[maxLevel];
-                }
-                else
-                {
-                    return this.TMabilityDefs[level + 1];
-                }                
-            }
-        }
-
-        public Texture2D Icon
-        {
-            get
-            {
-                return this.abilityDef.uiIcon;
-            }
-        }
-
-        public AbilityDef GetAbilityDef(int index)
-        {
-            try
-            {
-                return this.TMabilityDefs[index];
-            }
-            catch
-            {
-                return this.TMabilityDefs[0];
-            }
-            //
-            AbilityDef result = null;
-            bool flag = this.TMabilityDefs != null && this.TMabilityDefs.Count > 0;
-            if (flag)
-            {
-                result = this.TMabilityDefs[0];
-                bool flag2 = index > -1 && index < this.TMabilityDefs.Count;
-                if (flag2)
-                {
-                    result = this.TMabilityDefs[index];
-                }
-                else
-                {
-                    bool flag3 = index >= this.TMabilityDefs.Count;
-                    if (flag3)
-                    {
-                        result = this.TMabilityDefs[this.TMabilityDefs.Count - 1];
-                    }
-                }
-            }
-            return result;
-        }
-
-        public AbilityDef HasAbilityDef(AbilityDef defToFind)
-        {
-            return this.TMabilityDefs.FirstOrDefault((AbilityDef x) => x == defToFind);
-        }
-
         public MightPower()
         {
         }
@@ -163,19 +26,6 @@ namespace TorannMagic
             {
                 this.learnCost = 0;
             }
-        }
-
-        public void ExposeData()
-        {
-            Scribe_Values.Look<bool>(ref this.learned, "learned", true, false);
-            Scribe_Values.Look<bool>(ref this.autocast, "autocast", false, false);
-            Scribe_Values.Look<int>(ref this.learnCost, "learnCost", 2, false);
-            Scribe_Values.Look<int>(ref this.costToLevel, "costToLevel", 1, false);
-            Scribe_Values.Look<int>(ref this.level, "level", 0, false);
-            Scribe_Values.Look<int>(ref this.maxLevel, "maxLevel", 3, false);
-            Scribe_Values.Look<int>(ref this.ticksUntilNextCast, "ticksUntilNextCast", -1, false);
-            Scribe_Collections.Look<AbilityDef>(ref this.TMabilityDefs, "TMabilityDefs", (LookMode)4, null);
-            Scribe_Deep.Look<TMDefs.TM_Autocast>(ref this.autocasting, "autocasting", new object[0]);
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
@@ -49,7 +49,23 @@ namespace TorannMagic.ModOptions
             for (int i = 0; i < TM_ClassUtility.CustomClasses().Count; i++)
             {
                 TMDefs.TM_CustomClass customClass = TM_ClassUtility.CustomClasses()[i];
-                customTraits.AddDistinct(customClass.classTrait);
+                if (customTraits.Contains(customClass.classTrait))
+                {
+                    Log.Warning($"RimWorld of Magic trait {customClass.classTrait} already added. This is likely a naming conflict between mods.");
+                }
+                else
+                {
+                    // Map the trait to the texture to avoid having to TryGetComp
+                    Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
+                    if (customClass.classTexturePath != "")
+                    {
+                        customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + customClass.classTexturePath, true);
+                    }
+                    
+                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom"));
+                    // Add custom trait to list for processing
+                    customTraits.Add(customClass.classTrait);
+                }
                 customClass.classTrait.conflictingTraits.AddRange(TM_Data.AllClassTraits);
             }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
@@ -46,6 +46,7 @@ namespace TorannMagic.ModOptions
             //Conflicting trait levelset
             List<TraitDef> customTraits = new List<TraitDef>();
             customTraits.Clear();
+            const string customIconType = "TM_Icon_Custom";
             for (int i = 0; i < TM_ClassUtility.CustomClasses().Count; i++)
             {
                 TMDefs.TM_CustomClass customClass = TM_ClassUtility.CustomClasses()[i];
@@ -61,8 +62,8 @@ namespace TorannMagic.ModOptions
                     {
                         customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + customClass.classTexturePath, true);
                     }
+                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, customIconType));
                     
-                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom"));
                     // Add custom trait to list for processing
                     customTraits.Add(customClass.classTrait);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Need_Mana.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Need_Mana.cs
@@ -460,10 +460,9 @@ namespace TorannMagic
                                             }
                                             TM_MoteMaker.ThrowBloodSquirt(current.Position.ToVector3Shifted(), current.Map, 2.5f);
                                         }
-                                        else if (current.ParentHolder != null && current.ParentHolder is Caravan)
+                                        else if (current.ParentHolder is Caravan caravan)
                                         {
-                                            Caravan van = current.ParentHolder as Caravan;                                            
-                                            van.RemovePawn(current);
+                                            caravan.RemovePawn(current);
                                         }
                                         current.Destroy();
                                         undeadCount--;

--- a/RimWorldOfMagic/RimWorldOfMagic/Power.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Power.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Linq;
+using AbilityUser;
+using UnityEngine;
+using Verse;
+
+namespace TorannMagic
+{
+    public class Power : IExposable
+    {
+        public List<AbilityDef> TMabilityDefs;
+        public TMDefs.TM_Autocast autocasting;
+
+        public int ticksUntilNextCast = -1;
+
+        public int level;
+        public bool learned = false;
+        public bool autocast = false;
+        public int learnCost = 2;
+        protected int interactionTick = 0;
+        public int maxLevel = 3;
+        public int costToLevel = 1;
+
+        protected Power()
+        {
+
+        }
+        
+        public bool AutoCast
+        {
+            get
+            {
+                return autocast;
+            }
+            set
+            {
+                if (interactionTick < Find.TickManager.TicksGame)
+                {
+                    autocast = value;
+                    interactionTick = Find.TickManager.TicksGame + 5;
+                }
+            }
+        }
+        
+        private void SetMaxLevel()
+        {
+            this.maxLevel = this.TMabilityDefs.Count - 1;
+        }
+        
+        public AbilityDef abilityDescDef
+        {
+            get
+            {                
+                return this.abilityDef;
+            }
+        }
+        
+        public AbilityDef nextLevelAbilityDescDef
+        {
+            get
+            {
+                return this.nextLevelAbilityDef;                
+            }
+        }
+        
+        public AbilityDef abilityDef
+        {
+            get
+            {
+                if (TMabilityDefs != null && TMabilityDefs.Count > 0)
+                {
+                    SetMaxLevel();
+                    if (level <= 0)
+                    {
+                        return this.TMabilityDefs[0];
+                    }
+                    else if (level >= maxLevel)
+                    {
+                        return this.TMabilityDefs[maxLevel];
+                    }
+                    return this.TMabilityDefs[level];                    
+                }
+                return null;
+            }
+        }
+        
+        public AbilityDef nextLevelAbilityDef
+        {
+            get
+            {
+                SetMaxLevel();
+                if ((this.level + 1) >= this.maxLevel)
+                {
+                    return this.TMabilityDefs[maxLevel];
+                }
+                return this.TMabilityDefs[level + 1];
+            }
+        }
+        
+        public Texture2D Icon
+        {
+            get
+            {
+                return this.abilityDef.uiIcon;
+            }
+        }
+        
+        public AbilityDef GetAbilityDef(int index)
+        {
+            try
+            {
+                return this.TMabilityDefs[index];
+            }
+            catch
+            {
+                return this.TMabilityDefs[0];
+            }
+        }
+        
+        public AbilityDef HasAbilityDef(AbilityDef defToFind)
+        {
+            return this.TMabilityDefs.FirstOrDefault((AbilityDef x) => x == defToFind);
+        }
+        
+        public virtual void ExposeData()
+        {
+            Scribe_Values.Look<bool>(ref this.learned, "learned", true, false);
+            Scribe_Values.Look<bool>(ref this.autocast, "autocast", false, false);
+            Scribe_Values.Look<int>(ref this.learnCost, "learnCost", 2, false);
+            Scribe_Values.Look<int>(ref this.costToLevel, "costToLevel", 1, false);
+            Scribe_Values.Look<int>(ref this.level, "level", 0, false);
+            Scribe_Values.Look<int>(ref this.maxLevel, "maxLevel", 3, false);
+            Scribe_Values.Look<int>(ref this.ticksUntilNextCast, "ticksUntilNextCast", -1, false);
+            Scribe_Collections.Look<AbilityDef>(ref this.TMabilityDefs, "TMabilityDefs", LookMode.Def, null);
+            Scribe_Deep.Look<TMDefs.TM_Autocast>(ref this.autocasting, "autocasting", new object[0]);
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Attraction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Attraction.cs
@@ -91,7 +91,7 @@ namespace TorannMagic
                 cellList = targets.ToList<IntVec3>();
                 for(int i = 0; i < cellList.Count(); i ++)
                 {
-                    if (cellList[i].IsValid && cellList[i].InBounds(pawn.Map))
+                    if (cellList[i].IsValid && cellList[i].InBoundsWithNullCheck(pawn.Map))
                     {
                         victim = cellList[i].GetFirstPawn(pawn.Map);
                         if (victim != null && !victim.Dead && !victim.Downed)
@@ -134,7 +134,7 @@ namespace TorannMagic
                 for (int i = 0; i < 3; i++)
                 {
                     curCell = cellList.RandomElement();
-                    if (curCell.IsValid && curCell.InBounds(base.Map))
+                    if (curCell.IsValid && curCell.InBoundsWithNullCheck(base.Map))
                     {
                         victim = curCell.GetFirstPawn(base.Map);
                         if (victim != null && !victim.Dead && victim.RaceProps.IsFlesh && victim != this.pawn)
@@ -155,7 +155,7 @@ namespace TorannMagic
                 for(int i =0; i < hediffCellList.Count(); i++)
                 {
                     curCell = hediffCellList[i];
-                    if (curCell.IsValid && curCell.InBounds(base.Map))
+                    if (curCell.IsValid && curCell.InBoundsWithNullCheck(base.Map))
                     {
                         victim = curCell.GetFirstPawn(base.Map);
                         if (victim != null && !victim.Dead && victim != this.pawn)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Blizzard.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Blizzard.cs
@@ -69,7 +69,7 @@ namespace TorannMagic
                 Initialize(map);
             }
             impactPos = cellRect.RandomCell;
-            if (this.age > lastStrikeLarge + Rand.Range(200 - (pwrVal * 30), duration/(4 + pwrVal)) && impactPos.Standable(map) && impactPos.InBounds(map) && impactPos.DistanceToEdge(map) >= 2)
+            if (this.age > lastStrikeLarge + Rand.Range(200 - (pwrVal * 30), duration/(4 + pwrVal)) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map) && impactPos.DistanceToEdge(map) >= 2)
             {
                 this.lastStrikeLarge = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Blizzard_Large, impactPos, map);
@@ -79,7 +79,7 @@ namespace TorannMagic
                 snowCount++;
             }
             impactPos = cellRect.RandomCell;
-            if (this.age > lastStrikeTiny + Rand.Range(6-(pwrVal), 18-(2*pwrVal)) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if (this.age > lastStrikeTiny + Rand.Range(6-(pwrVal), 18-(2*pwrVal)) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeTiny = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Blizzard_Tiny, impactPos, map);
@@ -89,7 +89,7 @@ namespace TorannMagic
                 snowCount++;
             }
             impactPos = cellRect.RandomCell;
-            if ( this.age > lastStrikeSmall + Rand.Range(30-(2*pwrVal), 60-(4*pwrVal)) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if ( this.age > lastStrikeSmall + Rand.Range(30-(2*pwrVal), 60-(4*pwrVal)) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeSmall = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Blizzard_Small, impactPos, map);
@@ -136,7 +136,7 @@ namespace TorannMagic
             for (int i = 0; i < num; i++)
             {
                 IntVec3 intVec = center + GenRadial.RadialPattern[i];
-                if (intVec.InBounds(map))
+                if (intVec.InBoundsWithNullCheck(map))
                 {
                     float lengthHorizontal = (center - intVec).LengthHorizontal;
                     float num2 = 1f - lengthHorizontal / radius;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_BloodMoon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_BloodMoon.cs
@@ -105,13 +105,13 @@ namespace TorannMagic
 
                 this.CheckSpawnSustainer();
 
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     List<IntVec3> cellList = GenRadial.RadialCellsAround(base.Position, this.radius, true).ToList();
                     for (int i = 0; i < cellList.Count; i++)
                     {
                         curCell = cellList[i];
-                        if (curCell.InBounds(map) && curCell.IsValid)
+                        if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                         {
                             this.bloodCircleCells.Add(curCell);
                         }
@@ -122,7 +122,7 @@ namespace TorannMagic
                     for (int i = 0; i < cellList.Count; i++)
                     {
                         curCell = cellList[i];
-                        if (curCell.InBounds(map) && curCell.IsValid)
+                        if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                         {
                             outerRing.Add(curCell);
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChainLightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChainLightning.cs
@@ -184,7 +184,7 @@ namespace TorannMagic
 
         public void DamageCell(IntVec3 c, Pawn caster)
         {
-            if (c != default(IntVec3) && c.IsValid && c.InBounds(this.Map))
+            if (c != default(IntVec3) && c.IsValid && c.InBoundsWithNullCheck(this.Map))
             {
                 FleckMaker.ThrowLightningGlow(c.ToVector3Shifted(), this.Map, 1f);
                 List<Thing> thingList = c.GetThingList(this.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChargeBattery.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChargeBattery.cs
@@ -24,10 +24,9 @@ namespace TorannMagic
             bldg = cellRect.CenterCell.GetFirstBuilding(map);            
             if (bldg != null)
             {
-                if (bldg is Building_TMGolemBase)
+                if (bldg is Building_TMGolemBase golemBase)
                 {
-                    Building_TMGolemBase gb = bldg as Building_TMGolemBase;
-                    gb.Energy.AddEnergyFlat(400 * comp.arcaneDmg);
+                    golemBase.Energy.AddEnergyFlat(400 * comp.arcaneDmg);
                 }
                 else if (bldg.GetComp<CompPowerBattery>() != null)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChronostaticField.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChronostaticField.cs
@@ -91,7 +91,7 @@ namespace TorannMagic
             cellList = GenRadial.RadialCellsAround(base.Position, this.radius, true).ToList(); //this.radius instead of 2
             for (int i = 0; i < cellList.Count; i++)
             {
-                if (cellList[i].IsValid && cellList[i].InBounds(this.Map))
+                if (cellList[i].IsValid && cellList[i].InBoundsWithNullCheck(this.Map))
                 {
                     List<Thing> thingList = cellList[i].GetThingList(this.Map);
                     if (thingList != null && thingList.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_CorpseExplosion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_CorpseExplosion.cs
@@ -66,7 +66,7 @@ namespace TorannMagic
                 CellRect cellRect = CellRect.CenteredOn(base.Position, 1);
                 cellRect.ClipInsideMap(map);
                 IntVec3 curCell = cellRect.CenterCell;
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     Pawn undead = curCell.GetFirstPawn(map);
                     bool flag = undead != null && !undead.Dead;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_DryGround.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_DryGround.cs
@@ -27,7 +27,7 @@ namespace TorannMagic
                 {
                     curCell = cells.ToArray<IntVec3>()[i];
                     terrain = curCell.GetTerrain(map);
-                    if (curCell.InBounds(map) && curCell.IsValid && terrain.driesTo != null)
+                    if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid && terrain.driesTo != null)
                     {
                         if (terrain.defName == "MarshyTerrain" || terrain.defName == "Mud" || terrain.defName == "Marsh")
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_EarthernHammer.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_EarthernHammer.cs
@@ -82,7 +82,7 @@ namespace TorannMagic
             this.launchCells = GenRadial.RadialCellsAround(caster.Position, this.radius, false).ToList();
             for (int i = 0; i < launchCells.Count(); i++)
             {
-                if (launchCells[i].IsValid && launchCells[i].InBounds(caster.Map))
+                if (launchCells[i].IsValid && launchCells[i].InBoundsWithNullCheck(caster.Map))
                 {
                     List<Thing> cellList = launchCells[i].GetThingList(caster.Map);
                     bool invalidCell = false;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Encase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Encase.cs
@@ -104,7 +104,7 @@ namespace TorannMagic
                 //{
                 for(int k =0; k < wall.Count(); k++)
                 { 
-                    if(wall[k].position.IsValid && wall[k].position.InBounds(caster.Map) && !wall[k].position.Fogged(caster.Map) && !wall[k].position.InNoZoneEdgeArea(caster.Map))
+                    if(wall[k].position.IsValid && wall[k].position.InBoundsWithNullCheck(caster.Map) && !wall[k].position.Fogged(caster.Map) && !wall[k].position.InNoZoneEdgeArea(caster.Map))
                     //if (wallPositions[k].IsValid && wallPositions[k].InBounds(caster.Map) && !wallPositions[k].Fogged(caster.Map) && !wallPositions[k].InNoZoneEdgeArea(caster.Map))
                     {
                         if (wall[k].terrain.defName == "Marsh" || wall[k].terrain.defName == "WaterShallow" || wall[k].terrain.defName == "WaterMovingShallow" || wall[k].terrain.defName == "WaterOceanShallow" || wall[k].terrain.defName == "WaterMovingChestDeep")

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Explosion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Explosion.cs
@@ -160,7 +160,7 @@ namespace TorannMagic
                     IEnumerable<IntVec3> explosionCells = newExplosionCells.Except(oldExplosionCells);
                     foreach (IntVec3 cell in explosionCells)
                     {
-                        if (cell.InBounds(map))
+                        if (cell.InBoundsWithNullCheck(map))
                         {
                             Vector3 heading = (cell - centerCell).ToVector3();
                             float distance = heading.magnitude;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireball.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireball.cs
@@ -45,7 +45,7 @@ namespace TorannMagic
             for (int i = 0; i < (pwrVal * 3); i++)
 			{
 				IntVec3 randomCell = cellRect.RandomCell;
-                if(randomCell.IsValid && randomCell.InBounds(map) && !randomCell.Fogged(map))
+                if(randomCell.IsValid && randomCell.InBoundsWithNullCheck(map) && !randomCell.Fogged(map))
                 {
                     this.FireExplosion(randomCell, map, 2.2f, ver);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firestorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firestorm.cs
@@ -72,7 +72,7 @@ namespace TorannMagic
             }
 
             impactPos = cellRect.RandomCell;
-            if (this.age > lastStrikeLarge + Rand.Range((200/(1+pwrVal))+20, (duration/(1+pwrVal))+40) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if (this.age > lastStrikeLarge + Rand.Range((200/(1+pwrVal))+20, (duration/(1+pwrVal))+40) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeLarge = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Firestorm_Large, impactPos, map);
@@ -85,13 +85,13 @@ namespace TorannMagic
                 }                
             }
             impactPos = cellRect.RandomCell;
-            if (this.age > lastStrikeTiny + Rand.Range(7-pwrVal, 20-pwrVal) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if (this.age > lastStrikeTiny + Rand.Range(7-pwrVal, 20-pwrVal) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeTiny = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Firestorm_Tiny, impactPos, map);
             }
             impactPos = cellRect.RandomCell;
-            if ( this.age > lastStrikeSmall + Rand.Range(18-(2*pwrVal), 42-(2*pwrVal)) && impactPos.Standable(map) && impactPos.InBounds(map))
+            if ( this.age > lastStrikeSmall + Rand.Range(18-(2*pwrVal), 42-(2*pwrVal)) && impactPos.Standable(map) && impactPos.InBoundsWithNullCheck(map))
             {
                 this.lastStrikeSmall = this.age;
                 SkyfallerMaker.SpawnSkyfaller(TorannMagicDefOf.TM_Firestorm_Small, impactPos, map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
@@ -91,7 +91,7 @@ namespace TorannMagic
                 {
                     curCell = targets.ToArray<IntVec3>()[i];
 
-                    if (curCell.InBounds(map) && curCell.IsValid)
+                    if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                     {
                         victim = curCell.GetFirstPawn(map);
                         if(victim != null && !victim.Dead && victim.RaceProps.IsFlesh)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
@@ -165,9 +165,8 @@ namespace TorannMagic
         {
             int amt = Mathf.RoundToInt(Rand.Range(.5f, 1.5f) * d);
             DamageInfo dinfo = new DamageInfo(type, amt, 0, (float)-1, null, null, null, DamageInfo.SourceCategory.ThingOrUnknown);
-            if (this.launcher != null && this.launcher is Pawn)
+            if (this.launcher is Pawn caster)
             {
-                Pawn caster = this.launcher as Pawn;
                 dinfo = new DamageInfo(type, amt, 0, (float)-1, caster, null, null, DamageInfo.SourceCategory.ThingOrUnknown);                
             }
             bool flag = e != null;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_HealingCircle.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_HealingCircle.cs
@@ -148,7 +148,7 @@ namespace TorannMagic
             {                
                 Pawn pawn = null;                
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     pawn = curCell.GetFirstPawn(map);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
@@ -127,7 +127,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     victim = curCell.GetFirstPawn(map);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_IgniteBlood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_IgniteBlood.cs
@@ -128,7 +128,7 @@ namespace TorannMagic
                 for (int i = 0; i < 30; i++)
                 {
                     IntVec3 randomCell = cellList.RandomElement();
-                    if (randomCell.IsValid && randomCell.InBounds(pawn.Map) && !randomCell.Fogged(pawn.Map) && randomCell.Walkable(pawn.Map))
+                    if (randomCell.IsValid && randomCell.InBoundsWithNullCheck(pawn.Map) && !randomCell.Fogged(pawn.Map) && randomCell.Walkable(pawn.Map))
                     {
                         //FilthMaker.MakeFilth(randomCell, this.Map, ThingDefOf.Filth_Blood, 1);
                         //Log.Message("creating blood at " + randomCell);
@@ -185,7 +185,7 @@ namespace TorannMagic
                 List<IntVec3> cellList = GenRadial.RadialCellsAround(this.BF[i].position, .4f + this.BF[i].pulseCount, false).ToList();
                 for (int j = 0; j < cellList.Count; j++)
                 {
-                    if (cellList[j].IsValid && cellList[j].InBounds(this.Map))
+                    if (cellList[j].IsValid && cellList[j].InBoundsWithNullCheck(this.Map))
                     {
                         List<Thing> thingList = cellList[j].GetThingList(this.Map);
                         for (int k = 0; k < thingList.Count; k++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
@@ -152,7 +152,7 @@ namespace TorannMagic
 
         public void DamageCell(IntVec3 c, Thing caster)
         {
-            if (c != default(IntVec3) && c.IsValid && c.InBounds(this.Map))
+            if (c != default(IntVec3) && c.IsValid && c.InBoundsWithNullCheck(this.Map))
             {
                 FleckMaker.ThrowLightningGlow(c.ToVector3Shifted(), this.Map, 1f);
                 List<Thing> thingList = c.GetThingList(this.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
@@ -61,16 +61,15 @@ namespace TorannMagic
         private void Initialize(Thing t)
         {
             GenClamor.DoClamor(this, 2f, ClamorDefOf.Ability);
-            if (!t.DestroyedOrNull() && t is Pawn)
+            if (!t.DestroyedOrNull() && t is Pawn pawn)
             {
-                Pawn p = t as Pawn;
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
                 if (comp != null && comp.MagicData != null)
                 {
                     //pwrVal = TM_Calc.GetMagicSkillLevel(p, comp.MagicData.MagicPowerSkill_ChainLightning, "TM_ChainLightning", "_pwr", true);
                     //verVal = TM_Calc.GetMagicSkillLevel(p, comp.MagicData.MagicPowerSkill_ChainLightning, "TM_ChainLightning", "_ver", true);
-                    pwrVal = TM_Calc.GetSkillPowerLevel(p, TorannMagicDefOf.TM_ChainLightning);
-                    verVal = TM_Calc.GetSkillVersatilityLevel(p, TorannMagicDefOf.TM_ChainLightning);
+                    pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_ChainLightning);
+                    verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_ChainLightning);
                     this.arcaneDmg = comp.arcaneDmg;
                 }                
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningCloud.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningCloud.cs
@@ -93,7 +93,7 @@ namespace TorannMagic
                     for (int i = 0; i < 3; i++)
                     {
                         randomCell = cellRect.RandomCell;
-                        if (randomCell.InBounds(map))
+                        if (randomCell.InBoundsWithNullCheck(map))
                         {
                             victim = randomCell.GetFirstPawn(map);
                             if (victim != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningStorm.cs
@@ -79,7 +79,7 @@ namespace TorannMagic
 				if (((this.boltDelay + this.lastStrike) < this.age))
 				{
 					IntVec3 randomCell = cellRect.RandomCell;
-                    if (randomCell.IsValid && randomCell.InBounds(base.Map))
+                    if (randomCell.IsValid && randomCell.InBoundsWithNullCheck(base.Map))
                     {
                         //Map.weatherManager.eventHandler.AddEvent(new WeatherEvent_LightningStrike(map, randomCell));
                         Map.weatherManager.eventHandler.AddEvent(new TM_WeatherEvent_MeshFlash(map, randomCell, TM_MatPool.standardLightning, DamageDefOf.Flame, this.launcher, -1, 1.9f, 1f, 1.5f));

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Overwhelm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Overwhelm.cs
@@ -92,7 +92,7 @@ namespace TorannMagic
             for (int j = 0; j < targets.Count; j++)
             {
                 IntVec3 curCell = targets[j];
-                if (map != null && curCell.IsValid && curCell.InBounds(map))
+                if (map != null && curCell.IsValid && curCell.InBoundsWithNullCheck(map))
                 {
                     HolyExplosion(pwrVal, verVal, curCell, map, 0.4f);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsychicShock.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsychicShock.cs
@@ -83,7 +83,7 @@ namespace TorannMagic
                     for (int j = 0; j < targets.Count(); j++)
                     {
                         IntVec3 curCell = targets.ToArray<IntVec3>()[j];
-                        if (curCell.IsValid && curCell.InBounds(pawn.Map))
+                        if (curCell.IsValid && curCell.InBoundsWithNullCheck(pawn.Map))
                         {
                             Vector3 angle = GetVector(explosionCenters[i], curCell);
                             if (explosionRadii[i] <= 3)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
@@ -238,10 +238,9 @@ namespace TorannMagic
                                     }
                                 }
                             }
-                            else if (corpseThing is Pawn)
+                            else if (corpseThing is Pawn undeadPawn)
                             {
-                                Pawn undeadPawn = corpseThing as Pawn;
-                                if(undeadPawn != pawn && !TM_Calc.IsNecromancer(undeadPawn) && TM_Calc.IsUndead(corpseThing as Pawn))
+                                if(undeadPawn != pawn && !TM_Calc.IsNecromancer(undeadPawn) && TM_Calc.IsUndead(undeadPawn))
                                 {
                                     RemoveHediffsAddictionsAndPermanentInjuries(undeadPawn);
                                     TM_MoteMaker.ThrowPoisonMote(curCell.ToVector3Shifted(), map, .6f);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
@@ -36,7 +36,7 @@ namespace TorannMagic
                 curCell = targets.ToArray<IntVec3>()[i];
 
                 TM_MoteMaker.ThrowPoisonMote(curCell.ToVector3Shifted(), map, .3f);
-                if (curCell.InBounds(map))
+                if (curCell.InBoundsWithNullCheck(map))
                 { 
                     Corpse corpse = null;
                     List<Thing> thingList;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Refraction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Refraction.cs
@@ -166,27 +166,26 @@ namespace TorannMagic
                 for (int i = 0; i < cellList.Count; i++)
                 {
                     Thing t = cellList[i];
-                    if (t is Projectile && t.def.defName != "Projectile_Refraction" && !(t is Mote))
+                    if (t is Projectile projectile && projectile.def.defName != "Projectile_Refraction")
                     {
-                        Projectile proj = t as Projectile;
-                        IntVec3 projOrigin = Traverse.Create(root: proj).Field(name: "origin").GetValue<Vector3>().ToIntVec3();
+                        IntVec3 projOrigin = Traverse.Create(root: projectile).Field(name: "origin").GetValue<Vector3>().ToIntVec3();
 
-                        if (proj != null && proj.Launcher != null && (proj.Launcher.Faction != null || proj.def.defName == "Projectile_LightLaser") && !proj.def.projectile.flyOverhead && !wallPositions.Contains(projOrigin))
+                        if (projectile.Launcher != null && (projectile.Launcher.Faction != null || projectile.def.defName == "Projectile_LightLaser") && !projectile.def.projectile.flyOverhead && !wallPositions.Contains(projOrigin))
                         {
-                            if (proj.Launcher.Faction != this.caster.Faction)
+                            if (projectile.Launcher.Faction != this.caster.Faction)
                             {
                                 Vector3 displayEffect = this.wallPositions[k].ToVector3Shifted();
                                 displayEffect.x += Rand.Range(-.2f, .2f);
                                 displayEffect.z += Rand.Range(-.2f, .2f);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_LightBarrier, displayEffect, this.Map, .4f, .2f, .05f, .2f, 0, 0, 0, 0);
-                                IntVec3 targetVec = Traverse.Create(root: proj).Field(name: "destination").GetValue<Vector3>().ToIntVec3();
+                                IntVec3 targetVec = Traverse.Create(root: projectile).Field(name: "destination").GetValue<Vector3>().ToIntVec3();
                                 float targetRange = (this.Position - targetVec).LengthHorizontal;
-                                LocalTargetInfo initialTarget = proj.intendedTarget;
+                                LocalTargetInfo initialTarget = projectile.intendedTarget;
                                 targetVec.x += Mathf.RoundToInt(Rand.Range(-eMissVar, eMissVar) * targetRange);
                                 targetVec.z += Mathf.RoundToInt(Rand.Range(-eMissVar, eMissVar) * targetRange);
-                                TM_CopyAndLaunchProjectile.CopyAndLaunchThingFromPosition(proj.def, proj.Launcher, wallPositions[k], this.Map, targetVec, intendedTarget, ProjectileHitFlags.All, null);
-                                proj.Destroy(DestroyMode.Vanish);
-                                this.wallEnergy -= proj.def.projectile.GetDamageAmount(1f);
+                                TM_CopyAndLaunchProjectile.CopyAndLaunchThingFromPosition(projectile.def, projectile.Launcher, wallPositions[k], this.Map, targetVec, intendedTarget, ProjectileHitFlags.All, null);
+                                projectile.Destroy(DestroyMode.Vanish);
+                                this.wallEnergy -= projectile.def.projectile.GetDamageAmount(1f);
                             }
                             else
                             {
@@ -194,13 +193,13 @@ namespace TorannMagic
                                 displayEffect.x += Rand.Range(-.2f, .2f);
                                 displayEffect.z += Rand.Range(-.2f, .2f);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_LightBarrier, displayEffect, this.Map, .4f, .2f, .05f, .2f, 0, 0, 0, 0);
-                                IntVec3 targetCell = proj.intendedTarget.Cell;
+                                IntVec3 targetCell = projectile.intendedTarget.Cell;
                                 float targetRange = (this.Position - targetCell).LengthHorizontal;
-                                LocalTargetInfo initialTarget = proj.intendedTarget;
+                                LocalTargetInfo initialTarget = projectile.intendedTarget;
                                 targetCell.x += Mathf.RoundToInt(Rand.Range(-fMissVar, fMissVar) * targetRange);
                                 targetCell.z += Mathf.RoundToInt(Rand.Range(-fMissVar, fMissVar) * targetRange);
-                                TM_CopyAndLaunchProjectile.CopyAndLaunchThingFromPosition(proj.def, proj.Launcher, wallPositions[k], this.Map, targetCell, initialTarget, ProjectileHitFlags.All);
-                                this.wallEnergy -= proj.def.projectile.GetDamageAmount(1f);
+                                TM_CopyAndLaunchProjectile.CopyAndLaunchThingFromPosition(projectile.def, projectile.Launcher, wallPositions[k], this.Map, targetCell, initialTarget, ProjectileHitFlags.All);
+                                this.wallEnergy -= projectile.def.projectile.GetDamageAmount(1f);
                             }
                         }
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Repulsion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Repulsion.cs
@@ -100,14 +100,14 @@ namespace TorannMagic
                     curCell = cellList[i];
                     Vector3 angle = GetVector(base.Position, curCell);
                     TM_MoteMaker.ThrowArcaneWaveMote(curCell.ToVector3(), this.Map, .3f * (curCell - base.Position).LengthHorizontal, .1f, .05f, .3f, 0, 3, (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat(), (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat());
-                    if (curCell.IsValid && curCell.InBounds(this.Map))
+                    if (curCell.IsValid && curCell.InBoundsWithNullCheck(this.Map))
                     {
                         victim = curCell.GetFirstPawn(this.Map);
                         if (victim != null && !victim.Dead)
                         {
                             Vector3 launchVector = GetVector(base.Position, victim.Position);
                             IntVec3 projectedPosition = victim.Position + (force * launchVector).ToIntVec3();
-                            if (projectedPosition.IsValid && projectedPosition.InBounds(this.Map))
+                            if (projectedPosition.IsValid && projectedPosition.InBoundsWithNullCheck(this.Map))
                             {
                                 if (Rand.Chance(TM_Calc.GetSpellSuccessChance(pawn, victim, true)))
                                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
@@ -64,12 +64,11 @@ namespace TorannMagic
 
             if (!this.initialized)
             {
-                if (this.launcher is Pawn)
+                if (this.launcher is Pawn casterPawn)
                 {
-                    caster = this.launcher as Pawn;
-                    CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-                    MagicPowerSkill ver = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_ver");
-                    MagicPowerSkill pwr = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_eff");
+                    CompAbilityUserMagic comp = casterPawn.GetComp<CompAbilityUserMagic>();
+                    MagicPowerSkill ver = casterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_ver");
+                    MagicPowerSkill pwr = casterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_eff");
                     verVal = ver.level;
                     pwrVal = pwr.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
@@ -79,7 +79,7 @@ namespace TorannMagic
 
                 this.CheckSpawnSustainer();
 
-                if (curCell.InBounds(map))
+                if (curCell.InBoundsWithNullCheck(map))
                 {
                     Corpse corpse = null;
                     List<Thing> thingList;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Scorn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Scorn.cs
@@ -183,7 +183,7 @@ namespace TorannMagic
                         for (int j = 0; j < targets.Count(); j++)
                         {
                             IntVec3 curCell = targets[j];
-                            if (this.map != null && curCell.IsValid && curCell.InBounds(this.map))
+                            if (this.map != null && curCell.IsValid && curCell.InBoundsWithNullCheck(this.map))
                             {
                                 GenExplosion.DoExplosion(curCell, this.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.pawn, (int)((this.def.projectile.GetDamageAmount(1, null) * (1 + .15 * pwrVal)) * this.arcaneDmg * Rand.Range(.75f, 1.25f)), 0, TorannMagicDefOf.TM_SoftExplosion, def, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
@@ -102,7 +102,7 @@ namespace TorannMagic
                 {
                     tmpPos.z++;
                 }
-                if(tmpPos.IsValid && tmpPos.InBounds(map) && tmpPos.Walkable(map))
+                if(tmpPos.IsValid && tmpPos.InBoundsWithNullCheck(map) && tmpPos.Walkable(map))
                 {
                     targetPos = tmpPos;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
@@ -83,18 +83,17 @@ namespace TorannMagic
             this.startPos = caster.Position;
             IntVec3 targetPos = target.Position;
             IntVec3 tmpPos = targetPos;
-            if(!target.DestroyedOrNull() && target is Pawn)
+            if(!target.DestroyedOrNull() && target is Pawn pawn)
             {
-                Pawn p = target as Pawn;
-                if(p.Rotation == Rot4.East)
+                if(pawn.Rotation == Rot4.East)
                 {
                     tmpPos.x--;
                 }
-                else if(p.Rotation == Rot4.West)
+                else if(pawn.Rotation == Rot4.West)
                 {
                     tmpPos.x++;
                 }
-                else if(p.Rotation == Rot4.North)
+                else if(pawn.Rotation == Rot4.North)
                 {
                     tmpPos.z--;
                 }
@@ -142,10 +141,9 @@ namespace TorannMagic
 
         public void DoStrike(Thing target)
         {
-            if (target != null && target is Pawn)
+            if (target != null && target is Pawn targetPawn)
             {
-                Pawn t = target as Pawn;
-                if (t.Faction == null || (t.Faction != null && t.Faction != caster.Faction))
+                if (targetPawn.Faction == null || (targetPawn.Faction != null && targetPawn.Faction != caster.Faction))
                 {
                     //List<BodyPartRecord> partList = new List<BodyPartRecord>();
                     //partList.Clear();
@@ -159,26 +157,26 @@ namespace TorannMagic
                     //}
                     for (int i = 0; i < 4; i++)
                     {
-                        if (!t.DestroyedOrNull() && !t.Dead && t.Map != null)
+                        if (!targetPawn.DestroyedOrNull() && !targetPawn.Dead && targetPawn.Map != null)
                         {
                             int dmg = Mathf.RoundToInt(this.weaponDamage);
                             if (Rand.Chance(critChance))
                             {
                                 dmg *= 3;
                             }
-                            BodyPartRecord bpr = t.health.hediffSet.GetRandomNotMissingPart(DamageDefOf.Stab, BodyPartHeight.Undefined, BodyPartDepth.Outside);
-                            TM_Action.DamageEntities(target, bpr, dmg, Rand.Range(0f, .5f), DamageDefOf.Stab, this.caster);
-                            Vector3 rndPos = t.DrawPos;
+                            BodyPartRecord bpr = targetPawn.health.hediffSet.GetRandomNotMissingPart(DamageDefOf.Stab, BodyPartHeight.Undefined, BodyPartDepth.Outside);
+                            TM_Action.DamageEntities(targetPawn, bpr, dmg, Rand.Range(0f, .5f), DamageDefOf.Stab, this.caster);
+                            Vector3 rndPos = targetPawn.DrawPos;
                             rndPos.x += Rand.Range(-.2f, .2f);
                             rndPos.z += Rand.Range(-.2f, .2f);
-                            TM_MoteMaker.ThrowBloodSquirt(rndPos, t.Map, Rand.Range(.6f, 1f));
-                            TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_CrossStrike, rndPos, t.Map, Rand.Range(.6f, 1f), .4f, 0f, Rand.Range(.2f, .5f), 0, 0, 0, Rand.Range(0, 360));
+                            TM_MoteMaker.ThrowBloodSquirt(rndPos, targetPawn.Map, Rand.Range(.6f, 1f));
+                            TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_CrossStrike, rndPos, targetPawn.Map, Rand.Range(.6f, 1f), .4f, 0f, Rand.Range(.2f, .5f), 0, 0, 0, Rand.Range(0, 360));
                         }
                     }
-                    if (!t.DestroyedOrNull() && !t.Dead && !t.Downed && caster.IsColonist)
+                    if (!targetPawn.DestroyedOrNull() && !targetPawn.Dead && !targetPawn.Downed && caster.IsColonist)
                     {
                         caster.drafter.Drafted = true;
-                        Job job = new Job(JobDefOf.AttackMelee, t);
+                        Job job = new Job(JobDefOf.AttackMelee, targetPawn);
                         caster.jobs.TryTakeOrderedJob(job, JobTag.DraftedOrder);
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Snowball.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Snowball.cs
@@ -98,7 +98,7 @@ namespace TorannMagic
 			for (int i = 0; i < num; i++)
 			{
 				IntVec3 intVec = center + GenRadial.RadialPattern[i];
-				if (intVec.InBounds(map))
+				if (intVec.InBoundsWithNullCheck(map))
 				{
 					float lengthHorizontal = (center - intVec).LengthHorizontal;
 					float num2 = 1f - lengthHorizontal / radius;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spinning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spinning.cs
@@ -18,9 +18,8 @@ namespace TorannMagic
         public override void Tick()
         {
             base.Tick();
-            if(Find.TickManager.TicksGame % 2 == 0 && daggerCount > 0 && this.launcher != null && this.launcher is Pawn)
+            if(Find.TickManager.TicksGame % 2 == 0 && daggerCount > 0 && this.launcher is Pawn caster)
             {
-                Pawn caster = this.launcher as Pawn;
                 CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
                 if(comp != null)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spite.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spite.cs
@@ -40,9 +40,9 @@ namespace TorannMagic
                 verVal = 3;
             }
 
-            if(victim == null && this.intendedTarget != null && this.intendedTarget.Thing != null && this.intendedTarget.Thing is Pawn)
+            if(victim == null && this.intendedTarget != null && this.intendedTarget.Thing is Pawn intendedPawn)
             {
-                victim = this.intendedTarget.Thing as Pawn;
+                victim = intendedPawn;
             }
             
             if (victim != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonPoppi.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonPoppi.cs
@@ -59,7 +59,7 @@ namespace TorannMagic
                 for (int i = 0; i < 4 + pwrVal; i++)
                 {
                     centerCell = cellRect.RandomCell;
-                    if (centerCell.IsValid && centerCell.InBounds(pawn.Map) && centerCell.Standable(pawn.Map) && !centerCell.Fogged(pawn.Map))
+                    if (centerCell.IsValid && centerCell.InBoundsWithNullCheck(pawn.Map) && centerCell.Standable(pawn.Map) && !centerCell.Fogged(pawn.Map))
                     {
                         spawnThing.factionDef = TorannMagicDefOf.TM_ElementalFaction;
                         spawnThing.spawnCount = 1;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_TempestStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_TempestStrike.cs
@@ -46,9 +46,8 @@ namespace TorannMagic
         {
             if (spinCheck)
             {
-                if (this.launcher is Pawn)
+                if (this.launcher is Pawn pawn)
                 {
-                    Pawn pawn = this.launcher as Pawn;
                     if (pawn.equipment != null && pawn.equipment.Primary != null)
                     {
                         ThingWithComps weaponComp = pawn.equipment.Primary;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ThunderStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ThunderStrike.cs
@@ -100,12 +100,12 @@ namespace TorannMagic
             if (directionOffset != default(Vector3))
             {
                 currentPos = (this.origin + directionOffset).ToIntVec3();
-                if (currentPos != default(IntVec3) && currentPos.IsValid && currentPos.InBounds(base.Map) && currentPos.Walkable(base.Map) && currentPos.DistanceToEdge(base.Map) > 3)
+                if (currentPos != default(IntVec3) && currentPos.IsValid && currentPos.InBoundsWithNullCheck(base.Map) && currentPos.Walkable(base.Map) && currentPos.DistanceToEdge(base.Map) > 3)
                 {
                     CellRect cellRect = CellRect.CenteredOn(currentPos, 1);
                     //cellRect.ClipInsideMap(base.Map);
                     IntVec3 rndCell = cellRect.RandomCell;
-                    if (rndCell != null && rndCell != default(IntVec3) && rndCell.IsValid && rndCell.InBounds(base.Map) && rndCell.Walkable(base.Map) && rndCell.DistanceToEdge(base.Map) > 3)
+                    if (rndCell != null && rndCell != default(IntVec3) && rndCell.IsValid && rndCell.InBoundsWithNullCheck(base.Map) && rndCell.Walkable(base.Map) && rndCell.DistanceToEdge(base.Map) > 3)
                     {
                         Map.weatherManager.eventHandler.AddEvent(new TM_WeatherEvent_MeshFlash(base.Map, rndCell, TM_MatPool.chiLightning, TMDamageDefOf.DamageDefOf.TM_ChiBurn, this.launcher, Mathf.RoundToInt(Rand.Range(8, 14) * (1 +(.12f * pwrVal)) * this.arcaneDmg), Rand.Range(1.5f, 2f)));
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_WetGround.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_WetGround.cs
@@ -28,7 +28,7 @@ namespace TorannMagic
             for (int i = 0; i < cells.Count(); i++)
             {
                 curCell = cells.ToArray<IntVec3>()[i];                
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     terrain = curCell.GetTerrain(map);
                     if (terrain.defName == "Sand" || terrain.defName == "Gravel")

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,8 +134,8 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
-    <Compile Include="SimpleCache.cs" />
     <Compile Include="TraitIconMap.cs" />
+    <Compile Include="Utils\SimpleCache.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />
     <Compile Include="TMDefs\TM_Branding.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -132,8 +132,10 @@
     <Compile Include="Building_TMTotem_Healing.cs" />
     <Compile Include="Building_TMTotem_Lightning.cs" />
     <Compile Include="Building_TM_DMP.cs" />
+    <Compile Include="CompAbilityUserExtensions.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
+    <Compile Include="Power.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />
     <Compile Include="TMDefs\TM_Branding.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -377,6 +377,7 @@
     <Compile Include="FlyingObject_TimeDelay.cs" />
     <Compile Include="FlyingObject_ValiantCharge.cs" />
     <Compile Include="FlyingObject_Whirlwind.cs" />
+    <Compile Include="GenGridExtensions.cs" />
     <Compile Include="Gizmo_EnergyStatus.cs" />
     <Compile Include="Gizmo_StatusBar.cs" />
     <Compile Include="HarmonyPatches.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
+    <Compile Include="TraitIconMap.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />
     <Compile Include="TMDefs\TM_Branding.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
+    <Compile Include="SimpleCache.cs" />
     <Compile Include="TraitIconMap.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/SimpleCache.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/SimpleCache.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace TorannMagic
+{
+    public class SimpleCache<TKey, TValue>
+    {
+        private class CacheValue<T>
+        {
+            public readonly T Value;
+            public readonly DateTime Timeout;
+            public CacheValue(T value, double secondsToTimeout)
+            {
+                Value = value;
+                Timeout = DateTime.UtcNow.AddSeconds(secondsToTimeout);
+            }
+        }
+
+        private readonly Dictionary<TKey, CacheValue<TValue>> cache;
+        private DateTime nextFlush;
+        private readonly double minutesUntilFlush;
+
+        public SimpleCache(double minutesUntilFlush)
+        {
+            cache = new Dictionary<TKey, CacheValue<TValue>>();
+            nextFlush = DateTime.UtcNow.AddMinutes(minutesUntilFlush);
+            this.minutesUntilFlush = minutesUntilFlush;
+        }
+
+        public TValue GetOrCreate(TKey key, Func<TValue> valueGetter, double secondsToTimeout)
+        {
+            if (cache.ContainsKey(key) && cache[key].Timeout > DateTime.UtcNow)
+            {
+                return cache[key].Value;
+            }
+
+            if (DateTime.UtcNow > nextFlush)
+            {
+                DateTime now = DateTime.UtcNow;
+                var itemsToRemove = cache.Where(kv => now > kv.Value.Timeout).ToList();
+                foreach (var item in itemsToRemove)
+                {
+                    cache.Remove(item.Key);
+                }
+                
+                nextFlush = DateTime.UtcNow.AddMinutes(minutesUntilFlush);
+            }
+            cache[key] = new CacheValue<TValue>(valueGetter(), secondsToTimeout);
+            return cache[key].Value;
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/StatPart_Undead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/StatPart_Undead.cs
@@ -13,10 +13,9 @@ namespace TorannMagic
 
         public override void TransformValue(StatRequest req, ref float val)
         {
-            if (req.HasThing && req.Thing is Pawn)
+            if (req.HasThing && req.Thing is Pawn reqPawn)
             {
-                Pawn reqPawn = req.Thing as Pawn;
-                if (reqPawn != null && TM_Calc.IsUndeadNotVamp(reqPawn))
+                if (TM_Calc.IsUndeadNotVamp(reqPawn))
                 {
                     val *= 0f;
                 }
@@ -25,10 +24,9 @@ namespace TorannMagic
 
         public override string ExplanationPart(StatRequest req)
         {
-            if (req.HasThing && req.Thing is Pawn)
+            if (req.HasThing && req.Thing is Pawn reqPawn)
             {
-                Pawn reqPawn = req.Thing as Pawn;
-                if (reqPawn != null && TM_Calc.IsUndeadNotVamp(reqPawn))
+                if (TM_Calc.IsUndeadNotVamp(reqPawn))
                 {
                     return "TM_StatsReport_Undead".Translate();
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/TMDefs/TM_Autocast.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMDefs/TM_Autocast.cs
@@ -194,13 +194,12 @@ namespace TorannMagic.TMDefs
         //Advanced condition cases
         private bool DamageTaken(TM_AutocastCondition con, Thing t)
         {
-            if (t is Pawn)
+            if (t is Pawn pawn)
             {
-                Pawn p = t as Pawn;
-                if (p != null && p.health != null && p.health.hediffSet != null)
+                if (pawn.health != null && pawn.health.hediffSet != null)
                 {
                     //Log.Message("pawn injured? " + TM_Calc.IsPawnInjured(p, con.valueA) + " invert is " + con.invert);
-                    return (con.invert ? !TM_Calc.IsPawnInjured(p, con.valueA) : TM_Calc.IsPawnInjured(p, con.valueA));
+                    return (con.invert ? !TM_Calc.IsPawnInjured(pawn, con.valueA) : TM_Calc.IsPawnInjured(pawn, con.valueA));
                 }
             }
             return false;

--- a/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilitySelf.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilitySelf.cs
@@ -27,9 +27,8 @@ namespace TorannMagic
             //{
             Find.Targeter.targetingSource = verb;
             //}
-            if (this.verb.Ability.Def is TMAbilityDef)
+            if (this.verb.Ability.Def is TMAbilityDef tmAbility)
             {
-                TMAbilityDef tmAbility = (TMAbilityDef)(this.verb.Ability.Def);
                 CompAbilityUserMight compMight = this.pawn.TryGetComp<CompAbilityUserMight>();
                 CompAbilityUserMagic compMagic = this.pawn.TryGetComp<CompAbilityUserMagic>();
                 if (tmAbility.manaCost > 0 && pawn.story != null && pawn.story.traits != null && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))

--- a/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
@@ -43,11 +43,10 @@ namespace TorannMagic
                 targetPawn = TargetThingA as Pawn;
             }
 
-            cooldownFlag = this.verb.Ability.CooldownTicksLeft > 0 ? true : false;
+            cooldownFlag = this.verb.Ability.CooldownTicksLeft > 0;
 
-            if(this.verb.Ability.Def is TMAbilityDef)
+            if(this.verb.Ability.Def is TMAbilityDef tmAbilityDef)
             { 
-                TMAbilityDef tmAbility = (TMAbilityDef)(this.verb.Ability.Def);
                 CompAbilityUserMight compMight = this.pawn.TryGetComp<CompAbilityUserMight>();
                 CompAbilityUserMagic compMagic = this.pawn.TryGetComp<CompAbilityUserMagic>();
                 //if (compMagic != null)
@@ -58,13 +57,13 @@ namespace TorannMagic
                 //{
                 //    //compMight.AIAbilityJob = null;
                 //}
-                if (tmAbility.manaCost > 0 && pawn.story != null && pawn.story.traits != null && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
+                if (tmAbilityDef.manaCost > 0 && pawn.story != null && pawn.story.traits != null && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
                     if(this.pawn.Map.gameConditionManager.ConditionIsActive(TorannMagicDefOf.TM_ManaStorm))
                     {
                         //DamageInfo dinfo2;
                         //BodyPartRecord vitalPart = null;
-                        int amt = Mathf.RoundToInt(compMagic.ActualManaCost(tmAbility) * 100f);
+                        int amt = Mathf.RoundToInt(compMagic.ActualManaCost(tmAbilityDef) * 100f);
                         //IEnumerable<BodyPartRecord> partSearch = pawn.def.race.body.AllParts;
                         //vitalPart = partSearch.FirstOrDefault<BodyPartRecord>((BodyPartRecord x) => x.def.tags.Contains(BodyPartTagDefOf.ConsciousnessSource));
                         //dinfo2 = new DamageInfo(TMDamageDefOf.DamageDefOf.TM_Arcane, amt, 10, 0, pawn as Thing, vitalPart, null, DamageInfo.SourceCategory.ThingOrUnknown);
@@ -77,7 +76,7 @@ namespace TorannMagic
                     }
                     if (compMagic != null && compMagic.Mana != null)
                     {
-                        if (compMagic.ActualManaCost(tmAbility) > compMagic.Mana.CurLevel)
+                        if (compMagic.ActualManaCost(tmAbilityDef) > compMagic.Mana.CurLevel)
                         {
                             energyFlag = true;
                         }
@@ -87,11 +86,11 @@ namespace TorannMagic
                         energyFlag = true;
                     }
                 }
-                if (tmAbility.staminaCost > 0)
+                if (tmAbilityDef.staminaCost > 0)
                 {
                     if (compMight != null && compMight.Stamina != null)
                     {
-                        if (compMight.ActualStaminaCost(tmAbility) > compMight.Stamina.CurLevel)
+                        if (compMight.ActualStaminaCost(tmAbilityDef) > compMight.Stamina.CurLevel)
                         {
                             energyFlag = true;
                         }
@@ -206,10 +205,9 @@ namespace TorannMagic
                         //bool inRange = (pawn.Position - TargetLocA).LengthHorizontal < verb.verbProps.range;
                         //if (inRange && validTarg)
                         //{
-                        if (verb != null && verb.Ability != null && verb.Ability.Def is TMAbilityDef)
-                        { 
-                            TMAbilityDef tmad = (TMAbilityDef)(verb.Ability.Def);
-                            if (tmad != null && tmad.relationsAdjustment != 0 && targetPawn.Faction != null && targetPawn.Faction != this.pawn.Faction && !targetPawn.Faction.HostileTo(this.pawn.Faction))
+                        if (verb != null && verb.Ability != null && verb.Ability.Def is TMAbilityDef tmad)
+                        {
+                            if (tmad.relationsAdjustment != 0 && targetPawn.Faction != null && targetPawn.Faction != this.pawn.Faction && !targetPawn.Faction.HostileTo(this.pawn.Faction))
                             {
                                 targetPawn.Faction.TryAffectGoodwillWith(this.pawn.Faction, tmad.relationsAdjustment, true, false, TorannMagicDefOf.TM_OffensiveMagic, null);
                             }

--- a/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
@@ -249,7 +249,7 @@ namespace TorannMagic
             {                
                 if (verb != null && verb.verbProps != null && (pawn.Position - TargetLocA).LengthHorizontal < verb.verbProps.range)
                 {
-                    if (TargetLocA.IsValid && TargetLocA.InBounds(pawn.Map) && !TargetLocA.Fogged(pawn.Map))  //&& TargetLocA.Walkable(pawn.Map)
+                    if (TargetLocA.IsValid && TargetLocA.InBoundsWithNullCheck(pawn.Map) && !TargetLocA.Fogged(pawn.Map))  //&& TargetLocA.Walkable(pawn.Map)
                     {
                         ShootLine shootLine;
                         bool validTarg = verb.TryFindShootLineFromTo(pawn.Position, TargetLocA, out shootLine);

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
@@ -1596,7 +1596,7 @@ namespace TorannMagic
                         cellList = GenRadial.RadialCellsAround(p.Position, 6, true).ToList();
                         for (int i = 0; i < cellList.Count; i++)
                         {
-                            if (cellList[i].IsValid && cellList[i].InBounds(p.Map))
+                            if (cellList[i].IsValid && cellList[i].InBoundsWithNullCheck(p.Map))
                             {
                                 List<Thing> thingList = cellList[i].GetThingList(p.Map);
                                 if (thingList != null && thingList.Count > 0)
@@ -2140,7 +2140,7 @@ namespace TorannMagic
                     for (int i = 0; i < targets.Count; i++)
                     {
                         curCell = targets.ToArray<IntVec3>()[i];
-                        if (curCell.InBounds(map) && curCell.IsValid)
+                        if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                         {
                             victim = curCell.GetFirstPawn(map);
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
@@ -78,9 +78,8 @@ namespace TorannMagic
         {
             Thing instigator = dinfo.Instigator;
 
-            if (instigator is Pawn)
+            if (instigator is Pawn meleePawn)
             {
-                Pawn meleePawn = instigator as Pawn;
                 if ((dinfo.Weapon != null && dinfo.Weapon.IsMeleeWeapon) || dinfo.WeaponBodyPartGroup != null)
                 {
                     DamageInfo dinfo2 = new DamageInfo(dinfo.Def, dinfo.Amount, dinfo.ArmorPenetrationInt, dinfo.Angle, reflectingPawn, null, null, DamageInfo.SourceCategory.ThingOrUnknown, meleePawn);
@@ -93,17 +92,15 @@ namespace TorannMagic
         {
             Thing instigator = dinfo.Instigator;
 
-            if (instigator is Pawn)
+            if (instigator is Pawn shooterPawn)
             {
-                Pawn shooterPawn = instigator as Pawn;
                 if (dinfo.Weapon != null && !dinfo.Weapon.IsMeleeWeapon && dinfo.WeaponBodyPartGroup == null)
                 {
                     TM_CopyAndLaunchProjectile.CopyAndLaunchThing(shooterPawn.equipment.PrimaryEq.PrimaryVerb.verbProps.defaultProjectile, reflectingPawn, instigator, shooterPawn, ProjectileHitFlags.All, null);
                 }
             }
-            if (instigator is Building)
+            if (instigator is Building turret)
             {
-                Building turret = instigator as Building;
                 ThingDef projectile = null;
 
                 if (turret.def.building.turretGunDef != null)
@@ -131,9 +128,8 @@ namespace TorannMagic
         {
             Thing instigator = dinfo.Instigator;
 
-            if (instigator is Pawn)
+            if (instigator is Pawn shooterPawn)
             {
-                Pawn shooterPawn = instigator as Pawn;
                 if (dinfo.Weapon != null && !dinfo.Weapon.IsMeleeWeapon && dinfo.WeaponBodyPartGroup == null)
                 {
                     Pawn randomTarget = null;
@@ -144,9 +140,8 @@ namespace TorannMagic
                     }
                 }
             }
-            if (instigator is Building)
+            if (instigator is Building turret)
             {
-                Building turret = instigator as Building;
                 ThingDef projectile = null;
 
                 if (turret.def.building.turretGunDef != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -1884,7 +1884,7 @@ namespace TorannMagic
                 IntVec3 tmp = currentPos;
                 tmp.x += (Rand.Range(-radius, radius));
                 tmp.z += Rand.Range(-radius, radius);
-                if (tmp.InBounds(pawn.Map) && tmp.IsValid && tmp.Walkable(pawn.Map) && tmp.DistanceToEdge(pawn.Map) > 8)
+                if (tmp.InBoundsWithNullCheck(pawn.Map) && tmp.IsValid && tmp.Walkable(pawn.Map) && tmp.DistanceToEdge(pawn.Map) > 8)
                 {
                     List<Pawn> threatCount = TM_Calc.FindPawnsNearTarget(pawn, 4, tmp, true);
                     if (threatCount != null)
@@ -1918,7 +1918,7 @@ namespace TorannMagic
             for (int k = 0; k < outerCells.Count; k++)
             {
                 IntVec3 wall = outerCells[k];
-                if (wall.IsValid && wall.InBounds(map) && !wall.Fogged(map) && wall.Standable(map) && (!wall.Roofed(map) || allowRoofed))
+                if (wall.IsValid && wall.InBoundsWithNullCheck(map) && !wall.Fogged(map) && wall.Standable(map) && (!wall.Roofed(map) || allowRoofed))
                 {
                     List<Thing> cellList = new List<Thing>();
                     try
@@ -4264,7 +4264,7 @@ namespace TorannMagic
             List<IntVec3> cellList = GenAdjFast.AdjacentCells8Way(cell);
             for (int i = 0; i < cellList.Count; i++)
             {
-                if (cellList[i] != default(IntVec3) && cellList[i].InBounds(map) && cellList[i].Walkable(map) && !cellList[i].Fogged(map))
+                if (cellList[i] != default(IntVec3) && cellList[i].InBoundsWithNullCheck(map) && cellList[i].Walkable(map) && !cellList[i].Fogged(map))
                 {
                     cell = cellList[i];
                     break;
@@ -4278,7 +4278,7 @@ namespace TorannMagic
             List<IntVec3> cellList = GenRadial.RadialCellsAround(cell, range, true).InRandomOrder().ToList();
             for (int i = 0; i < cellList.Count; i++)
             {
-                if (cellList[i] != default(IntVec3) && cellList[i].InBounds(map) && !cellList[i].Fogged(map))
+                if (cellList[i] != default(IntVec3) && cellList[i].InBoundsWithNullCheck(map) && !cellList[i].Fogged(map))
                 {
                     cell = cellList[i];
                     break;
@@ -4577,7 +4577,7 @@ namespace TorannMagic
         {
             //Determines if a cell has a wall built on it
             Building wall = null;
-            if (cell != default(IntVec3) && cell.InBounds(map))
+            if (cell != default(IntVec3) && cell.InBoundsWithNullCheck(map))
             {
                 List<Thing> tList = cell.GetThingList(map);
                 if(tList != null && tList.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -249,12 +249,11 @@ namespace TorannMagic
 
         public static bool IsWall(Thing t)
         {
-            if(t != null && t is Building)
+            if(t is Building building)
             {
-                Building b = t as Building;
-                if (b.def.passability == Traversability.Impassable && b.def.holdsRoof)
+                if (building.def.passability == Traversability.Impassable && building.def.holdsRoof)
                 {
-                    if (t.def.defName.ToLower().Contains("wall") || (t.def.label.ToLower().Contains("wall")))
+                    if (building.def.defName.ToLower().Contains("wall") || (building.def.label.ToLower().Contains("wall")))
                     {
                         return true;
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -2270,9 +2270,9 @@ namespace TorannMagic
             }
             else if (pawn.ParentHolder.ToString().Contains("Caravan"))
             {
-                foreach (Pawn current in pawn.holdingOwner)
+                foreach (Thing currentThing in pawn.holdingOwner)
                 {
-                    if (current != null)
+                    if (currentThing is Pawn current)
                     {
                         if (current.RaceProps.Humanlike && current.Faction == pawn.Faction && current.apparel != null && current.apparel.WornApparelCount > 0)
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_MatPool.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_MatPool.cs
@@ -79,6 +79,9 @@ namespace TorannMagic
         public static readonly Texture2D wandererIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/wandererFlame", true);
         public static readonly Texture2D wayfarerIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/wayfarerFlame", true);
 
+        public static readonly Texture2D DefaultCustomMageIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomMageMark", true);
+        public static readonly Texture2D DefaultCustomFighterIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomFighterMark", true);
+
 
         //skeleton chain
         public static readonly Material circleChain = MaterialPool.MatFrom("PawnKind/skeleton_chain_circle", ShaderDatabase.MoteGlow);

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using RimWorld;
+using UnityEngine;
+
+namespace TorannMagic
+{
+    public static class TraitIconMap
+    {
+        // Data for ColonistBarColonistDrawer_Patch
+        private const string MageIcon = "TM_Icon_Mage";  // Use same strings in tuples for less memory usage
+        private const string FighterIcon = "TM_Icon_Fighter";
+        // Class to hold Values for below dictionary
+        public class TraitIconValue
+        {
+            public readonly Texture2D IconMaterial;
+            public readonly string IconType;
+
+            public TraitIconValue(Texture2D iconMaterial, string iconType)
+            {
+                IconMaterial = iconMaterial;
+                IconType = iconType;
+            }
+        }
+        // Dictionary that maps TraitDef to their appropriate Icon material and Icon type
+        // TODO: dynamically add custom classes on load to allow for easier checks
+        private static readonly Dictionary<TraitDef, TraitIconValue> TraitIconMapping = new Dictionary<TraitDef, TraitIconValue>()
+        {
+            { TorannMagicDefOf.InnerFire, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
+            { TorannMagicDefOf.HeartOfFrost, new TraitIconValue(TM_MatPool.iceIcon, MageIcon) },
+            { TorannMagicDefOf.StormBorn, new TraitIconValue(TM_MatPool.lightningIcon, MageIcon) },
+            { TorannMagicDefOf.Arcanist, new TraitIconValue(TM_MatPool.arcanistIcon, MageIcon) },
+            { TorannMagicDefOf.Paladin, new TraitIconValue(TM_MatPool.paladinIcon, MageIcon) },
+            { TorannMagicDefOf.Summoner, new TraitIconValue(TM_MatPool.summonerIcon, MageIcon) },
+            { TorannMagicDefOf.Druid, new TraitIconValue(TM_MatPool.druidIcon, MageIcon) },
+            { TorannMagicDefOf.Necromancer, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.Lich, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Bard, new TraitIconValue(TM_MatPool.bardIcon, MageIcon) },
+            { TorannMagicDefOf.Succubus, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Warlock, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Geomancer, new TraitIconValue(TM_MatPool.earthIcon, MageIcon) },
+            { TorannMagicDefOf.Technomancer, new TraitIconValue(TM_MatPool.technoIcon, MageIcon) },
+            { TorannMagicDefOf.BloodMage, new TraitIconValue(TM_MatPool.bloodmageIcon, MageIcon) },
+            { TorannMagicDefOf.Enchanter, new TraitIconValue(TM_MatPool.enchanterIcon, MageIcon) },
+            { TorannMagicDefOf.Chronomancer, new TraitIconValue(TM_MatPool.chronoIcon, MageIcon) },
+            { TorannMagicDefOf.Gladiator, new TraitIconValue(TM_MatPool.gladiatorIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Sniper, new TraitIconValue(TM_MatPool.sniperIcon, FighterIcon) },
+            { TorannMagicDefOf.Bladedancer, new TraitIconValue(TM_MatPool.bladedancerIcon, FighterIcon) },
+            { TorannMagicDefOf.Ranger, new TraitIconValue(TM_MatPool.rangerIcon, FighterIcon) },
+            { TorannMagicDefOf.Faceless, new TraitIconValue(TM_MatPool.facelessIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Psionic, new TraitIconValue(TM_MatPool.psiIcon, FighterIcon) },
+            { TorannMagicDefOf.DeathKnight, new TraitIconValue(TM_MatPool.deathknightIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Monk, new TraitIconValue(TM_MatPool.monkIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Wanderer, new TraitIconValue(TM_MatPool.wandererIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Wayfarer, new TraitIconValue(TM_MatPool.wayfarerIcon, FighterIcon) },
+            { TorannMagicDefOf.ChaosMage, new TraitIconValue(TM_MatPool.chaosIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Commander, new TraitIconValue(TM_MatPool.commanderIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_SuperSoldier, new TraitIconValue(TM_MatPool.SSIcon, FighterIcon) }
+        };
+
+        public static TraitIconValue Get(TraitDef traitDef)
+        {
+            return TraitIconMapping[traitDef];
+        }
+
+        public static bool ContainsKey(TraitDef traitDef)
+        {
+            return TraitIconMapping.ContainsKey(traitDef);
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -7,7 +7,7 @@ namespace TorannMagic
     public static class TraitIconMap
     {
         // Data for ColonistBarColonistDrawer_Patch
-        private const string MageIcon = "TM_Icon_Mage";  // Use same strings in tuples for less memory usage
+        private const string MageIcon = "TM_Icon_Mage";
         private const string FighterIcon = "TM_Icon_Fighter";
         // Class to hold Values for below dictionary
         public class TraitIconValue

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -21,8 +21,8 @@ namespace TorannMagic
                 IconType = iconType;
             }
         }
-        // Dictionary that maps TraitDef to their appropriate Icon material and Icon type
-        // TODO: dynamically add custom classes on load to allow for easier checks
+        // Dictionary that maps TraitDef to their appropriate Icon material and Icon type. Custom Classes are loaded
+        // via ModOptions.ModClassOptions.InitializeCustomClassActions
         private static readonly Dictionary<TraitDef, TraitIconValue> TraitIconMapping = new Dictionary<TraitDef, TraitIconValue>()
         {
             { TorannMagicDefOf.InnerFire, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
@@ -60,6 +60,11 @@ namespace TorannMagic
         public static TraitIconValue Get(TraitDef traitDef)
         {
             return TraitIconMapping[traitDef];
+        }
+
+        public static void Set(TraitDef traitDef, TraitIconValue traitIconValue)
+        {
+            TraitIconMapping[traitDef] = traitIconValue;
         }
 
         public static bool ContainsKey(TraitDef traitDef)

--- a/RimWorldOfMagic/RimWorldOfMagic/Utils/SimpleCache.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Utils/SimpleCache.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Verse;
 
-namespace TorannMagic
+namespace TorannMagic.Utils
 {
     public class SimpleCache<TKey, TValue>
     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeSpin.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeSpin.cs
@@ -116,7 +116,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBounds(base.CasterPawn.Map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(base.CasterPawn.Map) && curCell.IsValid)
                 {
                     victim = curCell.GetFirstPawn(map);
                 }
@@ -125,12 +125,7 @@ namespace TorannMagic
                 {
                     for (int j = 0; j < 2+pwrVal; j++)
                     {
-                        bool newTarg = false;
                         if (Rand.Chance(.5f + .04f*(pwrVal+verVal)))
-                        {
-                            newTarg = true;
-                        }
-                        if (newTarg)
                         {
                             DrawStrike(center, victim.Position.ToVector3(), map);
                             damageEntities(victim, null, GetWeaponDmg(this.CasterPawn), DamageDefOf.Cut);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodForBlood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodForBlood.cs
@@ -34,9 +34,8 @@ namespace TorannMagic
             }
             this.arcaneDmg = base.CasterPawn.GetComp<CompAbilityUserMagic>().arcaneDmg;
             this.arcaneDmg *= (1 + (.1f * bpwr.level));
-            if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
+            if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn victim)
             {
-                Pawn victim = this.currentTarget.Thing as Pawn;
                 if (victim.RaceProps.BloodDef != null && victim != this.CasterPawn)
                 {
                     for (int i = 0; i < 4; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse.cs
@@ -43,11 +43,9 @@ namespace TorannMagic
             MagicPowerSkill manaRegen = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
 
             Thing undeadThing = this.currentTarget.Thing;
-            if (undeadThing is Pawn)
+            if (undeadThing is Pawn undead)
             {
-                Pawn undead = (Pawn)undeadThing;
-
-                bool flag = undead != null && !undead.Dead;
+                bool flag = !undead.Dead;
                 if (flag)
                 {
                     if (TM_Calc.IsUndead(undead))

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_EarthSprites.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_EarthSprites.cs
@@ -135,7 +135,7 @@ namespace TorannMagic
                 IntVec3 cell = cellList[i];                
                 bldg = cell.GetFirstBuilding(this.CasterPawn.Map);
                 terrain = cell.GetTerrain(this.CasterPawn.Map);
-                if (cell.InBounds(this.CasterPawn.Map) && bldg == null && terrain == terrainDef)
+                if (cell.InBoundsWithNullCheck(this.CasterPawn.Map) && bldg == null && terrain == terrainDef)
                 {
                     this.CasterPawn.Map.terrainGrid.SetTerrain(cell, TerrainDef.Named("Gravel"));
                     FleckMaker.ThrowSmoke(cell.ToVector3Shifted(), this.CasterPawn.Map, Rand.Range(.8f, 1.2f));

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_FoldReality.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_FoldReality.cs
@@ -79,7 +79,7 @@ namespace TorannMagic
                 portalTarget.canTargetFires = false;
                 portalTarget.canTargetBuildings = false;
                 portalTarget.canTargetItems = false;
-                portalTarget.validator = ((TargetInfo x) => x.IsValid && !x.Cell.Fogged(map) && x.Cell.InBounds(map) && x.Cell.Walkable(map));
+                portalTarget.validator = ((TargetInfo x) => x.IsValid && !x.Cell.Fogged(map) && x.Cell.InBoundsWithNullCheck(map) && x.Cell.Walkable(map));
                 Find.Targeter.BeginTargeting(portalTarget, delegate (LocalTargetInfo x)
                 {
 
@@ -142,7 +142,7 @@ namespace TorannMagic
             for (int i = 0; i < targets.Count(); i++)
             {
                 curCell = targets.ToArray<IntVec3>()[i];                
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     List<Thing> thingList = curCell.GetThingList(map);
                     for(int j = 0; j < thingList.Count(); j++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Legion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Legion.cs
@@ -56,21 +56,19 @@ namespace TorannMagic
         {
             bool result = false;
 
-            if (this.currentTarget != null && base.CasterPawn != null && this.currentTarget.Thing is Pawn)
+            if (this.currentTarget != null && base.CasterPawn != null && this.currentTarget.Thing is Pawn targetPawn)
             {
-                Pawn targetPawn = this.currentTarget.Thing as Pawn;
                 if (targetPawn.RaceProps.Humanlike)
                 {
                     CompAbilityUserMight mightPawn = targetPawn.GetComp<CompAbilityUserMight>();
 
-                    TMAbilityDef tempAbility = null;
                     CompAbilityUserMight mightComp = this.CasterPawn.GetComp<CompAbilityUserMight>();
                     
                     if (mightPawn.IsMightUser)
                     {
                         if (!targetPawn.story.traits.HasTrait(TM_Calc.GetMightTrait(this.CasterPawn)))
                         {
-                            tempAbility = TM_Calc.GetCopiedMightAbility(targetPawn, base.CasterPawn);
+                            TMAbilityDef tempAbility = TM_Calc.GetCopiedMightAbility(targetPawn, base.CasterPawn);
 
                             if (tempAbility != null)
                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Mimic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Mimic.cs
@@ -56,9 +56,8 @@ namespace TorannMagic
         {
             bool result = false;
 
-            if (this.currentTarget != null && base.CasterPawn != null && this.currentTarget.Thing is Pawn)
+            if (this.currentTarget != null && base.CasterPawn != null && this.currentTarget.Thing is Pawn targetPawn)
             {
-                Pawn targetPawn = this.currentTarget.Thing as Pawn;
                 if (targetPawn.RaceProps.Humanlike)
                 {
                     CompAbilityUserMagic magicPawn = targetPawn.GetComp<CompAbilityUserMagic>();

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
@@ -175,29 +175,24 @@ namespace TorannMagic
 
         public void SearchForTargets(IntVec3 center, float radius, Map map, Pawn pawn)
         {
-            Pawn victim = null;
-            IntVec3 curCell;            
             IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(center, radius, true);
-            for (int i = 0; i < targets.Count(); i++)
+            foreach (IntVec3 curCell in targets)
             {
-                curCell = targets.ToArray<IntVec3>()[i];
                 FleckMaker.ThrowDustPuff(curCell, map, .2f);
                 if (curCell.InBounds(map) && curCell.IsValid)
                 {
-                    victim = curCell.GetFirstPawn(map);
-                }
-
-                if (victim != null && victim.Faction != pawn.Faction)
-                {
-                    if(Rand.Chance(.1f + .15f*pwrVal))
+                    Pawn victim = curCell.GetFirstPawn(map);
+                    if (victim != null && victim.Faction != pawn.Faction)
                     {
-                        this.dmgNum *= 3;
-                        MoteMaker.ThrowText(victim.DrawPos, victim.Map, "Critical Hit", -1f);
+                        if(Rand.Chance(.1f + .15f*pwrVal))
+                        {
+                            this.dmgNum *= 3;
+                            MoteMaker.ThrowText(victim.DrawPos, victim.Map, "Critical Hit", -1f);
+                        }
+                        DrawStrike(center, victim.Position.ToVector3(), map);
+                        damageEntities(victim, null, this.dmgNum, TMDamageDefOf.DamageDefOf.TM_PhaseStrike);
                     }
-                    DrawStrike(center, victim.Position.ToVector3(), map);
-                    damageEntities(victim, null, this.dmgNum, TMDamageDefOf.DamageDefOf.TM_PhaseStrike);
                 }
-                targets.GetEnumerator().MoveNext();
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
@@ -182,7 +182,7 @@ namespace TorannMagic
             {
                 curCell = targets.ToArray<IntVec3>()[i];
                 FleckMaker.ThrowDustPuff(curCell, map, .2f);
-                if (curCell.InBounds(map) && curCell.IsValid)
+                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                 {
                     victim = curCell.GetFirstPawn(map);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ReverseTime.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ReverseTime.cs
@@ -220,9 +220,8 @@ namespace TorannMagic
         {
 
             thing.HitPoints = Mathf.Clamp(thing.HitPoints + Mathf.RoundToInt((200 + (100 * pwrVal)) * this.arcaneDmg), 0, thing.MaxHitPoints);
-            if (thing is Apparel)
+            if (thing is Apparel apparelThing)
             {
-                Apparel apparelThing = thing as Apparel;
                 if(apparelThing.WornByCorpse)
                 {
                     apparelThing.Notify_PawnResurrected();

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowCall.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowCall.cs
@@ -53,16 +53,15 @@ namespace TorannMagic
                             soulPawn = compS.polyHost;
                         }
                     }
-                    if (soulPawn.ParentHolder != null && soulPawn.ParentHolder is Caravan)
+                    if (soulPawn.ParentHolder is Caravan caravan)
                     {
                         //Log.Message("caravan detected");
                         //p.DeSpawn();
-                        Caravan van = soulPawn.ParentHolder as Caravan;
-                        van.RemovePawn(soulPawn);
+                        caravan.RemovePawn(soulPawn);
                         GenPlace.TryPlaceThing(soulPawn, this.CasterPawn.Position, this.CasterPawn.Map, ThingPlaceMode.Near);
-                        if(van.PawnsListForReading != null && van.PawnsListForReading.Count <= 0)
+                        if(caravan.PawnsListForReading != null && caravan.PawnsListForReading.Count <= 0)
                         {
-                            CaravanEnterMapUtility.Enter(van, this.CasterPawn.Map, CaravanEnterMode.Center, CaravanDropInventoryMode.DropInstantly, false);
+                            CaravanEnterMapUtility.Enter(caravan, this.CasterPawn.Map, CaravanEnterMode.Center, CaravanDropInventoryMode.DropInstantly, false);
                         }
                         
                         //Messages.Message("" + p.LabelShort + " has shadow stepped to a caravan with " + soulPawn.LabelShort, MessageTypeDefOf.NeutralEvent);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowStep.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowStep.cs
@@ -49,12 +49,11 @@ namespace TorannMagic
                             soulPawnSpawned = true;
                         }
                     }
-                    if(soulPawn.ParentHolder != null && soulPawn.ParentHolder is Caravan)
+                    if(soulPawn.ParentHolder is Caravan caravan)
                     {
                         //Log.Message("caravan detected");
                         //p.DeSpawn();
-                        Caravan van = soulPawn.ParentHolder as Caravan;
-                        van.AddPawn(p, true);
+                        caravan.AddPawn(p, true);
                         Find.WorldPawns.PassToWorld(p);
                         p.Notify_PassedToWorld();
                         Messages.Message("" + p.LabelShort + " has shadow stepped to a caravan with " + soulPawn.LabelShort, MessageTypeDefOf.NeutralEvent);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShatterSentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShatterSentinel.cs
@@ -80,7 +80,7 @@ namespace TorannMagic
             for (int i = 0; i < outsideRing.Count; i++)
             {
                 IntVec3 intVec = outsideRing[i];
-                if (intVec.IsValid && intVec.InBounds(map))
+                if (intVec.IsValid && intVec.InBoundsWithNullCheck(map))
                 {
                     Vector3 moteDirection = TM_Calc.GetVector(sentinel.DrawPos.ToIntVec3(), intVec);
                     TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Rubble, sentinel.DrawPos, map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonSpiritWolves.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonSpiritWolves.cs
@@ -61,7 +61,7 @@ namespace TorannMagic
             {
                 foreach (IntVec3 c in tmpList)
                 {
-                    if (c != null && (c.IsValid && c.Standable(map) && c.InBounds(map)))
+                    if (c != null && (c.IsValid && c.Standable(map) && c.InBoundsWithNullCheck(map)))
                     {
                         cellList.Add(c);
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Teach.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Teach.cs
@@ -37,12 +37,11 @@ namespace TorannMagic
             Map map = base.CasterPawn.Map;
             Pawn mentor = base.CasterPawn;
 
-            if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn && this.currentTarget.Thing != mentor)
+            if(this.currentTarget.Thing is Pawn student && this.currentTarget.Thing != mentor)
             {
-                Pawn student = this.currentTarget.Thing as Pawn;
                 if (this.Ability.Def == TorannMagicDefOf.TM_TeachMagic)
                 {
-                    if (TM_Calc.IsMagicUser(mentor) && !TM_Calc.IsCrossClass(mentor, true) && student != null && student.story != null)
+                    if (TM_Calc.IsMagicUser(mentor) && !TM_Calc.IsCrossClass(mentor, true) && student.story != null)
                     {
                         if (TM_Calc.IsMagicUser(student) && !TM_Calc.IsCrossClass(student, true))
                         {
@@ -75,7 +74,7 @@ namespace TorannMagic
                 }
                 if (this.Ability.Def == TorannMagicDefOf.TM_TeachMight)
                 {
-                    if (TM_Calc.IsMightUser(mentor) && !TM_Calc.IsCrossClass(mentor, false) && student != null && student.story != null)
+                    if (TM_Calc.IsMightUser(mentor) && !TM_Calc.IsCrossClass(mentor, false) && student.story != null)
                     {
                         if (TM_Calc.IsMightUser(student) && !TM_Calc.IsCrossClass(student, false))
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_TigerStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_TigerStrike.cs
@@ -31,27 +31,28 @@ namespace TorannMagic
                     {
                         TM_Action.DamageEntities(target, null, 4, DamageDefOf.Stun, this.CasterPawn);
                     }
-                    if(verVal > 1 && Rand.Chance(.4f) && target is Pawn)
+
+                    Pawn targetPawn = target as Pawn;
+                    if(verVal > 1 && Rand.Chance(.4f) && targetPawn != null)
                     {
-                        if(TM_Calc.IsMagicUser(target as Pawn))
+                        if(TM_Calc.IsMagicUser(targetPawn))
                         {
-                            CompAbilityUserMagic compMagic = target.TryGetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic compMagic = targetPawn.TryGetComp<CompAbilityUserMagic>();
                             float manaDrain = Mathf.Clamp(compMagic.Mana.CurLevel, 0, .25f);
                             this.CasterPawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD).Severity += (manaDrain * 100);
                             compMagic.Mana.CurLevel -= manaDrain;
 
                         }
-                        else if(TM_Calc.IsMightUser(target as Pawn))
+                        else if(TM_Calc.IsMightUser(targetPawn))
                         {
-                            CompAbilityUserMight compMight = target.TryGetComp<CompAbilityUserMight>();
+                            CompAbilityUserMight compMight = targetPawn.TryGetComp<CompAbilityUserMight>();
                             float staminaDrain = Mathf.Clamp(compMight.Stamina.CurLevel, 0, .25f);
                             this.CasterPawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD).Severity += (staminaDrain * 100);
                             compMight.Stamina.CurLevel -= staminaDrain;
                         }
                     }
-                    if(verVal > 2 && Rand.Chance(.1f) && target is Pawn)
+                    if(verVal > 2 && Rand.Chance(.1f) && targetPawn != null)
                     {
-                        Pawn targetPawn = target as Pawn;
                         IEnumerable<BodyPartRecord> rangeOfParts = (targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BloodPumpingSource).Concat(
                             targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BloodFiltrationSource).Concat(
                                 targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BreathingPathway).Concat(
@@ -70,9 +71,8 @@ namespace TorannMagic
                     strikeStartVec.x += Rand.Range(-.2f, .2f);
                     Vector3 angle = TM_Calc.GetVector(strikeStartVec, strikeEndVec);
                     TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_TigerStrike, strikeStartVec, this.CasterPawn.Map, .4f, .08f, .03f, .05f, 0, 8f, (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat(), (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat());
-                    if(!target.DestroyedOrNull() && target is Pawn)
+                    if(!target.DestroyedOrNull() && targetPawn != null)
                     {
-                        Pawn targetPawn = target as Pawn;
                         if(targetPawn.Downed || targetPawn.Dead)
                         {
                             continueAttack = false;

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/CompBPReflector.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/CompBPReflector.cs
@@ -109,9 +109,8 @@ namespace TorannMagic.Weapon
                     TM_MoteMaker.ThrowSparkFlashMote(drawPos, this.GetPawn.Map, 2f);
                     Thing thing = new Thing();
                     thing.def = dinfo.Weapon;
-                    if (instigator is Pawn)
+                    if (instigator is Pawn shooterPawn)
                     {
-                        Pawn shooterPawn = instigator as Pawn;
                         if (!dinfo.Weapon.IsMeleeWeapon && dinfo.WeaponBodyPartGroup == null)
                         {
                             TM_CopyAndLaunchProjectile.CopyAndLaunchThing(shooterPawn.equipment.PrimaryEq.PrimaryVerb.verbProps.defaultProjectile, this.GetPawn, instigator, shooterPawn, ProjectileHitFlags.IntendedTarget, null);

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/SeerRing_Fire.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/SeerRing_Fire.cs
@@ -31,7 +31,7 @@ namespace TorannMagic.Weapon
                 try
                 {
                     IntVec3 randomCell = cellRect.RandomCell;
-                    if (randomCell.IsValid && randomCell.InBounds(map))
+                    if (randomCell.IsValid && randomCell.InBoundsWithNullCheck(map))
                     {
                         this.FireExplosion(randomCell, map, 1f);
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Verb_ArcaneBarrier.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Verb_ArcaneBarrier.cs
@@ -67,7 +67,7 @@ namespace TorannMagic.Weapon
             for (int i = 0; i < 5; i++)
             {
                 currentPosR = GetNewPos(currentPosR, this.currentTarget.Cell.x <= destinationRPos.x, this.currentTarget.Cell.z <= destinationRPos.z, false, 0, 0, xProbR, 1 - xProbR);
-                if(currentPosR.IsValid && currentPosR.InBounds(this.CasterPawn.Map) && !currentPosR.Impassable(this.CasterPawn.Map) && this.currentPosR.Walkable(this.CasterPawn.Map))
+                if(currentPosR.IsValid && currentPosR.InBoundsWithNullCheck(this.CasterPawn.Map) && !currentPosR.Impassable(this.CasterPawn.Map) && this.currentPosR.Walkable(this.CasterPawn.Map))
                 {
                     bool flag = true;
                     foreach (Thing current in currentPosR.GetThingList(this.CasterPawn.Map))
@@ -84,7 +84,7 @@ namespace TorannMagic.Weapon
                     }
                 }
                 currentPosL = GetNewPos(currentPosL, this.currentTarget.Cell.x <= destinationLPos.x, this.currentTarget.Cell.z <= destinationLPos.z, false, 0, 0, xProbL, 1 - xProbL);
-                if (currentPosL.IsValid && currentPosL.InBounds(this.CasterPawn.Map) && !currentPosL.Impassable(this.CasterPawn.Map) && this.currentPosL.Walkable(this.CasterPawn.Map))
+                if (currentPosL.IsValid && currentPosL.InBoundsWithNullCheck(this.CasterPawn.Map) && !currentPosL.Impassable(this.CasterPawn.Map) && this.currentPosL.Walkable(this.CasterPawn.Map))
                 {
                     bool flag = true;
                     foreach (Thing current in currentPosL.GetThingList(this.CasterPawn.Map))

--- a/RimWorldOfMagic/RimWorldOfMagic/WeatherEvent_HailWave.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WeatherEvent_HailWave.cs
@@ -63,7 +63,7 @@ namespace TorannMagic
                 validCells.Clear();
                 foreach(IntVec3 c in cells)
                 {
-                    if(c.InBounds(map) && c.DistanceToEdge(map) > 2)
+                    if(c.InBoundsWithNullCheck(map) && c.DistanceToEdge(map) > 2)
                     {
                         if (c.Roofed(map))
                         {
@@ -79,7 +79,7 @@ namespace TorannMagic
                     }
                 }                
                 currentVec = currentVec + (2 *waveDirection);                
-                if(!currentVec.ToIntVec3().InBounds(map))
+                if(!currentVec.ToIntVec3().InBoundsWithNullCheck(map))
                 {                    
                     this.age = this.duration;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoMagicBill.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoMagicBill.cs
@@ -157,10 +157,9 @@ namespace TorannMagic
                     CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>();
                     if (compMagic != null && compMagic.Mana != null)
                     {
-                        if (thing is Building_TMMagicCircle)
+                        if (thing is Building_TMMagicCircle tmMagicCircle)
                         {
-                            Building_TMMagicCircle mc = thing as Building_TMMagicCircle;
-                            if(mc.InteractionCellOccupied())
+                            if(tmMagicCircle.InteractionCellOccupied())
                             {
                                 return null;
                             }
@@ -247,15 +246,14 @@ namespace TorannMagic
                         
                         List<Pawn> billPawns = new List<Pawn>();
                         billPawns.Clear();
-                        if (bill.recipe is MagicRecipeDef)
+                        if (bill.recipe is MagicRecipeDef magicRecipeDef)
                         {
-                            MagicRecipeDef magicRecipe = bill.recipe as MagicRecipeDef;
                             CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>(); 
                             if(magicCircle.IsActive)
                             {
                                 issueBill = false;
                             }
-                            if (!magicCircle.CanEverDoBill(bill, out billPawns, magicRecipe))
+                            if (!magicCircle.CanEverDoBill(bill, out billPawns, magicRecipeDef))
                             {
                                 issueBill = false;
                             }
@@ -294,13 +292,13 @@ namespace TorannMagic
                                 if (TryFindBestBillIngredients(bill, pawn, (Thing)giver, chosenIngThings))
                                 {
                                     this.magicCircle = thing as Building_TMMagicCircle;
-                                    if (this.magicCircle != null && bill.recipe is MagicRecipeDef)
+                                    if (this.magicCircle != null && bill.recipe is MagicRecipeDef recipeDef)
                                     {
-                                        this.magicCircle.magicRecipeDef = bill.recipe as MagicRecipeDef;
+                                        this.magicCircle.magicRecipeDef = recipeDef;
                                         this.magicCircle.MageList.Clear();
                                         magicCircle.MageList.Add(pawn);
                                         //Log.Message("assigning magic bill to " + pawn.LabelShort);
-                                        if (bill.recipe is MagicRecipeDef && billPawns.Count > 1)
+                                        if (recipeDef != null && billPawns.Count > 1)
                                         {
                                             for (int j = 0; j < billPawns.Count; j++)
                                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/WorldTransport/TM_TransportPodsArrivalActionUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorldTransport/TM_TransportPodsArrivalActionUtility.cs
@@ -111,7 +111,7 @@ namespace TorannMagic.WorldTransport
             for (int i = 0; i < dropPods.Count; i++)
             {
                 IntVec3 result = default(IntVec3);
-                if (!exactCell || !(near.InBounds(map) && near.Walkable(map) && !near.Roofed(map)))
+                if (!exactCell || !(near.InBoundsWithNullCheck(map) && near.Walkable(map) && !near.Roofed(map)))
                 {                    
                     DropCellFinder.TryFindDropSpotNear(near, map, out result, allowFogged: false, canRoofPunch: true);
                 }


### PR DESCRIPTION
Small speedup for ColonistBarColonistDrawer_Patch by keeping track of trait icons in a dictionary and caching the whole patch for 5 seconds. Goes through all keys every 5 minutes to flush old keys.