### PR TITLE
Optimize and cache colonist bar colonist drawer patch

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6413,29 +6413,6 @@ namespace TorannMagic
                         // Early exit condition
                         if (!settingsRef.showClassIconOnColonistBar || colonist.story == null) return null;
                         
-                        // Check custom classes
-                        CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
-                        if (compMagic != null && compMagic.customClass != null)
-                        {
-                            Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
-                            if (compMagic.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMagic.customClass.classTexturePath, true);
-                            }
-
-                            return new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom");
-                        }
-                        CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
-                        if (compMight != null && compMight.customClass != null)
-                        {
-                            Texture2D customIcon = TM_MatPool.DefaultCustomFighterIcon;
-                            if (compMight.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMight.customClass.classTexturePath, true);
-                            }
-                            
-                            return new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom");
-                        }
                         for (int i = 0; i < colonist.story.traits.allTraits.Count; i++)
                         {
                             TraitDef trait = colonist.story.traits.allTraits[i].def;

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6398,7 +6398,7 @@ namespace TorannMagic
                 if (colonist.Dead) return;
 
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                if (colonist.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
+                if (colonist.health.hediffSet.HasHediff(TorannMagicDefOf.TM_UndeadHD))
                 {
                     float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
                     Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6391,8 +6391,8 @@ namespace TorannMagic
             }
         }
 
-        private static readonly SimpleCache<int, TraitIconMap.TraitIconValue> ColonistBarColonistDrawerCache = 
-            new SimpleCache<int, TraitIconMap.TraitIconValue>(5);
+        private static readonly SimpleCache<string, TraitIconMap.TraitIconValue> ColonistBarColonistDrawerCache =
+            new SimpleCache<string, TraitIconMap.TraitIconValue>(5);
 
         [HarmonyPatch(typeof(ColonistBarColonistDrawer), "DrawIcons", null)]
         public class ColonistBarColonistDrawer_Patch
@@ -6403,7 +6403,7 @@ namespace TorannMagic
 
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 var traitIconValue = ColonistBarColonistDrawerCache.GetOrCreate(
-                    colonist.thingIDNumber,
+                    colonist.ThingID,
                     () =>
                     {
                         if (colonist.health.hediffSet.HasHediff(TorannMagicDefOf.TM_UndeadHD))

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6395,231 +6395,65 @@ namespace TorannMagic
         {
             public static void Postfix(ColonistBarColonistDrawer __instance, ref Rect rect, Pawn colonist)
             {
-                if (!colonist.Dead)
+                if (colonist.Dead) return;
+
+                ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
+                if (colonist.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
                 {
-                    ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                    if (colonist.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
+                    float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
+                    Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
+                    rect = new Rect(vector.x, vector.y, num, num);
+                    GUI.DrawTexture(rect, TM_MatPool.Icon_Undead);
+                    TooltipHandler.TipRegion(rect, "TM_Icon_Undead".Translate());
+                    vector.x += num;
+                }
+                else if (settingsRef.showClassIconOnColonistBar && colonist.story != null)
+                {
+                    // Create the shapes for the icon
+                    float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
+                    Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
+                    rect = new Rect(vector.x, vector.y, num, num);
+                    // Check for custom classes
+                    CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
+                    if (compMagic != null && compMagic.customClass != null)
                     {
-                        float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
-                        Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
-                        rect = new Rect(vector.x, vector.y, num, num);
-                        GUI.DrawTexture(rect, TM_MatPool.Icon_Undead);
-                        TooltipHandler.TipRegion(rect, "TM_Icon_Undead".Translate());
+                        Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
+                        if (compMagic.customClass.classTexturePath != "")
+                        {
+                            customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMagic.customClass.classTexturePath, true);
+                        }
+                        GUI.DrawTexture(rect, customIcon);
+                        TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
                         vector.x += num;
-                        //rect = new Rect(vector.x, vector.y, num, num);
+                        return;
                     }
-                    else if (settingsRef.showClassIconOnColonistBar && colonist.story != null)
+                    CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
+                    if (compMight != null && compMight.customClass != null)
                     {
-                        float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
-                        Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
-                        rect = new Rect(vector.x, vector.y, num, num);
-                        CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
-                        CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
-                        if (compMagic != null && compMagic.customClass != null)
+                        Texture2D customIcon = TM_MatPool.DefaultCustomFighterIcon;
+                        if (compMight.customClass.classTexturePath != "")
                         {
-                            Texture2D customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomMageMark", true);
-                            if (compMagic.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMagic.customClass.classTexturePath, true);
-                            }
-                            GUI.DrawTexture(rect, customIcon);
-                            TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
-                            vector.x += num;
+                            customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMight.customClass.classTexturePath, true);
                         }
-                        else if (compMight != null && compMight.customClass != null)
+                        GUI.DrawTexture(rect, customIcon);
+                        TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
+                        vector.x += num;
+                    }
+                    // Otherwise use dictionary TraitIconMapping to apply the material and shape
+                    else
+                    {
+                        for (int i = 0; i < colonist.story.traits.allTraits.Count; i++)
                         {
-                            Texture2D customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomFighterMark", true);
-                            if (compMight.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMight.customClass.classTexturePath, true);
-                            }
-                            GUI.DrawTexture(rect, customIcon);
-                            TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
-                            vector.x += num;
+                            TraitDef trait = colonist.story.traits.allTraits[i].def;
+                            if (!TraitIconMap.ContainsKey(trait)) continue;
 
+                            GUI.DrawTexture(rect, TraitIconMap.Get(trait).IconMaterial);
+                            TooltipHandler.TipRegion(rect, TraitIconMap.Get(trait).IconType.Translate());
+                            vector.x += num;
+                            return;
                         }
-                        else
-                        {
-
-                            if (colonist.story.traits.HasTrait(TorannMagicDefOf.InnerFire))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.fireIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.HeartOfFrost))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.iceIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.StormBorn))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.lightningIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Arcanist))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.arcanistIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Paladin))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.paladinIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Summoner))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.summonerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Druid))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.druidIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Necromancer) || colonist.story.traits.HasTrait(TorannMagicDefOf.Lich))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.necroIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Priest))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.priestIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Bard))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.bardIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Succubus) || colonist.story.traits.HasTrait(TorannMagicDefOf.Warlock))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.demonkinIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Geomancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.earthIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Technomancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.technoIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.BloodMage))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.bloodmageIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Enchanter))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.enchanterIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Chronomancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.chronoIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Gladiator))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.gladiatorIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Sniper))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.sniperIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Bladedancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.bladedancerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Ranger))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.rangerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Faceless))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.facelessIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Psionic))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.psiIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.DeathKnight))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.deathknightIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Monk))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.monkIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.wandererIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.wayfarerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.ChaosMage))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.chaosIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Commander))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.commanderIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_SuperSoldier))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.SSIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                        }
-                        //rect = new Rect(vector.x, vector.y, num, num);
                     }
                 }
-                //return true;
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -18,6 +18,7 @@ using TorannMagic.TMDefs;
 using TorannMagic.Golems;
 using RimWorld.QuestGen;
 using System.Diagnostics;
+using TorannMagic.Utils;
 
 namespace TorannMagic
 {

--- a/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
@@ -49,7 +49,23 @@ namespace TorannMagic.ModOptions
             for (int i = 0; i < TM_ClassUtility.CustomClasses().Count; i++)
             {
                 TMDefs.TM_CustomClass customClass = TM_ClassUtility.CustomClasses()[i];
-                customTraits.AddDistinct(customClass.classTrait);
+                if (customTraits.Contains(customClass.classTrait))
+                {
+                    Log.Warning($"RimWorld of Magic trait {customClass.classTrait} already added. This is likely a naming conflict between mods.");
+                }
+                else
+                {
+                    // Map the trait to the texture to avoid having to TryGetComp
+                    Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
+                    if (customClass.classTexturePath != "")
+                    {
+                        customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + customClass.classTexturePath, true);
+                    }
+                    
+                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom"));
+                    // Add custom trait to list for processing
+                    customTraits.Add(customClass.classTrait);
+                }
                 customClass.classTrait.conflictingTraits.AddRange(TM_Data.AllClassTraits);
             }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
@@ -46,6 +46,7 @@ namespace TorannMagic.ModOptions
             //Conflicting trait levelset
             List<TraitDef> customTraits = new List<TraitDef>();
             customTraits.Clear();
+            const string customIconType = "TM_Icon_Custom";
             for (int i = 0; i < TM_ClassUtility.CustomClasses().Count; i++)
             {
                 TMDefs.TM_CustomClass customClass = TM_ClassUtility.CustomClasses()[i];
@@ -61,8 +62,8 @@ namespace TorannMagic.ModOptions
                     {
                         customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + customClass.classTexturePath, true);
                     }
+                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, customIconType));
                     
-                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom"));
                     // Add custom trait to list for processing
                     customTraits.Add(customClass.classTrait);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,8 +134,8 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
-    <Compile Include="SimpleCache.cs" />
     <Compile Include="TraitIconMap.cs" />
+    <Compile Include="Utils\SimpleCache.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />
     <Compile Include="TMDefs\TM_Branding.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
+    <Compile Include="TraitIconMap.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />
     <Compile Include="TMDefs\TM_Branding.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
+    <Compile Include="SimpleCache.cs" />
     <Compile Include="TraitIconMap.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/SimpleCache.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/SimpleCache.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace TorannMagic
+{
+    public class SimpleCache<TKey, TValue>
+    {
+        private class CacheValue<T>
+        {
+            public readonly T Value;
+            public readonly DateTime Timeout;
+            public CacheValue(T value, double secondsToTimeout)
+            {
+                Value = value;
+                Timeout = DateTime.UtcNow.AddSeconds(secondsToTimeout);
+            }
+        }
+
+        private readonly Dictionary<TKey, CacheValue<TValue>> cache;
+        private DateTime nextFlush;
+        private readonly double minutesUntilFlush;
+
+        public SimpleCache(double minutesUntilFlush)
+        {
+            cache = new Dictionary<TKey, CacheValue<TValue>>();
+            nextFlush = DateTime.UtcNow.AddMinutes(minutesUntilFlush);
+            this.minutesUntilFlush = minutesUntilFlush;
+        }
+
+        public TValue GetOrCreate(TKey key, Func<TValue> valueGetter, double secondsToTimeout)
+        {
+            if (cache.ContainsKey(key) && cache[key].Timeout > DateTime.UtcNow)
+            {
+                return cache[key].Value;
+            }
+
+            if (DateTime.UtcNow > nextFlush)
+            {
+                DateTime now = DateTime.UtcNow;
+                var itemsToRemove = cache.Where(kv => now > kv.Value.Timeout).ToList();
+                foreach (var item in itemsToRemove)
+                {
+                    cache.Remove(item.Key);
+                }
+                
+                nextFlush = DateTime.UtcNow.AddMinutes(minutesUntilFlush);
+            }
+            cache[key] = new CacheValue<TValue>(valueGetter(), secondsToTimeout);
+            return cache[key].Value;
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_MatPool.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_MatPool.cs
@@ -79,6 +79,9 @@ namespace TorannMagic
         public static readonly Texture2D wandererIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/wandererFlame", true);
         public static readonly Texture2D wayfarerIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/wayfarerFlame", true);
 
+        public static readonly Texture2D DefaultCustomMageIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomMageMark", true);
+        public static readonly Texture2D DefaultCustomFighterIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomFighterMark", true);
+
 
         //skeleton chain
         public static readonly Material circleChain = MaterialPool.MatFrom("PawnKind/skeleton_chain_circle", ShaderDatabase.MoteGlow);

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -23,53 +23,53 @@ namespace TorannMagic
         }
         // Dictionary that maps TraitDef to their appropriate Icon material and Icon type. Custom Classes are loaded
         // via ModOptions.ModClassOptions.InitializeCustomClassActions
-        private static readonly Dictionary<TraitDef, TraitIconValue> TraitIconMapping = new Dictionary<TraitDef, TraitIconValue>()
+        private static readonly Dictionary<ushort, TraitIconValue> TraitIconMapping = new Dictionary<ushort, TraitIconValue>()
         {
-            { TorannMagicDefOf.InnerFire, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
-            { TorannMagicDefOf.HeartOfFrost, new TraitIconValue(TM_MatPool.iceIcon, MageIcon) },
-            { TorannMagicDefOf.StormBorn, new TraitIconValue(TM_MatPool.lightningIcon, MageIcon) },
-            { TorannMagicDefOf.Arcanist, new TraitIconValue(TM_MatPool.arcanistIcon, MageIcon) },
-            { TorannMagicDefOf.Paladin, new TraitIconValue(TM_MatPool.paladinIcon, MageIcon) },
-            { TorannMagicDefOf.Summoner, new TraitIconValue(TM_MatPool.summonerIcon, MageIcon) },
-            { TorannMagicDefOf.Druid, new TraitIconValue(TM_MatPool.druidIcon, MageIcon) },
-            { TorannMagicDefOf.Necromancer, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
-            { TorannMagicDefOf.Lich, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
-            { TorannMagicDefOf.TM_Bard, new TraitIconValue(TM_MatPool.bardIcon, MageIcon) },
-            { TorannMagicDefOf.Succubus, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
-            { TorannMagicDefOf.Warlock, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
-            { TorannMagicDefOf.Geomancer, new TraitIconValue(TM_MatPool.earthIcon, MageIcon) },
-            { TorannMagicDefOf.Technomancer, new TraitIconValue(TM_MatPool.technoIcon, MageIcon) },
-            { TorannMagicDefOf.BloodMage, new TraitIconValue(TM_MatPool.bloodmageIcon, MageIcon) },
-            { TorannMagicDefOf.Enchanter, new TraitIconValue(TM_MatPool.enchanterIcon, MageIcon) },
-            { TorannMagicDefOf.Chronomancer, new TraitIconValue(TM_MatPool.chronoIcon, MageIcon) },
-            { TorannMagicDefOf.Gladiator, new TraitIconValue(TM_MatPool.gladiatorIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Sniper, new TraitIconValue(TM_MatPool.sniperIcon, FighterIcon) },
-            { TorannMagicDefOf.Bladedancer, new TraitIconValue(TM_MatPool.bladedancerIcon, FighterIcon) },
-            { TorannMagicDefOf.Ranger, new TraitIconValue(TM_MatPool.rangerIcon, FighterIcon) },
-            { TorannMagicDefOf.Faceless, new TraitIconValue(TM_MatPool.facelessIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Psionic, new TraitIconValue(TM_MatPool.psiIcon, FighterIcon) },
-            { TorannMagicDefOf.DeathKnight, new TraitIconValue(TM_MatPool.deathknightIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Monk, new TraitIconValue(TM_MatPool.monkIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Wanderer, new TraitIconValue(TM_MatPool.wandererIcon, MageIcon) },
-            { TorannMagicDefOf.TM_Wayfarer, new TraitIconValue(TM_MatPool.wayfarerIcon, FighterIcon) },
-            { TorannMagicDefOf.ChaosMage, new TraitIconValue(TM_MatPool.chaosIcon, MageIcon) },
-            { TorannMagicDefOf.TM_Commander, new TraitIconValue(TM_MatPool.commanderIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_SuperSoldier, new TraitIconValue(TM_MatPool.SSIcon, FighterIcon) }
+            { TorannMagicDefOf.InnerFire.index, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
+            { TorannMagicDefOf.HeartOfFrost.index, new TraitIconValue(TM_MatPool.iceIcon, MageIcon) },
+            { TorannMagicDefOf.StormBorn.index, new TraitIconValue(TM_MatPool.lightningIcon, MageIcon) },
+            { TorannMagicDefOf.Arcanist.index, new TraitIconValue(TM_MatPool.arcanistIcon, MageIcon) },
+            { TorannMagicDefOf.Paladin.index, new TraitIconValue(TM_MatPool.paladinIcon, MageIcon) },
+            { TorannMagicDefOf.Summoner.index, new TraitIconValue(TM_MatPool.summonerIcon, MageIcon) },
+            { TorannMagicDefOf.Druid.index, new TraitIconValue(TM_MatPool.druidIcon, MageIcon) },
+            { TorannMagicDefOf.Necromancer.index, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.Lich.index, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Bard.index, new TraitIconValue(TM_MatPool.bardIcon, MageIcon) },
+            { TorannMagicDefOf.Succubus.index, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Warlock.index, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Geomancer.index, new TraitIconValue(TM_MatPool.earthIcon, MageIcon) },
+            { TorannMagicDefOf.Technomancer.index, new TraitIconValue(TM_MatPool.technoIcon, MageIcon) },
+            { TorannMagicDefOf.BloodMage.index, new TraitIconValue(TM_MatPool.bloodmageIcon, MageIcon) },
+            { TorannMagicDefOf.Enchanter.index, new TraitIconValue(TM_MatPool.enchanterIcon, MageIcon) },
+            { TorannMagicDefOf.Chronomancer.index, new TraitIconValue(TM_MatPool.chronoIcon, MageIcon) },
+            { TorannMagicDefOf.Gladiator.index, new TraitIconValue(TM_MatPool.gladiatorIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Sniper.index, new TraitIconValue(TM_MatPool.sniperIcon, FighterIcon) },
+            { TorannMagicDefOf.Bladedancer.index, new TraitIconValue(TM_MatPool.bladedancerIcon, FighterIcon) },
+            { TorannMagicDefOf.Ranger.index, new TraitIconValue(TM_MatPool.rangerIcon, FighterIcon) },
+            { TorannMagicDefOf.Faceless.index, new TraitIconValue(TM_MatPool.facelessIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Psionic.index, new TraitIconValue(TM_MatPool.psiIcon, FighterIcon) },
+            { TorannMagicDefOf.DeathKnight.index, new TraitIconValue(TM_MatPool.deathknightIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Monk.index, new TraitIconValue(TM_MatPool.monkIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Wanderer.index, new TraitIconValue(TM_MatPool.wandererIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Wayfarer.index, new TraitIconValue(TM_MatPool.wayfarerIcon, FighterIcon) },
+            { TorannMagicDefOf.ChaosMage.index, new TraitIconValue(TM_MatPool.chaosIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Commander.index, new TraitIconValue(TM_MatPool.commanderIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_SuperSoldier.index, new TraitIconValue(TM_MatPool.SSIcon, FighterIcon) }
         };
 
         public static TraitIconValue Get(TraitDef traitDef)
         {
-            return TraitIconMapping[traitDef];
+            return TraitIconMapping[traitDef.index];
         }
 
         public static void Set(TraitDef traitDef, TraitIconValue traitIconValue)
         {
-            TraitIconMapping[traitDef] = traitIconValue;
+            TraitIconMapping[traitDef.index] = traitIconValue;
         }
 
         public static bool ContainsKey(TraitDef traitDef)
         {
-            return TraitIconMapping.ContainsKey(traitDef);
+            return TraitIconMapping.ContainsKey(traitDef.index);
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using RimWorld;
+using UnityEngine;
+
+namespace TorannMagic
+{
+    public static class TraitIconMap
+    {
+        // Data for ColonistBarColonistDrawer_Patch
+        private const string MageIcon = "TM_Icon_Mage";  // Use same strings in tuples for less memory usage
+        private const string FighterIcon = "TM_Icon_Fighter";
+        // Class to hold Values for below dictionary
+        public class TraitIconValue
+        {
+            public readonly Texture2D IconMaterial;
+            public readonly string IconType;
+
+            public TraitIconValue(Texture2D iconMaterial, string iconType)
+            {
+                IconMaterial = iconMaterial;
+                IconType = iconType;
+            }
+        }
+        // Dictionary that maps TraitDef to their appropriate Icon material and Icon type
+        // TODO: dynamically add custom classes on load to allow for easier checks
+        private static readonly Dictionary<TraitDef, TraitIconValue> TraitIconMapping = new Dictionary<TraitDef, TraitIconValue>()
+        {
+            { TorannMagicDefOf.InnerFire, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
+            { TorannMagicDefOf.HeartOfFrost, new TraitIconValue(TM_MatPool.iceIcon, MageIcon) },
+            { TorannMagicDefOf.StormBorn, new TraitIconValue(TM_MatPool.lightningIcon, MageIcon) },
+            { TorannMagicDefOf.Arcanist, new TraitIconValue(TM_MatPool.arcanistIcon, MageIcon) },
+            { TorannMagicDefOf.Paladin, new TraitIconValue(TM_MatPool.paladinIcon, MageIcon) },
+            { TorannMagicDefOf.Summoner, new TraitIconValue(TM_MatPool.summonerIcon, MageIcon) },
+            { TorannMagicDefOf.Druid, new TraitIconValue(TM_MatPool.druidIcon, MageIcon) },
+            { TorannMagicDefOf.Necromancer, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.Lich, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Bard, new TraitIconValue(TM_MatPool.bardIcon, MageIcon) },
+            { TorannMagicDefOf.Succubus, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Warlock, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Geomancer, new TraitIconValue(TM_MatPool.earthIcon, MageIcon) },
+            { TorannMagicDefOf.Technomancer, new TraitIconValue(TM_MatPool.technoIcon, MageIcon) },
+            { TorannMagicDefOf.BloodMage, new TraitIconValue(TM_MatPool.bloodmageIcon, MageIcon) },
+            { TorannMagicDefOf.Enchanter, new TraitIconValue(TM_MatPool.enchanterIcon, MageIcon) },
+            { TorannMagicDefOf.Chronomancer, new TraitIconValue(TM_MatPool.chronoIcon, MageIcon) },
+            { TorannMagicDefOf.Gladiator, new TraitIconValue(TM_MatPool.gladiatorIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Sniper, new TraitIconValue(TM_MatPool.sniperIcon, FighterIcon) },
+            { TorannMagicDefOf.Bladedancer, new TraitIconValue(TM_MatPool.bladedancerIcon, FighterIcon) },
+            { TorannMagicDefOf.Ranger, new TraitIconValue(TM_MatPool.rangerIcon, FighterIcon) },
+            { TorannMagicDefOf.Faceless, new TraitIconValue(TM_MatPool.facelessIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Psionic, new TraitIconValue(TM_MatPool.psiIcon, FighterIcon) },
+            { TorannMagicDefOf.DeathKnight, new TraitIconValue(TM_MatPool.deathknightIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Monk, new TraitIconValue(TM_MatPool.monkIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Wanderer, new TraitIconValue(TM_MatPool.wandererIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Wayfarer, new TraitIconValue(TM_MatPool.wayfarerIcon, FighterIcon) },
+            { TorannMagicDefOf.ChaosMage, new TraitIconValue(TM_MatPool.chaosIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Commander, new TraitIconValue(TM_MatPool.commanderIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_SuperSoldier, new TraitIconValue(TM_MatPool.SSIcon, FighterIcon) }
+        };
+
+        public static TraitIconValue Get(TraitDef traitDef)
+        {
+            return TraitIconMapping[traitDef];
+        }
+
+        public static bool ContainsKey(TraitDef traitDef)
+        {
+            return TraitIconMapping.ContainsKey(traitDef);
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -7,7 +7,7 @@ namespace TorannMagic
     public static class TraitIconMap
     {
         // Data for ColonistBarColonistDrawer_Patch
-        private const string MageIcon = "TM_Icon_Mage";  // Use same strings in tuples for less memory usage
+        private const string MageIcon = "TM_Icon_Mage";
         private const string FighterIcon = "TM_Icon_Fighter";
         // Class to hold Values for below dictionary
         public class TraitIconValue

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -21,8 +21,8 @@ namespace TorannMagic
                 IconType = iconType;
             }
         }
-        // Dictionary that maps TraitDef to their appropriate Icon material and Icon type
-        // TODO: dynamically add custom classes on load to allow for easier checks
+        // Dictionary that maps TraitDef to their appropriate Icon material and Icon type. Custom Classes are loaded
+        // via ModOptions.ModClassOptions.InitializeCustomClassActions
         private static readonly Dictionary<TraitDef, TraitIconValue> TraitIconMapping = new Dictionary<TraitDef, TraitIconValue>()
         {
             { TorannMagicDefOf.InnerFire, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
@@ -60,6 +60,11 @@ namespace TorannMagic
         public static TraitIconValue Get(TraitDef traitDef)
         {
             return TraitIconMapping[traitDef];
+        }
+
+        public static void Set(TraitDef traitDef, TraitIconValue traitIconValue)
+        {
+            TraitIconMapping[traitDef] = traitIconValue;
         }
 
         public static bool ContainsKey(TraitDef traitDef)

--- a/RimWorldOfMagic/RimWorldOfMagic/Utils/SimpleCache.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Utils/SimpleCache.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Verse;
 
-namespace TorannMagic
+namespace TorannMagic.Utils
 {
     public class SimpleCache<TKey, TValue>
     {


### PR DESCRIPTION
Fix for accidental wrong merge before. This optimizes drawing the icons on the colonist bar by loading traits (including custom class traits) into a dictionary and using that to check for icon rather than sequential if elses. On top of that it then caches the response for 5 seconds so it can skip the trait and hediff checking most of the time since colonists dont change that frequently.

Note there is a change to how custom classes are recognized by the patch. Instead of using their Comp, it relies on a unique trait. A warning has been added if the traits overlap with another mod. I have tested with a bunch of custom classes on workshop and did not see any issues. Note with the caching there is a maximum of 5 second delay before the icon appears/disappears with the trait.

Average ms reduction increases with the number of colonists where it's not an improvement at 3 colonists, but becomes significant around 6 colonists. around 40 the time for the function went from average of .450ms to .3ms.