### PR TITLE
Only go through each colonists hediffs once in Get_NightRestingUndead by using HashSet

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2856,7 +2856,7 @@ namespace TorannMagic
         public static bool Get_NightResting_Undead(Caravan __instance, ref bool __result)
         {
             List<Pawn> caravan = __instance.PawnsListForReading;
-            bool anyLivingColonists = !caravan.Any(pawn => 
+            bool anyLivingColonists = caravan.Any(pawn => 
                 pawn.IsColonist 
                 && !pawn.health.hediffSet.hediffs.Any(hediff => UndeadHediffDefs.Contains(hediff.def))
             );

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2846,20 +2846,22 @@ namespace TorannMagic
             return true;
         }
 
+        private static readonly HashSet<HediffDef> UndeadHediffDefs = new HashSet<HediffDef>()
+        {
+            TorannMagicDefOf.TM_UndeadHD,
+            TorannMagicDefOf.TM_UndeadAnimalHD,
+            TorannMagicDefOf.TM_LichHD
+        };
+
         public static bool Get_NightResting_Undead(Caravan __instance, ref bool __result)
         {
-            List<Pawn> undeadCaravan = __instance.PawnsListForReading;
-            bool allUndead = true;
-            for (int i = 0; i < undeadCaravan.Count; i++)
-            {
-                if (undeadCaravan[i].IsColonist && !(undeadCaravan[i].health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")) || undeadCaravan[i].health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadAnimalHD")) || undeadCaravan[i].health.hediffSet.HasHediff(HediffDef.Named("TM_LichHD"))))
-                {
-                    allUndead = false;
-                    break;
-                }
-            }
-            __result = !allUndead;
-            return !allUndead;
+            List<Pawn> caravan = __instance.PawnsListForReading;
+            bool anyLivingColonists = !caravan.Any(pawn => 
+                pawn.IsColonist 
+                && !pawn.health.hediffSet.hediffs.Any(hediff => UndeadHediffDefs.Contains(hediff.def))
+            );
+            __result = anyLivingColonists;
+            return anyLivingColonists;
         }
 
         [HarmonyPriority(2000)]


### PR DESCRIPTION
Note that LINQ is slower than a standard for loop, but 
```
// Go through each pawn in the caravan
for (int i = 0; i < caravan.Count; i++)
{
    if (!caravan[i].IsColonist) continue;
    // Search the hediffs for an undead hediff
    for (int j = 0; j < caravan[i].health.hediffSet.hediffs.Count; j++)
    {
        if (UndeadHediffDefs.Contains(caravan[i].health.hediffSet.hediffs[j].def))
        {
            __result = true;
            return true;
        }
    }
}
```
is significantly harder to read than what I committed, so I went with LINQ for readability.