### PR TITLE
Improve get can do random mental breaks

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -502,7 +502,7 @@ namespace TorannMagic
 
         private static void Get_CanDoRandomMentalBreaks(MentalBreaker __instance, Pawn ___pawn, ref bool __result)
         {
-            if (___pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EmotionSuppressionHD))
+            if (__result && ___pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EmotionSuppressionHD))
                 __result = false;
         }        
 

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -500,15 +500,10 @@ namespace TorannMagic
             }
         }
 
-        private static void Get_CanDoRandomMentalBreaks(MentalBreaker __instance, Pawn ___pawn, ref bool __result)
+        private static void Get_CanDoRandomMentalBreaks(MentalBreaker __instance, Pawn __pawn, ref bool __result)
         {
-            if(___pawn != null && __result)
-            {
-                if(___pawn.health != null && ___pawn.health.hediffSet != null && ___pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EmotionSuppressionHD))
-                {
-                    __result = false;
-                }
-            }
+            if (__result && __pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EmotionSuppressionHD))
+                __result = false;
         }        
 
         [HarmonyPatch(typeof(Plant), "PlantCollected", null)]

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -500,9 +500,9 @@ namespace TorannMagic
             }
         }
 
-        private static void Get_CanDoRandomMentalBreaks(MentalBreaker __instance, Pawn __pawn, ref bool __result)
+        private static void Get_CanDoRandomMentalBreaks(MentalBreaker __instance, Pawn ___pawn, ref bool __result)
         {
-            if (__result && __pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EmotionSuppressionHD))
+            if (___pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EmotionSuppressionHD))
                 __result = false;
         }        
 


### PR DESCRIPTION
It's my understanding that pawn cannot be null on this method. In addition to that as long as pawn is not null, then we know for a fact that pawn.health and pawn.health.hediffSet are not null since they are maintained by rimworld itself. If they are null, it's something outside of this mod breaking them.

Therefore there's only one check we need to do: hediff check.

I leave the __result check in for optimization in the case that there are a lot of animals