### PR TITLE
Speed up Get_IsColonist_Polymorphed

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -77,7 +77,7 @@ namespace TorannMagic
             //harmonyInstance.Patch(AccessTools.Method(typeof(Pawn_ApparelTracker), "Notify_ApparelAdded"), null, new HarmonyMethod(typeof(TorannMagicMod), "Notify_ApparelAdded_PostFix"));
             //harmonyInstance.Patch(AccessTools.Method(typeof(Pawn_ApparelTracker), "Notify_ApparelRemoved"), null, new HarmonyMethod(typeof(TorannMagicMod), "Notify_ApparelRemoved_PostFix"));
 
-            harmonyInstance.Patch(AccessTools.Method(typeof(Pawn), "get_IsColonist", null, null), new HarmonyMethod(typeof(TorannMagicMod), "Get_IsColonist_Polymorphed", null), null);
+            harmonyInstance.Patch(AccessTools.Method(typeof(Pawn), "get_IsColonist", null, null), null, new HarmonyMethod(typeof(TorannMagicMod), "Get_IsColonist_Polymorphed"), null);
             harmonyInstance.Patch(AccessTools.Method(typeof(Caravan), "get_NightResting", null, null), new HarmonyMethod(typeof(TorannMagicMod), "Get_NightResting_Undead", null), null);
             harmonyInstance.Patch(AccessTools.Method(typeof(Pawn_StanceTracker), "get_Staggered", null, null), new HarmonyMethod(typeof(TorannMagicMod), "Get_Staggered", null), null);
             harmonyInstance.Patch(AccessTools.Method(typeof(Verb_LaunchProjectile), "get_Projectile", null, null), new HarmonyMethod(typeof(TorannMagicMod), "Get_Projectile_ES", null), null);
@@ -2029,10 +2029,10 @@ namespace TorannMagic
             }
         }
 
-        public static bool Get_IsColonist_Polymorphed(Pawn __instance, ref bool __result)
+        public static void Get_IsColonist_Polymorphed(Pawn __instance, ref bool __result)
         {
-            if (__instance == null || __instance.Faction != Faction.OfPlayerSilentFail) return true;
-            
+            if (__instance.Faction != Faction.OfPlayerSilentFail || __result) return;
+
             // TryGetComp but faster by avoiding generic isInst
             CompPolymorph cp = null;
             for (int i = 0; i < __instance.AllComps.Count; i++)
@@ -2042,10 +2042,9 @@ namespace TorannMagic
             }
             
             if (cp?.Original == null || !cp.Original.RaceProps.Humanlike) 
-                return true;
+                return;
             
             __result = true;
-            return false;
         }
 
         [HarmonyPatch(typeof(FloatMenuMakerMap), "AddJobGiverWorkOrders", null)]

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2037,10 +2037,11 @@ namespace TorannMagic
             CompPolymorph cp = null;
             for (int i = 0; i < __instance.AllComps.Count; i++)
             {
-                if (__instance.AllComps[i] is CompPolymorph)
-                    cp = __instance.AllComps[i] as CompPolymorph;
+                if (!(__instance.AllComps[i] is CompPolymorph)) continue;
+                cp = __instance.AllComps[i] as CompPolymorph;
+                break;
             }
-            
+
             if (cp?.Original != null && cp.Original.RaceProps.Humanlike)
                 __result = true;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2041,10 +2041,8 @@ namespace TorannMagic
                     cp = __instance.AllComps[i] as CompPolymorph;
             }
             
-            if (cp?.Original == null || !cp.Original.RaceProps.Humanlike) 
-                return;
-            
-            __result = true;
+            if (cp?.Original != null && cp.Original.RaceProps.Humanlike)
+                __result = true;
         }
 
         [HarmonyPatch(typeof(FloatMenuMakerMap), "AddJobGiverWorkOrders", null)]

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2031,24 +2031,21 @@ namespace TorannMagic
 
         public static bool Get_IsColonist_Polymorphed(Pawn __instance, ref bool __result)
         {
-            Pawn p = __instance;
-            if (p != null && p.Faction == Faction.OfPlayerSilentFail)// __instance.GetComp<CompPolymorph>() != null && __instance.GetComp<CompPolymorph>().Original != null && __instance.GetComp<CompPolymorph>().Original.RaceProps.Humanlike)
+            if (__instance == null || __instance.Faction != Faction.OfPlayerSilentFail) return true;
+            
+            // TryGetComp but faster by avoiding generic isInst
+            CompPolymorph cp = null;
+            for (int i = 0; i < __instance.AllComps.Count; i++)
             {
-                CompPolymorph cp = __instance.GetComp<CompPolymorph>();
-                if (cp != null && cp.Original != null && cp.Original.RaceProps.Humanlike)
-                {
-                    __result = true;
-                    return false;
-                }
-                //if(__instance is TMPawnGolem)
-                //{
-                //    __result = true;
-                //    return false;
-                //}
-                //__result = __instance.Faction != null && __instance.Faction.IsPlayer;
-                //return false;
+                if (__instance.AllComps[i] is CompPolymorph)
+                    cp = __instance.AllComps[i] as CompPolymorph;
             }
-            return true;
+            
+            if (cp?.Original == null || !cp.Original.RaceProps.Humanlike) 
+                return true;
+            
+            __result = true;
+            return false;
         }
 
         [HarmonyPatch(typeof(FloatMenuMakerMap), "AddJobGiverWorkOrders", null)]

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2031,7 +2031,7 @@ namespace TorannMagic
 
         public static void Get_IsColonist_Polymorphed(Pawn __instance, ref bool __result)
         {
-            if (__instance.Faction != Faction.OfPlayerSilentFail || __result) return;
+            if (__instance.Faction == null || !__instance.Faction.IsPlayer || __result) return;
 
             // TryGetComp but faster by avoiding generic isInst
             CompPolymorph cp = null;


### PR DESCRIPTION
Uses note from jecstools source code to point out that GetComp<CompPolymorph>() is slower than a for loop checking for is CompPolymorph. Speed tests show a difference of average .8 ms to .3 ms on 4 times speed with dubs performance analyzer