### PR TITLE
focuses on improving readability of  Pawn_HealthTracker postfix…

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
@@ -8,6 +8,7 @@ using Verse;
 using Verse.AI;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using TorannMagic.TMDefs;
 using TorannMagic.Golems;
 
@@ -825,7 +826,7 @@ namespace TorannMagic.AutoCast
                 if (!inCombat && jobTarget != null && jobTarget.Thing != null)
                 {
                     Pawn transferPawn = jobTarget.Thing as Pawn;
-                    CompAbilityUserMagic tComp = transferPawn.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic tComp = transferPawn.GetCompAbilityUserMagic();
                     if (reverse)
                     {                        
                         if(casterComp.Mana.CurLevel >= .3f || tComp.Mana.CurLevel <= .9f)
@@ -1052,7 +1053,7 @@ namespace TorannMagic.AutoCast
                 if (jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
                 {
                     Pawn targetPawn = jobTarget.Thing as Pawn;
-                    CompAbilityUserMagic targetPawnComp = targetPawn.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic targetPawnComp = targetPawn.GetCompAbilityUserMagic();
                     if (targetPawn.CurJobDef.joyKind != null || targetPawn.CurJobDef == JobDefOf.Wait_Wander || targetPawn.CurJobDef == JobDefOf.GotoWander)
                     {
                         if (targetPawn.IsColonist && targetPawnComp.MagicUserLevel < casterComp.MagicUserLevel && caster.relations.OpinionOf(targetPawn) >= 0)
@@ -1086,7 +1087,7 @@ namespace TorannMagic.AutoCast
                 if (jobTarget != null && jobTarget.Thing != null && jobTarget.Thing is Pawn && (jobTarget.Cell - caster.Position).LengthHorizontal < (abilitydef.MainVerb.range * 1.5f))
                 {
                     Pawn targetPawn = jobTarget.Thing as Pawn;
-                    CompAbilityUserMight targetPawnComp = targetPawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight targetPawnComp = targetPawn.GetCompAbilityUserMight();
                     if ((targetPawn.CurJobDef.joyKind != null && targetPawn.CurJobDef != TorannMagicDefOf.JobDriver_TM_Meditate) || targetPawn.CurJobDef == JobDefOf.Wait_Wander || targetPawn.CurJobDef == JobDefOf.GotoWander)
                     {
                         if (targetPawn.IsColonist && targetPawnComp.MightUserLevel < casterComp.MightUserLevel && caster.relations.OpinionOf(targetPawn) >= 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_60mmMortar.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_60mmMortar.cs
@@ -9,6 +9,7 @@ using Verse.AI;
 using UnityEngine;
 using Verse.Sound;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -65,10 +66,10 @@ namespace TorannMagic
 
                 if (!initialized)
                 {
-                    comp = mannableComp.ManningPawn.GetComp<CompAbilityUserMight>();
-                    this.verVal = mannableComp.ManningPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_60mmMortar.FirstOrDefault((MightPowerSkill x) => x.label == "TM_60mmMortar_ver").level;
-                    this.pwrVal = mannableComp.ManningPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_60mmMortar.FirstOrDefault((MightPowerSkill x) => x.label == "TM_60mmMortar_pwr").level;
-                    this.effVal = mannableComp.ManningPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_60mmMortar.FirstOrDefault((MightPowerSkill x) => x.label == "TM_60mmMortar_eff").level;
+                    comp = mannableComp.ManningPawn.GetCompAbilityUserMight();
+                    this.verVal = mannableComp.ManningPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_60mmMortar.FirstOrDefault((MightPowerSkill x) => x.label == "TM_60mmMortar_ver").level;
+                    this.pwrVal = mannableComp.ManningPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_60mmMortar.FirstOrDefault((MightPowerSkill x) => x.label == "TM_60mmMortar_pwr").level;
+                    this.effVal = mannableComp.ManningPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_60mmMortar.FirstOrDefault((MightPowerSkill x) => x.label == "TM_60mmMortar_eff").level;
                     this.mortarTicksToFire = Find.TickManager.TicksGame + (300);
                     this.mortarMaxRange += (verVal * 10);
                     if(verVal >= 3)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
@@ -4,6 +4,7 @@ using Verse;
 using Verse.Sound;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI;
 using Verse.AI.Group;
@@ -184,7 +185,7 @@ namespace TorannMagic
                 for (int i = 0; i < pList.Count; i++)
                 {
                     Pawn p = pList[i];
-                    CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = p.GetCompAbilityUserMight();
                     if(comp != null && comp.combatItems != null && comp.combatItems.Count > 0)
                     {
                         if(comp.combatItems.Contains(this))

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMArcaneCapacitor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMArcaneCapacitor.cs
@@ -6,6 +6,7 @@ using Verse.AI;
 using System.Diagnostics;
 using UnityEngine;
 using RimWorld;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -67,7 +68,7 @@ namespace TorannMagic
         public override IEnumerable<FloatMenuOption> GetFloatMenuOptions(Pawn myPawn)
         {
             List<FloatMenuOption> list = new List<FloatMenuOption>();
-            CompAbilityUserMagic comp = myPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = myPawn.GetCompAbilityUserMagic();
             if (!myPawn.CanReach(this, PathEndMode.InteractionCell, Danger.Some, false, false, TraverseMode.ByPawn))
             {
                 list.Add(new FloatMenuOption("CannotUseNoPath".Translate(), null, MenuOptionPriority.Default, null, null, 0f, null, null));
@@ -127,7 +128,7 @@ namespace TorannMagic
                     pawn = mapPawns[i];
                     if(!pawn.DestroyedOrNull() && !pawn.Dead && !pawn.Downed && pawn.RaceProps.Humanlike && pawn.Faction != null && pawn.Faction == this.Faction)
                     {
-                        CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                         float rangeToTarget = (pawn.Position - this.Position).LengthHorizontal;
                         if (pawn.drafter != null && TM_Calc.IsMagicUser(pawn) &&  rangeToTarget <= effectRadius && comp != null && comp.Mana != null)
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMMagicCircleBase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMMagicCircleBase.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using UnityEngine;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -655,7 +656,7 @@ namespace TorannMagic
                     for (int i =0; i < magePawnsInRange.Count; i++)
                     {
                         Pawn p = magePawnsInRange[i];
-                        CompAbilityUserMagic comp = p.GetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                         if (p.Spawned && !p.Drafted && !p.InMentalState && p.GetPosture() == PawnPosture.Standing && p.workSettings.WorkIsActive(TorannMagicDefOf.TM_Magic) && comp != null && comp.Mana != null && comp.Mana.CurLevel >= manaReq)
                         {
                             pawnsAble.Add(p);
@@ -696,7 +697,7 @@ namespace TorannMagic
         //                    for (int i = 0; i < magePawnsInRange.Count; i++)
         //                    {
         //                        Pawn p = magePawnsInRange[i];
-        //                        CompAbilityUserMagic comp = p.GetComp<CompAbilityUserMagic>();
+        //                        CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
         //                        if (p != abilityUser.Pawn && p.workSettings.WorkIsActive(TorannMagicDefOf.TM_Magic) && comp != null && comp.Mana != null && comp.Mana.CurLevel >= manaReq && p.GetPosture() == PawnPosture.Standing && !p.InMentalState)
         //                        {
         //                            //Log.Message("" + p.LabelShort + " available to work recipe " + mrDef.defName);
@@ -784,7 +785,7 @@ namespace TorannMagic
                         this.magicRecipeDef = allPawns[i].CurJob.bill.recipe as MagicRecipeDef;
                         //Log.Message("checking mages available: " + mages.Count);
                        
-                        //CanDoJob(allPawns[i].GetComp<CompAbilityUserMagic>(), allPawns[i].CurJob.bill.recipe as MagicRecipeDef, this);
+                        //CanDoJob(allPawns[i].GetCompAbilityUserMagic(), allPawns[i].CurJob.bill.recipe as MagicRecipeDef, this);
                     }
                 }
             }
@@ -796,7 +797,7 @@ namespace TorannMagic
             for (int i = 0; i < mages.Count; i++)
             {
                 //Log.Message("pawn " + i + " " + mages[i].LabelShort + " with job " + mages[i].CurJob);
-                CompAbilityUserMagic comp = mages[i].GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = mages[i].GetCompAbilityUserMagic();
                 if (comp != null && comp.Mana != null )
                 {
                     //Log.Message("" + comp.Pawn.LabelShort + " is ready");

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMPortal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMPortal.cs
@@ -6,6 +6,7 @@ using Verse.AI;
 using System.Diagnostics;
 using UnityEngine;
 using RimWorld;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -185,7 +186,7 @@ namespace TorannMagic
         public override IEnumerable<FloatMenuOption> GetFloatMenuOptions(Pawn myPawn)
         {
             List<FloatMenuOption> list = new List<FloatMenuOption>();
-            CompAbilityUserMagic comp = myPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = myPawn.GetCompAbilityUserMagic();
             if (!myPawn.CanReach(this, PathEndMode.InteractionCell, Danger.Some, false, false, TraverseMode.ByPawn))
             {
                 list.Add(new FloatMenuOption("CannotUseNoPath".Translate(), null, MenuOptionPriority.Default, null, null, 0f, null, null));

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMSentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMSentinel.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 using UnityEngine;
 using RimWorld;
 using AbilityUser;
-
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -49,7 +49,7 @@ namespace TorannMagic
                     {
                         if (!mapPawns[i].DestroyedOrNull() && mapPawns[i].Spawned && !mapPawns[i].Downed && mapPawns[i].RaceProps.Humanlike)
                         {
-                            CompAbilityUserMagic comp = mapPawns[i].GetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic comp = mapPawns[i].GetCompAbilityUserMagic();
                             if (comp.IsMagicUser && comp.summonedSentinels.Count > 0)
                             {
                                 for (int j = 0; j < comp.summonedSentinels.Count(); j++)
@@ -107,7 +107,7 @@ namespace TorannMagic
                             if (hostilePawn != null)
                             {
                                 SpawnSentinel();
-                                CompAbilityUserMagic comp = this.sustainerPawn.GetComp<CompAbilityUserMagic>();
+                                CompAbilityUserMagic comp = this.sustainerPawn.GetCompAbilityUserMagic();
                                 comp.summonedSentinels.Remove(this);
                                 comp.summonedSentinels.Add(this.newPawn as Thing);
                                 this.Destroy(DestroyMode.Vanish);

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TM_DMP.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TM_DMP.cs
@@ -6,6 +6,7 @@ using Verse.AI;
 using System.Diagnostics;
 using UnityEngine;
 using RimWorld;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -80,7 +81,7 @@ namespace TorannMagic
         public override IEnumerable<FloatMenuOption> GetFloatMenuOptions(Pawn myPawn)
         {
             List<FloatMenuOption> list = new List<FloatMenuOption>();
-            CompAbilityUserMagic comp = myPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = myPawn.GetCompAbilityUserMagic();
             if (!myPawn.CanReach(this, PathEndMode.InteractionCell, Danger.Some, false, false, TraverseMode.ByPawn))
             {
                 list.Add(new FloatMenuOption("CannotUseNoPath".Translate(), null, MenuOptionPriority.Default, null, null, 0f, null, null));
@@ -158,7 +159,7 @@ namespace TorannMagic
                     pawn = mapPawns[i];
                     if(!pawn.DestroyedOrNull() && pawn.Spawned && !pawn.Dead && !pawn.Downed && pawn.RaceProps != null && !pawn.AnimalOrWildMan() && pawn.RaceProps.Humanlike && pawn.Faction != null && pawn.Faction == this.Faction)
                     {
-                        CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                         float rangeToTarget = (pawn.Position - this.Position).LengthHorizontal;
                         if (pawn.drafter != null && TM_Calc.IsMagicUser(pawn) && rangeToTarget <= effectRadius && comp != null && comp.Mana != null)
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TechnoTurret.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TechnoTurret.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 using UnityEngine;
@@ -77,7 +78,7 @@ namespace TorannMagic
             {
                 if (!initialized)
                 {
-                    comp = manPawn.GetComp<CompAbilityUserMagic>();
+                    comp = manPawn.GetCompAbilityUserMagic();
                     this.verVal = comp.MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoTurret_ver").level;
                     this.pwrVal = comp.MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoTurret_pwr").level;
                     this.effVal = comp.MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoTurret_eff").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -10,6 +10,7 @@ using Verse;
 using Verse.AI;
 using Verse.Sound;
 using AbilityUserAI;
+using TorannMagic.Extensions;
 using TorannMagic.Ideology;
 
 namespace TorannMagic
@@ -5463,7 +5464,7 @@ namespace TorannMagic
                 }
                 else if(this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    CompAbilityUserMight compMight = this.Pawn.TryGetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight compMight = this.Pawn.GetCompAbilityUserMight();
                     adjustedManaCost *= 1f - (magicDef.efficiencyReductionPercent * compMight.MightData.GetSkill_Efficiency(TorannMagicDefOf.TM_Mimic).level);
                 }
                 else
@@ -5823,7 +5824,7 @@ namespace TorannMagic
             //CompAbilityUserMight compMight = null;
             //if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    compMight = this.Pawn.TryGetComp<CompAbilityUserMight>();
+            //    compMight = this.Pawn.GetCompAbilityUserMight();
             //}
             if (settingsRef.autocastEnabled && this.Pawn.jobs != null && this.Pawn.CurJob != null && this.Pawn.CurJob.def != TorannMagicDefOf.TMCastAbilityVerb && this.Pawn.CurJob.def != TorannMagicDefOf.TMCastAbilitySelf && 
                 this.Pawn.CurJob.def != JobDefOf.Ingest && this.Pawn.CurJob.def != JobDefOf.ManTurret && this.Pawn.GetPosture() == PawnPosture.Standing && !this.Pawn.CurJob.playerForced && !this.Pawn.Map.GameConditionManager.ConditionIsActive(TorannMagicDefOf.ManaDrain) && !this.Pawn.Map.GameConditionManager.ConditionIsActive(TorannMagicDefOf.TM_ManaStorm))
@@ -8063,7 +8064,7 @@ namespace TorannMagic
             {
                 if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Bard))
                 {
-                    MagicPowerSkill bardtraining_pwr = this.Pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BardTraining.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BardTraining_pwr");
+                    MagicPowerSkill bardtraining_pwr = this.Pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BardTraining.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BardTraining_pwr");
 
                     List<Trait> traits = this.Pawn.story.traits.allTraits;
                     for (int i = 0; i < traits.Count; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
@@ -10,6 +10,7 @@ using Verse.AI;
 using UnityEngine;
 using System.Text;
 using CompDeflector;
+using TorannMagic.Extensions;
 using TorannMagic.Ideology;
 
 namespace TorannMagic
@@ -245,7 +246,7 @@ namespace TorannMagic
 
             if (this.customClass != null)
             {
-                CompAbilityUserMagic mComp = this.Pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic mComp = this.Pawn.GetCompAbilityUserMagic();
                 bool shouldDraw = true;
                 if(mComp != null)
                 {
@@ -3193,7 +3194,7 @@ namespace TorannMagic
         public void SiphonReversal(int verVal)
         {
             Pawn pawn = this.Pawn;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             comp.Stamina.CurLevel += (.015f * verVal);         
             int num = 1 + verVal;
             using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
@@ -4449,7 +4450,7 @@ namespace TorannMagic
             {                
                 if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Bladedancer))
                 {
-                    MightPowerSkill bladefocus_pwr = this.Pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BladeFocus.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeFocus_pwr");
+                    MightPowerSkill bladefocus_pwr = this.Pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BladeFocus.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeFocus_pwr");
 
                     List<Trait> traits = this.Pawn.story.traits.allTraits;
                     for (int i = 0; i < traits.Count; i++)
@@ -4505,7 +4506,7 @@ namespace TorannMagic
 
                 if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Sniper))
                 {
-                    MightPowerSkill sniperfocus_pwr = this.Pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_SniperFocus.FirstOrDefault((MightPowerSkill x) => x.label == "TM_SniperFocus_pwr");
+                    MightPowerSkill sniperfocus_pwr = this.Pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_SniperFocus.FirstOrDefault((MightPowerSkill x) => x.label == "TM_SniperFocus_pwr");
 
                     List<Trait> traits = this.Pawn.story.traits.allTraits;
                     for (int i = 0; i < traits.Count; i++)
@@ -4533,7 +4534,7 @@ namespace TorannMagic
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 if ((this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Bladedancer) || (this.customClass != null && this.customClass.classFighterAbilities.Contains(TorannMagicDefOf.TM_BladeArt))) && !this.Pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_BladeArtHD))
                 {
-                    MightPowerSkill bladeart_pwr = this.Pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BladeArt.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeArt_pwr");
+                    MightPowerSkill bladeart_pwr = this.Pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BladeArt.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeArt_pwr");
 
                     //HealthUtility.AdjustSeverity(this.Pawn, TorannMagicDefOf.TM_BladeArtHD, -5f);
                     HealthUtility.AdjustSeverity(this.Pawn, TorannMagicDefOf.TM_BladeArtHD, (.5f) + bladeart_pwr.level);
@@ -4544,7 +4545,7 @@ namespace TorannMagic
                 }
                 if ((this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Ranger) || (this.customClass != null && this.customClass.classFighterAbilities.Contains(TorannMagicDefOf.TM_BowTraining))))
                 {                    
-                    MightPowerSkill bowtraining_pwr = this.Pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BowTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BowTraining_pwr");
+                    MightPowerSkill bowtraining_pwr = this.Pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BowTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BowTraining_pwr");
                     if (!this.Pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_BowTrainingHD))
                     {
                         //HealthUtility.AdjustSeverity(this.Pawn, TorannMagicDefOf.TM_BowTrainingHD, -5f);
@@ -4564,7 +4565,7 @@ namespace TorannMagic
 
                         if (rec.def == TorannMagicDefOf.TM_BladeArtHD && this.Pawn.IsColonist)
                         {
-                            MightPowerSkill bladeart_pwr = this.Pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BladeArt.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeArt_pwr");
+                            MightPowerSkill bladeart_pwr = this.Pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BladeArt.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeArt_pwr");
                             if (rec.Severity < (float)(.5f + bladeart_pwr.level) || rec.Severity > (float)(.6f + bladeart_pwr.level))
                             {
                                 HealthUtility.AdjustSeverity(this.Pawn, TorannMagicDefOf.TM_BladeArtHD, -5f);
@@ -4576,7 +4577,7 @@ namespace TorannMagic
 
                         if (rec.def == TorannMagicDefOf.TM_BowTrainingHD && this.Pawn.IsColonist)
                         {
-                            MightPowerSkill bowtraining_pwr = this.Pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BowTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BowTraining_pwr");
+                            MightPowerSkill bowtraining_pwr = this.Pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BowTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BowTraining_pwr");
                             if (rec.Severity < (float)(.5f + bowtraining_pwr.level) || rec.Severity > (float)(.6f + bowtraining_pwr.level))
                             {
                                 HealthUtility.AdjustSeverity(this.Pawn, TorannMagicDefOf.TM_BowTrainingHD, -5f);

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAnimalController.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using Verse.AI;
 using Verse.Sound;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -101,7 +102,7 @@ namespace TorannMagic
                 {
                     if (summonerPawn != null)
                     {
-                        CompAbilityUserMagic comp = summonerPawn.TryGetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMagic comp = summonerPawn.GetCompAbilityUserMagic();
                         if (comp != null)
                         {
                             verVal = TM_Calc.GetSkillVersatilityLevel(summonerPawn, TorannMagicDefOf.TM_GuardianSpirit);
@@ -163,7 +164,7 @@ namespace TorannMagic
                                     if(Rand.Chance(hexChance))
                                     {
                                         HealthUtility.AdjustSeverity(p, TorannMagicDefOf.TM_HexHD, 1f);
-                                        CompAbilityUserMagic bondedMagicComp = this.summonerPawn.TryGetComp<CompAbilityUserMagic>();
+                                        CompAbilityUserMagic bondedMagicComp = this.summonerPawn.GetCompAbilityUserMagic();
 
                                         if (bondedMagicComp != null && !bondedMagicComp.HexedPawns.Contains(p) && bondedMagicComp.MagicData != null && bondedMagicComp.MagicData.MagicPowersShaman.FirstOrDefault((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Hex).learned)
                                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompPolymorph.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompPolymorph.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using UnityEngine;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -66,7 +67,7 @@ namespace TorannMagic
         {
             get
             {                
-                return spawner.GetComp<CompAbilityUserMagic>();
+                return spawner.GetCompAbilityUserMagic();
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSentinel.cs
@@ -6,6 +6,7 @@ using RimWorld;
 using UnityEngine;
 using Verse.AI;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -293,7 +294,7 @@ namespace TorannMagic
                         }
                     }
                 }
-                CompAbilityUserMagic comp = this.sustainerPawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = this.sustainerPawn.GetCompAbilityUserMagic();
                 comp.summonedSentinels.Remove(this.Pawn);
                 comp.summonedSentinels.Add(spawnedThing);
                 DamageInfo dinfo = new DamageInfo(DamageDefOf.Blunt, 10*healthDeficit, 0, (float)-1, this.Pawn, null, null, DamageInfo.SourceCategory.ThingOrUnknown);

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSummoned.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSummoned.cs
@@ -1,5 +1,6 @@
 ﻿using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -37,7 +38,7 @@ namespace TorannMagic
         {
             get
             {
-                return spawner.GetComp<CompAbilityUserMagic>();
+                return spawner.GetCompAbilityUserMagic();
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_ClassExtraction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_ClassExtraction.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using TorannMagic.Enchantment;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -11,8 +12,8 @@ namespace TorannMagic
     {
         public override void DoEffect(Pawn user)
         {
-            CompAbilityUserMagic compMagic = user.GetComp<CompAbilityUserMagic>();
-            CompAbilityUserMight compMight = user.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMagic compMagic = user.GetCompAbilityUserMagic();
+            CompAbilityUserMight compMight = user.GetCompAbilityUserMight();
             int essenceXP = 0;
             if(compMagic != null && compMagic.IsMagicUser && compMagic.MagicUserXP != 0 && compMagic.MagicData != null)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_Essence.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_Essence.cs
@@ -3,6 +3,7 @@ using Verse;
 using System.Collections.Generic;
 using System.Linq;
 using TorannMagic.Enchantment;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -13,8 +14,8 @@ namespace TorannMagic
         public override float OrderPriority => -800f;
         public override void DoEffect(Pawn user)
         {
-            CompAbilityUserMagic compMagic = user.GetComp<CompAbilityUserMagic>();
-            CompAbilityUserMight compMight = user.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMagic compMagic = user.GetCompAbilityUserMagic();
+            CompAbilityUserMight compMight = user.GetCompAbilityUserMight();
 
             if(this.parent.def == TorannMagicDefOf.TM_MagicArtifact_MightEssence && compMight != null && compMight.IsMightUser)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_GemOfInsight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_GemOfInsight.cs
@@ -2,6 +2,7 @@
 using Verse;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -9,8 +10,8 @@ namespace TorannMagic
     {
         public override void DoEffect(Pawn user)
         {
-            CompAbilityUserMight compMight = user.GetComp<CompAbilityUserMight>();
-            CompAbilityUserMagic compMagic = user.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMight compMight = user.GetCompAbilityUserMight();
+            CompAbilityUserMagic compMagic = user.GetCompAbilityUserMagic();
 
             if(!(compMagic.IsMagicUser || compMight.IsMightUser || user.story.traits.HasTrait(TorannMagicDefOf.TM_Gifted) || user.story.traits.HasTrait(TorannMagicDefOf.PhysicalProdigy) || user.story.traits.HasTrait(TorannMagicDefOf.Undead)))
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_LearnMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_LearnMagic.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using Verse;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 
@@ -32,7 +33,7 @@ namespace TorannMagic
                             ApplyTraitAdjustments(user, TM_ClassUtility.CustomClasses()[i].classTrait);
                             //
                             this.parent.SplitOff(1).Destroy(DestroyMode.Vanish);
-                            CompAbilityUserMagic comp = user.TryGetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic comp = user.GetCompAbilityUserMagic();
                             if (comp != null)
                             {
                                 comp.customIndex = i;
@@ -42,7 +43,7 @@ namespace TorannMagic
                             {
                                 Log.Message("failed to initialize custom magic class comp");
                             }
-                            CompAbilityUserMight mComp = user.TryGetComp<CompAbilityUserMight>();
+                            CompAbilityUserMight mComp = user.GetCompAbilityUserMight();
                             if (mComp != null && TM_ClassUtility.CustomClasses()[i].isFighter)
                             {
                                 mComp.customIndex = i;

--- a/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_LearnMight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_LearnMight.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using Verse;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -32,7 +33,7 @@ namespace TorannMagic
                             ApplyTraitAdjustments(user, TM_ClassUtility.CustomClasses()[i].classTrait);
                             //
                             this.parent.SplitOff(1).Destroy(DestroyMode.Vanish);
-                            CompAbilityUserMight comp = user.TryGetComp<CompAbilityUserMight>();
+                            CompAbilityUserMight comp = user.GetCompAbilityUserMight();
                             if (comp != null)
                             {
                                 comp.customIndex = i;
@@ -42,7 +43,7 @@ namespace TorannMagic
                             {
                                 Log.Message("failed to initialize custom might class comp");
                             }
-                            CompAbilityUserMagic mComp = user.TryGetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic mComp = user.GetCompAbilityUserMagic();
                             if(mComp != null && TM_ClassUtility.CustomClasses()[i].isMage)
                             {
                                 mComp.customIndex = i;
@@ -59,7 +60,7 @@ namespace TorannMagic
                         FixTrait(user, user.story.traits.allTraits);
                         user.story.traits.GainTrait(new Trait(TorannMagicDefOf.Gladiator, 0, false));
                         this.parent.SplitOff(1).Destroy(DestroyMode.Vanish);
-                        CompAbilityUserMight comp = user.GetComp<CompAbilityUserMight>();
+                        CompAbilityUserMight comp = user.GetCompAbilityUserMight();
                         comp.skill_Sprint = true;
                     }
                     else if (parent.def.defName == "BookOfSniper")

--- a/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_LearnSkill.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_LearnSkill.cs
@@ -2,6 +2,7 @@
 using Verse;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -9,7 +10,7 @@ namespace TorannMagic
     {
         public override void DoEffect(Pawn user)
         {
-            CompAbilityUserMight comp = user.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = user.GetCompAbilityUserMight();
 
             if (parent.def != null && (TM_Calc.IsMightUser(user) || TM_Calc.IsWayfarer(user)))
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_LearnSpell.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_LearnSpell.cs
@@ -2,6 +2,7 @@
 using Verse;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -9,7 +10,7 @@ namespace TorannMagic
     {
         public override void DoEffect(Pawn user)
         {
-            CompAbilityUserMagic comp = user.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = user.GetCompAbilityUserMagic();
             MagicPower magicPower;
             if (parent.def != null && (TM_Calc.IsMagicUser(user) || TM_Calc.IsWanderer(user)))
             {                

--- a/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_SpiritBinding.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompUseEffect_SpiritBinding.cs
@@ -2,6 +2,7 @@
 using Verse;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -9,7 +10,7 @@ namespace TorannMagic
     {
         public override void DoEffect(Pawn user)
         {
-            CompAbilityUserMagic comp = user.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = user.GetCompAbilityUserMagic();
 
             if (parent.def != null && (TM_Calc.IsMagicUser(user) || TM_Calc.IsWanderer(user)))
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_ManaDrain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/GameCondition_ManaDrain.cs
@@ -3,6 +3,7 @@ using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -38,7 +39,7 @@ namespace TorannMagic
                 pawn = victims.ToArray<Pawn>()[i];
                 if (pawn != null)
                 {
-                    CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                     if (comp != null && comp.IsMagicUser && comp.Mana != null)
                     {
                         if ( comp.Mana.CurLevel == 1)

--- a/RimWorldOfMagic/RimWorldOfMagic/Conditions/IncidentWorker_ArcaneSickness.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Conditions/IncidentWorker_ArcaneSickness.cs
@@ -3,6 +3,7 @@ using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -23,7 +24,7 @@ namespace TorannMagic
                 {
                     break;
                 }
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp.IsMagicUser)
                 {
                     HediffGiverUtility.TryApply(pawn, this.def.diseaseIncident, this.def.diseasePartsToAffect, false, 1, null);
@@ -51,7 +52,7 @@ namespace TorannMagic
                 {
                     return false;
                 }
-                CompAbilityUserMagic comp = p.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 if (comp != null && !comp.IsMagicUser)
                 {
                     return false;

--- a/RimWorldOfMagic/RimWorldOfMagic/Effect_DragonStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Effect_DragonStrike.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using RimWorld;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -48,7 +49,7 @@ namespace TorannMagic
             //    pwrVal = mpwr.level;
             //}
             Pawn casterPawn = base.CasterPawn;
-            CompAbilityUserMight comp = this.CasterPawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.CasterPawn.GetCompAbilityUserMight();
             int pwrVal = TM_Calc.GetSkillPowerLevel(casterPawn, this.Ability.Def as TMAbilityDef, false);
             if (comp != null)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Effect_LightLance.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Effect_LightLance.cs
@@ -3,6 +3,7 @@ using AbilityUser;
 using System.Collections.Generic;
 using RimWorld;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {    
@@ -51,7 +52,7 @@ namespace TorannMagic
             int shotCount = 3;
             if(!base.CasterPawn.DestroyedOrNull())
             {
-                CompAbilityUserMagic comp = base.CasterPawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = base.CasterPawn.GetCompAbilityUserMagic();
                 if (comp != null)
                 {
                     //shotCount -= TM_Calc.GetMagicSkillLevel(base.CasterPawn, comp.MagicData.MagicPowerSkill_LightLance, "TM_LightLance", "_pwr", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Effect_SpiritOfLight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Effect_SpiritOfLight.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using System.Collections.Generic;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {    
@@ -11,7 +12,7 @@ namespace TorannMagic
 
         public virtual void Effect()
         {
-            CompAbilityUserMagic comp = CasterPawn.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = CasterPawn.GetCompAbilityUserMagic();
             if (comp.SoL != null)
             {
                 comp.SoL.shouldDismiss = true;

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/HediffComp_Enchantment.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/HediffComp_Enchantment.cs
@@ -2,6 +2,7 @@
 using RimWorld;
 using System.Linq;
 using System.Text;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Enchantment
 {
@@ -94,8 +95,8 @@ namespace TorannMagic.Enchantment
             }
             if(Find.TickManager.TicksGame % 120 == 0)
             {
-                compMagic = this.Pawn.GetComp<CompAbilityUserMagic>();
-                compMight = this.Pawn.GetComp<CompAbilityUserMight>();
+                compMagic = this.Pawn.GetCompAbilityUserMagic();
+                compMight = this.Pawn.GetCompAbilityUserMight();
                 DetermineEnchantments();
             }
             if(Find.TickManager.TicksGame % 480 == 0 && this.enchantment == "unknown")

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/JobDriver_EnchantItem.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/JobDriver_EnchantItem.cs
@@ -3,6 +3,7 @@ using Verse.AI;
 using Verse;
 using RimWorld;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using Verse.Sound;
 
 namespace TorannMagic.Enchantment
@@ -118,7 +119,7 @@ namespace TorannMagic.Enchantment
             {
                 CompEnchantedItem enchantment = thing.TryGetComp<CompEnchantedItem>();            
                 CompEnchant enchantingItem = actor.TryGetComp<CompEnchant>();
-                CompAbilityUserMagic pawnComp = actor.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic pawnComp = actor.GetCompAbilityUserMagic();
                 if (enchantment != null && enchantingItem != null && enchanting.actor.jobs.curDriver.ticksLeftThisToil < 1)
                 {
                     if (EnchantItem(enchantingItem.enchantingContainer[0], enchantment))

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_OrbTraitor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic.Enchantment
@@ -36,7 +37,7 @@ namespace TorannMagic.Enchantment
         protected override bool TryCastShot()
         {
             bool result = false;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             if (this.currentTarget != null && base.CasterPawn != null && comp != null)
             {
                 if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
@@ -121,7 +122,7 @@ namespace TorannMagic.Enchantment
                         }
                     }
                 }
-                CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
                 if(comp != null)
                 {
                     comp.RemovePawnAbility(TorannMagicDefOf.TM_Artifact_Conviction);

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_WeaponWintersFury.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/Verb_WeaponWintersFury.cs
@@ -5,6 +5,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using TorannMagic.Conditions;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Enchantment
 {
@@ -15,7 +16,7 @@ namespace TorannMagic.Enchantment
         {
             Map map = base.CasterPawn.Map;
             WeatherDef rainMakerDef = new WeatherDef();
-            CompAbilityUserMagic comp = base.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = base.CasterPawn.GetCompAbilityUserMagic();
             if (map != null && map.weatherManager != null && comp != null && comp.MagicData != null)
             {
                 MagicMapComponent mmc = map.GetComponent<MagicMapComponent>();

--- a/RimWorldOfMagic/RimWorldOfMagic/Extensions/ThingWithCompsExtensions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Extensions/ThingWithCompsExtensions.cs
@@ -1,0 +1,32 @@
+using AbilityUser;
+using Verse;
+
+namespace TorannMagic.Extensions
+{
+    public static class ThingWithCompsExtensions
+    {
+        // Non-generic GetComp<CompAbilityUserMagic> for performance since isInst against generic T is slow
+        public static CompAbilityUserMagic GetCompAbilityUserMagic(this ThingWithComps thingWithComps)
+        {
+            for (int i = 0; i < thingWithComps.AllComps.Count; i++)
+            {
+                if (thingWithComps.AllComps[i] is CompAbilityUserMagic comp)
+                    return comp;
+            }
+
+            return default;
+        }
+
+        // Non-generic GetComp<CompAbilityUserMight> for performance since isInst against generic T is slow
+        public static CompAbilityUserMight GetCompAbilityUserMight(this ThingWithComps thingWithComps)
+        {
+            for (int i = 0; i < thingWithComps.AllComps.Count; i++)
+            {
+                if (thingWithComps.AllComps[i] is CompAbilityUserMight comp)
+                    return comp;
+            }
+
+            return default;
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DeathBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DeathBolt.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -120,7 +121,7 @@ namespace TorannMagic
                 FleckMaker.Static(this.origin, this.Map, FleckDefOf.ExplosionFlash, 12f);
                 SoundDefOf.Ambient_AltitudeWind.sustainFadeoutTime.Equals(30.0f);
                 FleckMaker.ThrowDustPuff(this.origin, this.Map, Rand.Range(1.2f, 1.8f));
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp != null && comp.PowerModifier > 0)
                 {
                     this.arcaneDmg += .2f;
@@ -146,7 +147,7 @@ namespace TorannMagic
         {
             bool spawned = flyingThing.Spawned;
             this.pawn = launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if (comp != null)
             {
                 foreach (MagicPower current in comp.MagicData.MagicPowersN)
@@ -174,8 +175,8 @@ namespace TorannMagic
                 this.arcaneDmg = comp.arcaneDmg;
                 pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_DeathBolt, true);
                 verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_DeathBolt, true);
-                //MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_DeathBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_DeathBolt_pwr");
-                //MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_DeathBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_DeathBolt_ver");
+                //MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_DeathBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_DeathBolt_pwr");
+                //MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_DeathBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_DeathBolt_ver");
                 //verVal = ver.level;
                 //pwrVal = pwr.level;
                 //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DirtDevil.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DirtDevil.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -130,7 +131,7 @@ namespace TorannMagic
         {
             bool spawned = flyingThing.Spawned;
             pawn = launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if (comp != null)
             {
                 if (comp.MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level >= 3)

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DragonStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DragonStrike.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -134,7 +135,7 @@ namespace TorannMagic
             bool spawned = flyingThing.Spawned;            
             pawn = launcher as Pawn;
             drafted = pawn.Drafted;
-            comp = pawn.GetComp<CompAbilityUserMight>();
+            comp = pawn.GetCompAbilityUserMight();
             verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_DragonStrike, true);
             //verVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_DragonStrike, "TM_DragonStrike", "_ver", true);
             //this.verVal = comp.MightData.MightPowerSkill_DragonStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_DragonStrike_ver").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_EyeOfTheStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_EyeOfTheStorm.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -147,12 +148,12 @@ namespace TorannMagic
         {
             bool spawned = flyingThing.Spawned;
             pawn = launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             this.arcaneDmg = comp.arcaneDmg;
             verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_EyeOfTheStorm, false);
             pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_EyeOfTheStorm, false);
-            //MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EyeOfTheStorm_pwr");
-            //MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EyeOfTheStorm_ver");
+            //MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EyeOfTheStorm_pwr");
+            //MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EyeOfTheStorm_ver");
             //verVal = ver.level;
             //pwrVal = pwr.level;
             //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Flight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Flight.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -121,7 +122,7 @@ namespace TorannMagic
             bool spawned = flyingThing.Spawned;            
             pawn = launcher as Pawn;
             drafted = pawn.Drafted;
-            comp = pawn.GetComp<CompAbilityUserMagic>();
+            comp = pawn.GetCompAbilityUserMagic();
 
             if (spawned)
             {               

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightLance.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightLance.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -119,7 +120,7 @@ namespace TorannMagic
             if (pawn != null)
             {
                 GetFilteredList();
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if(comp != null)
                 {
                     //pwrVal = comp.MagicData.MagicPowerSkill_LightLance.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightLance_pwr").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightningTrap.cs
@@ -149,10 +149,10 @@ namespace TorannMagic
             bool spawned = flyingThing.Spawned;
             pawn = launcher as Pawn;
             this.speed = _speed;
-            //CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            //CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             //this.arcaneDmg = comp.arcaneDmg;
-            //MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EyeOfTheStorm_pwr");
-            //MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EyeOfTheStorm_ver");
+            //MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EyeOfTheStorm_pwr");
+            //MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EyeOfTheStorm_ver");
             //verVal = ver.level;
             //pwrVal = pwr.level;
             //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LivingWall.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LivingWall.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -515,7 +516,7 @@ namespace TorannMagic
         {
             if (!CasterPawn.DestroyedOrNull() && !CasterPawn.Dead)
             {
-                CompAbilityUserMagic comp = CasterPawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = CasterPawn.GetCompAbilityUserMagic();
                 //int verVal = TM_Calc.GetMagicSkillLevel(CasterPawn, comp.MagicData.MagicPowerSkill_LivingWall, "TM_LivingWall", "_ver", true);
                 //int pwrVal = TM_Calc.GetMagicSkillLevel(CasterPawn, comp.MagicData.MagicPowerSkill_LivingWall, "TM_LivingWall", "_pwr", true);
                 int verVal = TM_Calc.GetSkillVersatilityLevel(CasterPawn, TorannMagicDefOf.TM_LivingWall, true);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsiStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsiStorm.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
@@ -140,11 +141,11 @@ namespace TorannMagic
             bool spawned = flyingThing.Spawned;
             pawn = launcher as Pawn;
             
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             this.arcaneDmg = comp.mightPwr;
-            //MightPowerSkill pwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_pwr");
-            //MightPowerSkill ver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_ver");
+            //MightPowerSkill pwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_pwr");
+            //MightPowerSkill ver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_ver");
             //verVal = ver.level;
             //pwrVal = pwr.level;
             verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_PsionicStorm, false);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicDash.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicDash.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UnityEngine;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -117,7 +118,7 @@ namespace TorannMagic
                 FleckMaker.Static(this.origin, this.Map, FleckDefOf.ExplosionFlash, 12f);
                 SoundDefOf.Ambient_AltitudeWind.sustainFadeoutTime.Equals(30.0f);
                 FleckMaker.ThrowDustPuff(this.origin, this.Map, Rand.Range(1.2f, 1.8f));
-                CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                 verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_PsionicDash, false);
                 pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_PsionicDash, false);
                 //verVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_PsionicDash, "TM_PsionicDash", "_ver", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicLeap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicLeap.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using Verse;
 using Verse.AI;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -136,7 +137,7 @@ namespace TorannMagic
             pawn = launcher as Pawn;
             this.oldjobTarget = pawn.CurJob.targetA.Thing;
             //Log.Message("pre leap target is " + this.oldjobTarget.LabelShort);
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             this.effVal = TM_Calc.GetSkillEfficiencyLevel(pawn, TorannMagicDefOf.TM_PsionicAugmentation, false); //comp.MightData.MightPowerSkill_PsionicAugmentation.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicAugmentation_eff").level;
             if (spawned)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicStorm.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using Verse;
 using Verse.Sound;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -135,7 +136,7 @@ namespace TorannMagic
                 this.targetCells = new List<IntVec3>();
                 this.targetCells.Clear();
                 this.targetCells = GenRadial.RadialCellsAround(this.targetCenter.ToIntVec3(), 4, true).ToList();
-                this.verVal = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_ver").level;
+                this.verVal = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_ver").level;
             }
             //flyingThing.ThingID += Rand.Range(0, 2147).ToString();
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ShadowBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ShadowBolt.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
@@ -150,22 +151,22 @@ namespace TorannMagic
         {
             bool spawned = flyingThing.Spawned;
             pawn = launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
 
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
 
             this.arcaneDmg = comp.arcaneDmg;
             pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_ShadowBolt, true);
             verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_ShadowBolt, true);
-            //MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ShadowBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ShadowBolt_pwr");
-            //MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ShadowBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ShadowBolt_ver");
+            //MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ShadowBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ShadowBolt_pwr");
+            //MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ShadowBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ShadowBolt_ver");
             //verVal = ver.level;
             //pwrVal = pwr.level;
             
             //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
             //}

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritOfLight.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using Verse;
 using Verse.Sound;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -462,7 +463,7 @@ namespace TorannMagic
         {
             if (!pawn.DestroyedOrNull())
             {
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 comp.SoL = null;
             }
             base.Destroy(mode);
@@ -495,7 +496,7 @@ namespace TorannMagic
         {
             if(!pawn.DestroyedOrNull() && pawn.Spawned)
             {
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if(comp != null && comp.IsMagicUser)
                 {
                     //pwrVal = TM_Calc.GetMagicSkillLevel(pawn, comp.MagicData.MagicPowerSkill_SpiritOfLight, "TM_SpiritOfLight", "_pwr");

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritWolves.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritWolves.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 using Verse.Sound;
@@ -101,7 +102,7 @@ namespace TorannMagic
                 FleckMaker.ThrowDustPuff(this.origin, this.Map, Rand.Range(1.2f, 1.8f));
                 GetVector();
                 this.angle = (Quaternion.AngleAxis(90, Vector3.up) * this.direction).ToAngleFlat();
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if(comp != null && comp.IsMagicUser)
                 {
                     //verVal = TM_Calc.GetMagicSkillLevel(pawn, comp.MagicData.MagicPowerSkill_SpiritWolves, "TM_SpiritWolves", "_ver", true);
@@ -266,7 +267,7 @@ namespace TorannMagic
             bool addAbilities = false;
             if (pawn != null)
             {
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 for (int i = 0; i < effectRadial.Count(); i++)
                 {
                     curCell = effectRadial.ToArray<IntVec3>()[i];

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ValiantCharge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ValiantCharge.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -160,18 +161,18 @@ namespace TorannMagic
             bool spawned = flyingThing.Spawned;
             this.pawn = launcher as Pawn;
             pawn.health.AddHediff(invul, null, null);
-            comp = pawn.GetComp<CompAbilityUserMagic>();
+            comp = pawn.GetCompAbilityUserMagic();
             pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_ValiantCharge);
             verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_ValiantCharge);
-            //pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ValiantCharge_pwr");
-            //ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ValiantCharge_ver");
+            //pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ValiantCharge_pwr");
+            //ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ValiantCharge_ver");
             //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             //pwrVal = pwr.level;
             //verVal = ver.level;
             //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
             //}

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Whirlwind.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Whirlwind.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UnityEngine;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -226,7 +227,7 @@ namespace TorannMagic
                             {
                                 cleaveVictim.TakeDamage(dinfo);
                                 FleckMaker.ThrowMicroSparks(cleaveVictim.Position.ToVector3(), base.Map);
-                                CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                                 verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_Whirlwind);
                                 //verVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_Whirlwind, "TM_Whirlwind", "_ver", true);
                                 //MightPowerSkill ver = comp.MightData.MightPowerSkill_Whirlwind.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Whirlwind_ver");
@@ -254,7 +255,7 @@ namespace TorannMagic
         public static int GetWeaponDmg(Pawn caster)
         {
             
-            CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             //MightPowerSkill pwr = comp.MightData.MightPowerSkill_Whirlwind.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Whirlwind_pwr");
             //pwrVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_Whirlwind, "TM_Whirlwind", "_pwr", true);
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, TorannMagicDefOf.TM_Whirlwind, true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Gizmo_EnergyStatus.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Gizmo_EnergyStatus.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Verse;
 using UnityEngine;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -41,8 +42,8 @@ namespace TorannMagic
         {
             if (!pawn.DestroyedOrNull() && !pawn.Dead)
             {
-                CompAbilityUserMagic compMagic = pawn.GetComp<CompAbilityUserMagic>();
-                CompAbilityUserMight compMight = pawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic();
+                CompAbilityUserMight compMight = pawn.GetCompAbilityUserMight();
 
                 bool isMage = compMagic.IsMagicUser && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless);
                 bool isFighter = compMight.IsMightUser;

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompGolem.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompGolem.cs
@@ -9,6 +9,7 @@ using Verse.AI.Group;
 using AbilityUser;
 using TorannMagic.TMDefs;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Golems
 {
@@ -609,7 +610,7 @@ namespace TorannMagic.Golems
         {
             if(!pawnMaster.DestroyedOrNull() && !pawnMaster.Dead)
             {
-                CompAbilityUserMagic masterComp = pawnMaster.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic masterComp = pawnMaster.GetCompAbilityUserMagic();
                 if(TM_Calc.IsMagicUser(pawnMaster) && masterComp != null && masterComp.MagicData != null && masterComp.MagicData.AllMagicPowersWithSkills.FirstOrDefault((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Golemancy).learned)
                 {
                     float pSev = .5f + masterComp.MagicData.GetSkill_Power(TorannMagicDefOf.TM_Golemancy).level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_Awakening.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_Awakening.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using Verse.Sound;
 using TorannMagic.TMDefs;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Golems
 {
@@ -65,7 +66,7 @@ namespace TorannMagic.Golems
                         }
 
                         verb.Ability.PostAbilityAttempt();
-                        CompAbilityUserMagic ecomp = enemyCaster.TryGetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMagic ecomp = enemyCaster.GetCompAbilityUserMagic();
                         if (ecomp != null)
                         {
                             for (int j = 0; j < ecomp.AbilityData.AllPowers.Count; j++)

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -520,7 +520,7 @@ namespace TorannMagic
                 if(by != null && by.health != null && by.health.hediffSet != null)
                 {
                     Pawn p = by;
-                    CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = p.GetCompAbilityUserMight();
                     Hediff_ApothecaryHerbs hd = p.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ApothecaryHerbsHD) as Hediff_ApothecaryHerbs;
                     if(hd != null)
                     {
@@ -1008,7 +1008,7 @@ namespace TorannMagic
             public static void Postfix(Pawn p, Thing from)
             {
                 float statValue = from.GetStatValue(StatDefOf.Comfort);
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 if (statValue >= 0f && comp != null && comp.Mana != null)
                 {
                     comp.Mana.CurLevel += .0001f * statValue;
@@ -1039,7 +1039,7 @@ namespace TorannMagic
             {
                 if (__instance != null && ___currentPlayer != null && Find.TickManager.TicksGame % 131 == 0)
                 {
-                    CompAbilityUserMagic comp = ___currentPlayer.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = ___currentPlayer.GetCompAbilityUserMagic();
                     if (comp != null && comp.MagicData != null && comp.IsMagicUser)
                     {
                         if (comp.MagicData.MagicPowersB.FirstOrDefault((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Entertain).learned)
@@ -1048,7 +1048,7 @@ namespace TorannMagic
                             {
                                 if (p.RaceProps.Humanlike && Building_MusicalInstrument.IsAffectedByInstrument(__instance.def, __instance.Position, p.Position, __instance.Map))
                                 {
-                                    CompAbilityUserMagic compListener = p.TryGetComp<CompAbilityUserMagic>();
+                                    CompAbilityUserMagic compListener = p.GetCompAbilityUserMagic();
                                     if (compListener != null && compListener.IsMagicUser && compListener.Mana != null)
                                     {
                                         compListener.Mana.CurLevel += .0075f;
@@ -1354,7 +1354,7 @@ namespace TorannMagic
         public static void PawnEquipment_Drop_Postfix(Pawn_EquipmentTracker __instance, ThingWithComps eq, ref bool __result)
         {
             Pawn p = __instance.pawn;
-            CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = p.GetCompAbilityUserMight();
             if (p != null && comp != null && (p.story.traits.HasTrait(TorannMagicDefOf.TM_SuperSoldier) || (comp.customClass != null)) && comp.equipmentContainer != null && __result)
             {
                 if (comp.equipmentContainer.Count > 0)
@@ -1379,7 +1379,7 @@ namespace TorannMagic
                 {
                     comp.weaponDamage = TM_Calc.GetSkillDamage(p);
                 }
-                CompAbilityUserMagic mComp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic mComp = p.GetCompAbilityUserMagic();
                 if (mComp != null)
                 {
                     mComp.weaponDamage = TM_Calc.GetSkillDamage(p);
@@ -1390,7 +1390,7 @@ namespace TorannMagic
         //public static void PawnEquipment_Transfer_Postfix(Pawn_EquipmentTracker __instance, ThingWithComps eq, ref bool __result)
         //{
         //    Pawn p = __instance.pawn;
-        //    CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
+        //    CompAbilityUserMight comp = p.GetCompAbilityUserMight();
         //    if (p != null && comp != null && p.story.traits.HasTrait(TorannMagicDefOf.TM_SuperSoldier) && __result)
         //    {
 
@@ -1402,7 +1402,7 @@ namespace TorannMagic
             if (!newEq.def.defName.Contains("Spec_Base"))
             {
                 Pawn p = __instance.pawn;
-                CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = p.GetCompAbilityUserMight();
                 if (p != null && comp != null && (p.story.traits.HasTrait(TorannMagicDefOf.TM_SuperSoldier) || (comp.customClass != null)))
                 {
                     if (comp.equipmentContainer == null)
@@ -1440,7 +1440,7 @@ namespace TorannMagic
                     {
                         comp.weaponDamage = TM_Calc.GetSkillDamage(p);
                     }
-                    CompAbilityUserMagic mComp = p.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic mComp = p.GetCompAbilityUserMagic();
                     if (mComp != null)
                     {
                         mComp.weaponDamage = TM_Calc.GetSkillDamage(p);
@@ -1581,7 +1581,7 @@ namespace TorannMagic
             {
                 if (recipient != null && initiator != null)
                 {
-                    CompAbilityUserMight comp = initiator.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = initiator.GetCompAbilityUserMight();
                     if (__instance.interaction == InteractionDefOf.Chitchat)
                     {
                         if (initiator.story != null && comp != null && initiator.story.traits != null && (initiator.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer) || TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_FieldTraining, null, comp)))
@@ -1808,7 +1808,7 @@ namespace TorannMagic
                                         {
                                             if (mapPawns[j].health != null && mapPawns[j].health.hediffSet != null && mapPawns[j].health.hediffSet.HasHediff(TorannMagicDefOf.TM_PredictionHD, false) && mapPawns[j].IsColonist)
                                             {
-                                                CompAbilityUserMagic comp = mapPawns[j].GetComp<CompAbilityUserMagic>();
+                                                CompAbilityUserMagic comp = mapPawns[j].GetCompAbilityUserMagic();
                                                 if (comp != null && comp.MagicData != null)
                                                 {
                                                     if (comp.predictionIncidentDef != null)
@@ -1837,7 +1837,7 @@ namespace TorannMagic
                                         }
                                         for (int j = 0; j < predictingPawnsAvailable.Count; j++)
                                         {
-                                            CompAbilityUserMagic comp = predictingPawnsAvailable[j].GetComp<CompAbilityUserMagic>();
+                                            CompAbilityUserMagic comp = predictingPawnsAvailable[j].GetCompAbilityUserMagic();
                                             MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_Prediction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Prediction_ver");
                                             if (__instance.CanFireNow(parms) && !ModOptions.Constants.GetBypassPrediction() && Rand.Chance(.25f + (.05f * ver.level))) //up to 40% chance to predict, per chronomancer
                                             {
@@ -1995,8 +1995,8 @@ namespace TorannMagic
             {
                 foreach (Pawn item in map.mapPawns.PawnsInFaction(Faction.OfPlayer))
                 {
-                    CompAbilityUserMagic compMagic = item.GetComp<CompAbilityUserMagic>();
-                    CompAbilityUserMight compMight = item.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMagic compMagic = item.GetCompAbilityUserMagic();
+                    CompAbilityUserMight compMight = item.GetCompAbilityUserMight();
                     if (compMight != null && compMight.IsMightUser)
                     {
                         wealthPawns += 400 + (compMight.MightUserLevel * 20);
@@ -2567,7 +2567,7 @@ namespace TorannMagic
                         Pawn pawn = mapPawns[i];
                         if (!pawn.DestroyedOrNull() && pawn.RaceProps.Humanlike && pawn.story != null)
                         {
-                            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                             if (comp.IsMagicUser && comp.overdriveBuilding != null)
                             {
                                 if (overdriveThing == comp.overdriveBuilding)
@@ -2601,7 +2601,7 @@ namespace TorannMagic
                     Pawn pawn = mapPawns[i];
                     if (!pawn.DestroyedOrNull() && pawn.RaceProps.Humanlike && pawn.story != null)
                     {
-                        CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                         if (comp.IsMagicUser && comp.overdriveBuilding != null)
                         {
                             if (overdriveThing == comp.overdriveBuilding)
@@ -2810,7 +2810,7 @@ namespace TorannMagic
             if (__instance.caster != null && __instance.caster is Pawn && __instance.Bursting)
             {
                 Pawn pawn = __instance.caster as Pawn;
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp != null && pawn.RaceProps.Humanlike && pawn.GetPosture() == PawnPosture.Standing && comp.HasTechnoWeapon && (pawn.story != null && pawn.story.traits != null &&
                     ((pawn.story.traits.HasTrait(TorannMagicDefOf.Technomancer) || pawn.story.traits.HasTrait(TorannMagicDefOf.ChaosMage) || TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_TechnoWeapon, comp, null)))) &&
                     comp.useElementalShotToggle && pawn.equipment.Primary.def.IsRangedWeapon && pawn.equipment.Primary.def.techLevel >= TechLevel.Industrial)
@@ -2878,12 +2878,12 @@ namespace TorannMagic
                 }
                 if (__instance.IsColonist)
                 {
-                    CompAbilityUserMight compMight = __instance.TryGetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight compMight = __instance.GetCompAbilityUserMight();
                     if (compMight == null && compMight.IsMightUser)
                     {
                         return;
                     }
-                    CompAbilityUserMagic compMagic = __instance.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic compMagic = __instance.GetCompAbilityUserMagic();
                     if (compMagic == null && compMagic.IsMagicUser)
                     {
                         return;
@@ -2953,8 +2953,8 @@ namespace TorannMagic
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             if (Find.Selector.NumSelected == 1)
             {
-                CompAbilityUserMagic compMagic = __instance.GetComp<CompAbilityUserMagic>();
-                CompAbilityUserMight compMight = __instance.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMagic compMagic = __instance.GetCompAbilityUserMagic();
+                CompAbilityUserMight compMight = __instance.GetCompAbilityUserMight();
                 var gizmoList = __result.ToList();
                 bool canBecomeClassless = false;
                 if (settingsRef.Wanderer && __instance.story.traits.HasTrait(TorannMagicDefOf.TM_Gifted))
@@ -3228,7 +3228,7 @@ namespace TorannMagic
                 bool result;
                 if (flag)
                 {
-                    CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                     bool flagChrono = comp != null && comp.IsMagicUser && comp.recallSet;
                     if (flagChrono || (dinfo.Value.Def == TMDamageDefOf.DamageDefOf.TM_DisablingBlow || dinfo.Value.Def == TMDamageDefOf.DamageDefOf.TM_Whirlwind || dinfo.Value.Def == TMDamageDefOf.DamageDefOf.TM_GrapplingHook || dinfo.Value.Def == TMDamageDefOf.DamageDefOf.TM_DisablingShot || dinfo.Value.Def == TMDamageDefOf.DamageDefOf.TM_Tranquilizer) || TM_Calc.IsUndeadNotVamp(pawn))
                     {
@@ -3383,8 +3383,8 @@ namespace TorannMagic
                                 float chc = 1f * settingsRef.deathRetaliationChance;
                                 if (Rand.Chance(chc))
                                 {
-                                    CompAbilityUserMagic compMagic = pawn.GetComp<CompAbilityUserMagic>();
-                                    CompAbilityUserMight compMight = pawn.GetComp<CompAbilityUserMight>();
+                                    CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic();
+                                    CompAbilityUserMight compMight = pawn.GetCompAbilityUserMight();
                                     if (compMagic != null && compMagic.IsMagicUser)
                                     {
                                         compMagic.canDeathRetaliate = true;
@@ -3530,7 +3530,7 @@ namespace TorannMagic
                                         }
                                     }
 
-                                    CompAbilityUserMight compMight = p.TryGetComp<CompAbilityUserMight>();
+                                    CompAbilityUserMight compMight = p.GetCompAbilityUserMight();
                                     if (p.IsInvisible() && compMight != null && compMight.IsMightUser && compMight.MightData != null)
                                     {
                                         MightPowerSkill mps = compMight.MightData.GetSkill_Power(TorannMagicDefOf.TM_ShadowSlayer);
@@ -3908,7 +3908,7 @@ namespace TorannMagic
                             if (instigator.RaceProps.Humanlike && instigator.story != null)
                             {
                                 //Log.Message("checking class bonus damage");
-                                CompAbilityUserMight comp = instigator.GetComp<CompAbilityUserMight>();
+                                CompAbilityUserMight comp = instigator.GetCompAbilityUserMight();
                                 if ((instigator.story.traits.HasTrait(TorannMagicDefOf.Gladiator) || TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_Cleave, null, comp)) && instigator.equipment.Primary != null && instigator.equipment.Primary.def.IsMeleeWeapon)
                                 {
                                     float cleaveChance = Mathf.Min(instigator.equipment.Primary.def.BaseMass * .15f, .75f);
@@ -3965,7 +3965,7 @@ namespace TorannMagic
 
                             if (instigator.RaceProps.Humanlike && instigator.health.hediffSet.HasHediff(TorannMagicDefOf.TM_MindOverBodyHD) && instigator.equipment.Primary == null)
                             {
-                                CompAbilityUserMight comp = instigator.GetComp<CompAbilityUserMight>();
+                                CompAbilityUserMight comp = instigator.GetCompAbilityUserMight();
                                 MightPowerSkill ver = comp.MightData.MightPowerSkill_DragonStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_DragonStrike_ver");
                                 if (Rand.Chance(.3f + (.05f * ver.level)) && comp != null)
                                 {
@@ -4008,7 +4008,7 @@ namespace TorannMagic
                         {
                             if (instigator.equipment.Primary == null && dinfo.Def != TMDamageDefOf.DamageDefOf.TM_PsionicInjury && dinfo.Def != DamageDefOf.Stun)
                             {
-                                CompAbilityUserMight comp = instigator.GetComp<CompAbilityUserMight>();
+                                CompAbilityUserMight comp = instigator.GetCompAbilityUserMight();
                                 MightPowerSkill pwr = comp.MightData.MightPowerSkill_PsionicAugmentation.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicAugmentation_pwr");
                                 float dmgNum = dinfo.Amount;
                                 float pawnDPS = instigator.GetStatValue(StatDefOf.MeleeDPS, false);
@@ -4056,7 +4056,7 @@ namespace TorannMagic
                             //Log.Message("checking instigator melee bonus ");                            
                             if (Rand.Chance(.2f) && instigator.story != null && instigator.story.traits != null && instigator.story.traits.HasTrait(TorannMagicDefOf.Paladin))
                             {
-                                CompAbilityUserMagic comp = instigator.GetComp<CompAbilityUserMagic>();
+                                CompAbilityUserMagic comp = instigator.GetCompAbilityUserMagic();
                                 if (comp != null)
                                 {
                                     float amount = Rand.Range(2f, 4f) + Rand.Range(0f, .1f * comp.MagicUserLevel);
@@ -4066,7 +4066,7 @@ namespace TorannMagic
                             }
                             if (instigator.health.hediffSet.HasHediff(TorannMagicDefOf.TM_HediffFightersFocus) && Rand.Chance(.2f))
                             {
-                                CompAbilityUserMight comp = instigator.GetComp<CompAbilityUserMight>();
+                                CompAbilityUserMight comp = instigator.GetCompAbilityUserMight();
                                 if (comp != null && comp.MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_pwr").level >= 7)
                                 {
                                     if (pawn.equipment != null && pawn.equipment.Primary != null && (pawn.equipment.Primary.def.IsRangedWeapon || pawn.equipment.Primary.def.IsMeleeWeapon))
@@ -4146,7 +4146,7 @@ namespace TorannMagic
             {
                 if (__instance.CasterIsPawn)
                 {
-                    CompAbilityUserMight comp = __instance.CasterPawn.TryGetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = __instance.CasterPawn.GetCompAbilityUserMight();
                     if (comp != null && comp.MightData != null && comp.Stamina != null && __instance.CasterPawn.health != null && __instance.CasterPawn.health.hediffSet != null)
                     {
                         if (__instance.CasterPawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_MindOverBodyHD, false) && __instance.CasterPawn.equipment.Primary == null && ___burstShotsLeft <= 0)
@@ -4301,7 +4301,7 @@ namespace TorannMagic
                     if (__instance.CasterPawn.RaceProps.Humanlike)
                     {
                         Pawn pawn = __instance.CasterPawn;
-                        CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                        CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                         if (comp != null && (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless) || TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_Transpose, null, comp)))
                         {
 
@@ -4438,17 +4438,17 @@ namespace TorannMagic
             public static bool Prefix(AbilityAIDef abilityDef, Pawn pawn, ref LocalTargetInfo __result)
             {
                 bool flagComp = false;
-                //CompAbilityUserMagic magicComp = pawn.TryGetComp<CompAbilityUserMagic>();
+                //CompAbilityUserMagic magicComp = pawn.GetCompAbilityUserMagic();
                 //if(magicComp != null && magicComp.customClass != null)
                 //{
 
                 //}
-                CompAbilityUserMight mightComp = pawn.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mightComp = pawn.GetCompAbilityUserMight();
                 if (mightComp != null && mightComp.customClass != null)
                 {
                     flagComp = true;
                 }
-                CompAbilityUserMagic magicComp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic magicComp = pawn.GetCompAbilityUserMagic();
                 if (magicComp != null && magicComp.customClass != null)
                 {
                     flagComp = true;
@@ -4531,17 +4531,17 @@ namespace TorannMagic
             public static bool Prefix(AbilityAIDef abilityDef, Pawn pawn, LocalTargetInfo target, ref bool __result)
             {
                 bool flagComp = false;
-                //CompAbilityUserMagic magicComp = pawn.TryGetComp<CompAbilityUserMagic>();
+                //CompAbilityUserMagic magicComp = pawn.GetCompAbilityUserMagic();
                 //if(magicComp != null && magicComp.customClass != null)
                 //{
 
                 //}
-                CompAbilityUserMight mightComp = pawn.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mightComp = pawn.GetCompAbilityUserMight();
                 if (mightComp != null && mightComp.customClass != null)
                 {
                     flagComp = true;
                 }
-                CompAbilityUserMagic magicComp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic magicComp = pawn.GetCompAbilityUserMagic();
                 if (magicComp != null && magicComp.customClass != null)
                 {
                     flagComp = true;
@@ -5887,7 +5887,7 @@ namespace TorannMagic
                 }
                 IntVec3 c = IntVec3.FromVector3(clickPos);
                 Enchantment.CompEnchant comp = pawn.TryGetComp<Enchantment.CompEnchant>();
-                CompAbilityUserMagic pawnComp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic pawnComp = pawn.GetCompAbilityUserMagic();
                 if (comp != null && pawnComp != null && pawnComp.IsMagicUser && pawn.story != null && pawn.story.traits != null && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
                     if (comp.enchantingContainer == null)
@@ -6004,7 +6004,7 @@ namespace TorannMagic
                     {
                         if (item is Building && (item.def == TorannMagicDefOf.TableArcaneForge))
                         {
-                            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                             if (comp != null && comp.Mana != null && comp.Mana.CurLevel < .5f)
                             {
                                 string text = null;
@@ -6050,8 +6050,8 @@ namespace TorannMagic
         //    {
         //        if (__instance.Def.defName.Contains("TM_"))
         //        {
-        //            CompAbilityUserMagic comp = __instance.Pawn.GetComp<CompAbilityUserMagic>();
-        //            CompAbilityUserMight mightComp = __instance.Pawn.GetComp<CompAbilityUserMight>();
+        //            CompAbilityUserMagic comp = __instance.Pawn.GetCompAbilityUserMagic();
+        //            CompAbilityUserMight mightComp = __instance.Pawn.GetCompAbilityUserMight();
         //            if (comp.IsMagicUser && !__instance.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
         //            {
         //                __instance.CooldownTicksLeft = Mathf.RoundToInt((float)__instance.MaxCastingTicks * comp.coolDown);
@@ -6318,7 +6318,7 @@ namespace TorannMagic
         {
             public static void Postfix(Pawn initiator, Pawn recipient, ref float __result)
             {
-                CompAbilityUserMagic comp = initiator.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = initiator.GetCompAbilityUserMagic();
                 if (comp != null && (initiator.story.traits.HasTrait(TorannMagicDefOf.TM_Bard) || TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_Entertain, comp, null)))
                 {
                     MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_Entertain.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Entertain_ver");
@@ -6397,8 +6397,8 @@ namespace TorannMagic
                         float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
                         Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
                         rect = new Rect(vector.x, vector.y, num, num);
-                        CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
-                        CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMight compMight = colonist.GetCompAbilityUserMight();
+                        CompAbilityUserMagic compMagic = colonist.GetCompAbilityUserMagic();
                         if (compMagic != null && compMagic.customClass != null)
                         {
                             Texture2D customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomMageMark", true);
@@ -6622,7 +6622,7 @@ namespace TorannMagic
                     Pawn pawn = (Pawn)InteractionsTrackerTick_Patch.pawn.GetValue(__instance);
                     if (pawn.IsColonist && !pawn.Downed && !pawn.Dead && pawn.RaceProps.Humanlike)
                     {
-                        CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                         int lastInteractionTime = (int)InteractionsTrackerTick_Patch.lastInteractionTime.GetValue(__instance);
                         if (comp != null && comp.IsMagicUser && (comp.Pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Bard) || TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_Entertain, comp, null)))
                         {
@@ -6904,7 +6904,7 @@ namespace TorannMagic
         {
             public static void Postfix(Pawn pawn, SkillDef relevantSkill, ref QualityCategory __result)
             {
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp != null && comp.IsMagicUser && pawn.story.traits != null && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless) && comp.ArcaneForging)
                 {
                     List<IntVec3> cellList = GenRadial.RadialCellsAround(pawn.Position, 2, true).ToList();
@@ -6993,7 +6993,7 @@ namespace TorannMagic
             {
                 if (p.RaceProps.Humanlike && p.skills != null)
                 {
-                    CompAbilityUserMagic comp = p.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                     if (p.workSettings.WorkIsActive(WorkTypeDefOf.Doctor) && comp != null && (p.story.traits.HasTrait(TorannMagicDefOf.TM_Golemancer) || TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_RuneCarving, comp, null)))
                     {
                         if (comp.MagicData.MagicPowersGolemancer.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RuneCarving).learned && recipe.PawnSatisfiesSkillRequirements(p) && p.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation) && p.health.capacities.CapableOf(PawnCapacityDefOf.Moving) && !p.skills.GetSkill(SkillDefOf.Artistic).TotallyDisabled && !p.skills.GetSkill(SkillDefOf.Crafting).TotallyDisabled)
@@ -7069,7 +7069,7 @@ namespace TorannMagic
             {
                 if (p.RaceProps.Humanlike && p.skills != null)
                 {
-                    CompAbilityUserMagic comp = p.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                     if (p.workSettings.WorkIsActive(WorkTypeDefOf.Doctor) && comp != null && (p.story.traits.HasTrait(TorannMagicDefOf.Druid) || TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_RegrowLimb, comp, null)))
                     {
                         if (comp.MagicData.MagicPowersD.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RegrowLimb).learned && recipe.PawnSatisfiesSkillRequirements(p) && p.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation) && p.health.capacities.CapableOf(PawnCapacityDefOf.Moving))

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_AbilityResource.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_AbilityResource.cs
@@ -3,6 +3,7 @@ using Verse;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -52,7 +53,7 @@ namespace TorannMagic
 
         private void UpdateCachedValues()
         {
-            CompAbilityUserMight comp = this.Pawn.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             if (comp != null)
             {
                 int lvlMax = 0;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Aura.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Aura.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -41,7 +42,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
             if (spawned && comp != null && comp.IsMagicUser)
             {
                 DetermineHediff();
@@ -81,12 +82,12 @@ namespace TorannMagic
                             FleckMaker.ThrowLightningGlow(pawn.DrawPos, pawn.Map, .8f);
                             if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                             {
-                                CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+                                CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
                                 comp.MightUserXP += Rand.Range(10, 15);
                             }
                             else
                             {
-                                CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+                                CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
                                 comp.MagicUserXP += Rand.Range(10, 15);
                             }
                             Find.HistoryEventsManager.RecordEvent(new HistoryEvent(TorannMagicDefOf.TM_UsedMagic, this.Pawn.Named(HistoryEventArgsNames.Doer), this.Pawn.Named(HistoryEventArgsNames.Subject), this.Pawn.Named(HistoryEventArgsNames.AffectedFaction), this.Pawn.Named(HistoryEventArgsNames.Victim)), true);
@@ -104,7 +105,7 @@ namespace TorannMagic
         public void DetermineHediff()
         {
             MagicPower abilityPower = null;            
-            CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
             if (parent.def == TorannMagicDefOf.TM_Shadow_AuraHD && comp != null)
             {
                 abilityPower = comp.MagicData.MagicPowersA.FirstOrDefault((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Shadow);                

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BattleHymn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BattleHymn.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -36,7 +37,7 @@ namespace TorannMagic
             bool spawned = base.Pawn.Spawned;
             if (spawned)
             {
-                CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
                 pwrVal = TM_Calc.GetSkillPowerLevel(Pawn, TorannMagicDefOf.TM_BattleHymn);
                 verVal = TM_Calc.GetSkillVersatilityLevel(Pawn, TorannMagicDefOf.TM_BattleHymn);
                 effVal = TM_Calc.GetSkillEfficiencyLevel(Pawn, TorannMagicDefOf.TM_BattleHymn);
@@ -75,7 +76,7 @@ namespace TorannMagic
             bool flag4 = Find.TickManager.TicksGame % chantFrequency == 0;
             if (flag4 && map != null)
             {
-                CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
                 if (comp.Mana.CurLevel > (.09f - (.009f * effVal)))
                 {
                     List<Pawn> pawns = this.Pawn.Map.mapPawns.AllPawnsSpawned;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Blood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Blood.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -45,7 +46,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
             if (spawned && comp != null && comp.IsMagicUser)
             {
                 //bloodPwr = comp.MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_pwr").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BloodForBlood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BloodForBlood.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -55,7 +56,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMagic comp = this.linkedPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.linkedPawn.GetCompAbilityUserMagic();
             if(TM_Calc.GetBloodLossTypeDef(this.Pawn.health.hediffSet.hediffs) == null)
             {
                 HealthUtility.AdjustSeverity(this.Pawn, HediffDefOf.BloodLoss, .05f);

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BloodShield.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BloodShield.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -55,7 +56,7 @@ namespace TorannMagic
         {
             bool spawned = base.Pawn.Spawned;
             this.lastSeverity = this.parent.Severity;
-            CompAbilityUserMagic comp = this.linkedPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.linkedPawn.GetCompAbilityUserMagic();
             if (spawned && comp != null && comp.IsMagicUser)
             {
                 bloodshieldVer = comp.MagicData.MagicPowerSkill_BloodShield.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodShield_ver").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BrandingBase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BrandingBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -118,7 +119,7 @@ namespace TorannMagic
                 CompAbilityUserMagic comp = null;
                 if(branderPawn != null)
                 {
-                    comp = branderPawn.TryGetComp<CompAbilityUserMagic>();
+                    comp = branderPawn.GetCompAbilityUserMagic();
                     if (!BranderPawn.DestroyedOrNull() && !BranderPawn.Dead && comp != null && comp.Mana != null)
                     {
                         if(BranderPawn.Downed)

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BrandingSiphon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BrandingSiphon.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -14,8 +15,8 @@ namespace TorannMagic
         {
             if(parent.Severity >= .1f)
             {
-                CompAbilityUserMagic comp = this.Pawn.TryGetComp<CompAbilityUserMagic>();
-                CompAbilityUserMagic branderComp = BranderPawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
+                CompAbilityUserMagic branderComp = BranderPawn.GetCompAbilityUserMagic();
                 if(comp != null && comp.Mana != null && branderComp != null && branderComp.Mana != null)
                 {
                     float pwrAmt = .005f * this.parent.Severity;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BurningFury.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BurningFury.cs
@@ -3,6 +3,7 @@ using Verse;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 using TorannMagic.Golems;
 
@@ -62,7 +63,7 @@ namespace TorannMagic
             {
                 if(comp == null && TM_Calc.IsMightUser(this.Pawn))
                 {
-                    comp = this.Pawn.GetComp<CompAbilityUserMight>();
+                    comp = this.Pawn.GetCompAbilityUserMight();
                     int pwrVal = comp.MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_pwr").level;
                     if (pwrVal >= 4)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Chi.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Chi.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -49,7 +50,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
 
             if (comp != null && comp.IsMightUser)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_CommanderAura.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_CommanderAura.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -44,7 +45,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             if (spawned && comp != null && comp.IsMightUser)
             {
                 DetermineHediff();
@@ -86,7 +87,7 @@ namespace TorannMagic
                                 }
                             }
                         }
-                        CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+                        CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
                         comp.MightUserXP += Rand.Range(2, 5);                        
                     }        
                 }
@@ -120,7 +121,7 @@ namespace TorannMagic
 
         private void DetermineHediff()
         {           
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             if (parent.def == TorannMagicDefOf.TM_CommanderAuraHD && comp != null)
             {
                 pwrVal = comp.MightData.MightPowerSkill_CommanderAura.FirstOrDefault((MightPowerSkill x) => x.label == "TM_CommanderAura_pwr").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_DeathMark.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_DeathMark.cs
@@ -2,6 +2,7 @@
 using Verse;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using Verse.AI;
 
 namespace TorannMagic
@@ -85,7 +86,7 @@ namespace TorannMagic
         {
             if (!instigator.Dead && !instigator.Downed)
             {
-                MagicPowerSkill ver = instigator.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RaiseUndead.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RaiseUndead_ver");
+                MagicPowerSkill ver = instigator.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RaiseUndead.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RaiseUndead_ver");
                 undeadPawn.SetFaction(instigator.Faction);
                 IntVec3 screamPos = undeadPawn.Position;
                 screamPos.z += 2;
@@ -99,7 +100,7 @@ namespace TorannMagic
                     //RemoveTraits(undeadPawn, undeadPawn.story.traits.allTraits);
                     //RedoSkills(undeadPawn);
                     undeadPawn.story.traits.GainTrait(new Trait(TraitDef.Named("Undead"), 0, false));
-                    CompAbilityUserMagic undeadComp = undeadPawn.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic undeadComp = undeadPawn.GetCompAbilityUserMagic();
                     if (undeadComp.IsMagicUser)
                     {
                         //undeadComp.ClearPowers();

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Empath.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Empath.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -46,7 +47,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
             if (spawned && comp != null && comp.IsMagicUser && this.Pawn.needs.mood != null)
             {
                 pwrVal = comp.MagicData.GetSkill_Power(TorannMagicDefOf.TM_Empathy).level;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_EnchantedWeapon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_EnchantedWeapon.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -47,7 +48,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMagic comp = this.enchanterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.enchanterPawn.GetCompAbilityUserMagic();
             if (!spawned || this.enchanterPawn == null)
             {
                 this.removeNow = true;
@@ -70,7 +71,7 @@ namespace TorannMagic
                 {
                     if(!this.enchanterPawn.DestroyedOrNull() && !this.enchanterPawn.Dead)
                     {
-                        CompAbilityUserMagic comp = this.enchanterPawn.GetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMagic comp = this.enchanterPawn.GetCompAbilityUserMagic();
                         if(comp != null && comp.weaponEnchants != null && comp.weaponEnchants.Count >0)
                         {
                             bool isRegistered = false;
@@ -108,7 +109,7 @@ namespace TorannMagic
         {
             if(this.enchanterPawn != null)
             {
-                CompAbilityUserMagic comp = enchanterPawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = enchanterPawn.GetCompAbilityUserMagic();
                 if(comp != null && comp.weaponEnchants != null && comp.weaponEnchants.Count > 0)
                 {
                     if(comp.weaponEnchants.Contains(this.Pawn))

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_GearRepair.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_GearRepair.cs
@@ -3,6 +3,7 @@ using Verse;
 using System.Collections.Generic;
 using HarmonyLib;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -65,7 +66,7 @@ namespace TorannMagic
                 {
                     gear[i].HitPoints++;
                 }
-                CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
                 if (comp != null && comp.MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 5)
                 {
                     if (gear[i].HitPoints >= gear[i].MaxHitPoints && gear[i].WornByCorpse)

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_HarvestPassion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_HarvestPassion.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -57,7 +58,7 @@ namespace TorannMagic
             bool spawned = base.Pawn.Spawned && Pawn.skills != null && !Pawn.Dead;
             if (spawned && !caster.DestroyedOrNull() && !caster.Dead && !caster.Downed)
             {                
-                CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
                 if(comp != null && comp.MagicData != null)
                 {
                     if (comp.MagicData.GetSkill_Power(TorannMagicDefOf.TM_HarvestPassion) != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Hate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Hate.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -55,7 +56,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             this.stats = new List<StatModifier>();
             this.stats.Clear();
             if (spawned && comp != null && comp.IsMightUser)

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_InnerHealing.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_InnerHealing.cs
@@ -3,6 +3,7 @@ using Verse;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -74,7 +75,7 @@ namespace TorannMagic
             }
             else
             {
-                comp = this.Pawn.TryGetComp<CompAbilityUserMight>();
+                comp = this.Pawn.GetCompAbilityUserMight();
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Inspirational.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Inspirational.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -34,8 +35,8 @@ namespace TorannMagic
             bool spawned = base.Pawn.Spawned;
             if (spawned)
             {
-                MagicPowerSkill pwr = this.Pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Inspire.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Inspire_pwr");
-                MagicPowerSkill ver = this.Pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Inspire.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Inspire_ver");
+                MagicPowerSkill pwr = this.Pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Inspire.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Inspire_pwr");
+                MagicPowerSkill ver = this.Pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Inspire.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Inspire_ver");
                 this.pwrVal = pwr.level;
                 this.verVal = ver.level;
             }
@@ -55,8 +56,8 @@ namespace TorannMagic
             }
             if(Find.TickManager.TicksGame % 600 == 0)
             {
-                MagicPowerSkill pwr = this.Pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Inspire.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Inspire_pwr");
-                MagicPowerSkill ver = this.Pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Inspire.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Inspire_ver");
+                MagicPowerSkill pwr = this.Pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Inspire.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Inspire_pwr");
+                MagicPowerSkill ver = this.Pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Inspire.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Inspire_ver");
                 this.pwrVal = pwr.level;
                 this.verVal = ver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_LightCapacitance.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_LightCapacitance.cs
@@ -2,6 +2,7 @@
 using Verse;
 using UnityEngine;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -70,7 +71,7 @@ namespace TorannMagic
             {
                 if (base.Pawn.Spawned && base.Pawn.Map != null)
                 {
-                    CompAbilityUserMagic comp = base.Pawn.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = base.Pawn.GetCompAbilityUserMagic();
                     if (comp != null && comp.SoL != null)
                     {
                         return comp.SoL;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_MageLight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_MageLight.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -43,7 +44,7 @@ namespace TorannMagic
                 gProps.glowRadius = 7f;
                 glower.parent = this.Pawn;
                 glower.Initialize(gProps);
-                comp = base.Pawn.GetComp<CompAbilityUserMagic>();
+                comp = base.Pawn.GetCompAbilityUserMagic();
                 this.nextLightningTick = Find.TickManager.TicksGame + Rand.Range(400, 800);
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Nightshade.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Nightshade.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -56,7 +57,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             if (spawned && comp != null && comp.IsMightUser)
             {
                 pwrVal = comp.MightData.MightPowerSkill_Nightshade.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Nightshade_pwr").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Prediction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Prediction.cs
@@ -3,6 +3,7 @@ using Verse;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -40,10 +41,10 @@ namespace TorannMagic
             {
                 //FleckMaker.ThrowLightningGlow(base.Pawn.TrueCenter(), base.Pawn.Map, 3f);
                 Pawn caster = this.Pawn;
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
                 if (comp != null)
                 {
-                    pwrVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Prediction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Prediction_pwr").level;
+                    pwrVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Prediction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Prediction_pwr").level;
                     this.parent.Severity = .5f + pwrVal;
                 }
             }
@@ -93,12 +94,12 @@ namespace TorannMagic
         {
             float sev = this.parent.Severity;
             Pawn caster = this.Pawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
 
             if (comp != null)
             {
-                pwrVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Prediction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Prediction_pwr").level;
+                pwrVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Prediction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Prediction_pwr").level;
                 if (sev <= 0)
                 {
                     this.removeNow = true;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_ProvisionerAura.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_ProvisionerAura.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -45,7 +46,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             if (spawned && comp != null && comp.IsMightUser)
             {
                 DetermineHediff();
@@ -88,7 +89,7 @@ namespace TorannMagic
                                 }
                             }
                         }
-                        CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+                        CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
                         comp.MightUserXP += Rand.Range(2, 5);                        
                     }
                     else //map null
@@ -118,7 +119,7 @@ namespace TorannMagic
 
         private void DetermineHediff()
         {           
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             if (parent.def == TorannMagicDefOf.TM_ProvisionerAuraHD && comp != null)
             {
                 pwrVal = comp.MightData.MightPowerSkill_ProvisionerAura.FirstOrDefault((MightPowerSkill x) => x.label == "TM_ProvisionerAura_pwr").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Psionic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Psionic.cs
@@ -5,6 +5,7 @@ using Verse;
 using Verse.AI;
 using Verse.Sound;
 using RimWorld;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -85,12 +86,12 @@ namespace TorannMagic
 
         private void DeterminePsionicHD()
         {
-            this.comp = this.Pawn.GetComp<CompAbilityUserMight>();
-            if (comp != null && comp.MightData != null)
+            this.comp = this.Pawn.GetCompAbilityUserMight();
+            if (comp?.MightData != null)
             {
-                this.PwrVal = this.Pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicAugmentation.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicAugmentation_pwr").level;
-                this.EffVal = this.Pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicAugmentation.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicAugmentation_eff").level;
-                this.VerVal = this.Pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicAugmentation.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicAugmentation_ver").level;
+                this.PwrVal = this.comp.MightData.MightPowerSkill_PsionicAugmentation.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicAugmentation_pwr").level;
+                this.EffVal = this.comp.MightData.MightPowerSkill_PsionicAugmentation.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicAugmentation_eff").level;
+                this.VerVal = this.comp.MightData.MightPowerSkill_PsionicAugmentation.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicAugmentation_ver").level;
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_RangerBond.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_RangerBond.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
+using TorannMagic.Extensions;
 using Verse;
 
 namespace TorannMagic
@@ -50,7 +51,7 @@ namespace TorannMagic
                 {
                     if (!mapPawns[i].DestroyedOrNull() && mapPawns[i].Spawned && !mapPawns[i].Downed && mapPawns[i].RaceProps.Humanlike)
                     {
-                        CompAbilityUserMight comp = mapPawns[i].GetComp<CompAbilityUserMight>();
+                        CompAbilityUserMight comp = mapPawns[i].GetCompAbilityUserMight();
                         if (comp.IsMightUser && comp.bondedPet != null)
                         {
                             if (comp.bondedPet == this.Pawn)
@@ -59,7 +60,7 @@ namespace TorannMagic
                                 break;
                             }
                         }
-                        CompAbilityUserMagic compMagic = mapPawns[i].GetComp<CompAbilityUserMagic>();
+                        CompAbilityUserMagic compMagic = mapPawns[i].GetCompAbilityUserMagic();
                         if(compMagic.IsMagicUser && compMagic.bondedSpirit != null)
                         {
                             if(compMagic.bondedSpirit == this.Pawn)
@@ -154,12 +155,12 @@ namespace TorannMagic
         private void UpdateBond()
         {
             int verVal = 0;
-            CompAbilityUserMight comp = this.bonderPawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.bonderPawn.GetCompAbilityUserMight();
             if (comp != null && comp.IsMightUser)
             {
                 verVal = comp.MightData.MightPowerSkill_AnimalFriend.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AnimalFriend_ver").level;
             }
-            CompAbilityUserMagic compMagic = this.bonderPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compMagic = this.bonderPawn.GetCompAbilityUserMagic();
             if(compMagic != null && compMagic.IsMagicUser)
             {
                 verVal = compMagic.MagicData.MagicPowerSkill_GuardianSpirit.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_GuardianSpirit_ver").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Rend.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Rend.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -55,7 +56,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMagic comp = this.linkedPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.linkedPawn.GetCompAbilityUserMagic();
             if (spawned && comp != null && comp.IsMagicUser)
             {
                 MagicPowerSkill bpwr = comp.MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_pwr");

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Shapeshift.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Shapeshift.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -55,7 +56,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             this.stats = new List<StatModifier>();
             this.stats.Clear();
             if (spawned && comp != null && comp.IsMightUser)

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_SoulBond.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_SoulBond.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
+using TorannMagic.Extensions;
 using Verse;
 
 namespace TorannMagic
@@ -68,7 +69,7 @@ namespace TorannMagic
                     Find.HistoryEventsManager.RecordEvent(new HistoryEvent(TorannMagicDefOf.TM_UsedMagic, this.Pawn.Named(HistoryEventArgsNames.Doer), this.Pawn.Named(HistoryEventArgsNames.Subject), this.Pawn.Named(HistoryEventArgsNames.AffectedFaction), this.Pawn.Named(HistoryEventArgsNames.Victim)), true);
                 }
                 Pawn pawn = base.Pawn;
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 Pawn soulPawn = comp.soulBondPawn;
                 bondedPawn = soulPawn;
                 if(soulPawn != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_SupressiveAura.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_SupressiveAura.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
 using RimWorld.Planet;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -48,7 +49,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
             if (spawned && comp != null && comp.IsMagicUser)
             {
                 pwrVal = comp.MagicData.GetSkill_Power(TorannMagicDefOf.TM_SuppressiveAura).level;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_TaskMasterAura.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_TaskMasterAura.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -43,7 +44,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = base.Pawn.Spawned;
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             if (spawned && comp != null && comp.IsMightUser)
             {
                 DetermineHediff();
@@ -102,7 +103,7 @@ namespace TorannMagic
                             }
                         }
                     }
-                    CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
                     comp.MightUserXP += Rand.Range(2, 5);                    
                 }
 
@@ -115,7 +116,7 @@ namespace TorannMagic
 
         private void DetermineHediff()
         {           
-            CompAbilityUserMight comp = this.Pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.Pawn.GetCompAbilityUserMight();
             if (parent.def == TorannMagicDefOf.TM_TaskMasterAuraHD && comp != null)
             {
                 pwrVal = comp.MightData.MightPowerSkill_TaskMasterAura.FirstOrDefault((MightPowerSkill x) => x.label == "TM_TaskMasterAura_pwr").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_TechnoBit.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_TechnoBit.cs
@@ -5,6 +5,7 @@ using Verse;
 using Verse.AI;
 using Verse.Sound;
 using RimWorld;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -91,7 +92,7 @@ namespace TorannMagic
 
         private void DetermineHDRank()
         {
-            CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
             this.PwrVal = comp.MagicData.MagicPowerSkill_TechnoBit.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoBit_pwr").level;
             this.EffVal = comp.MagicData.MagicPowerSkill_TechnoBit.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoBit_eff").level;
             this.VerVal = comp.MagicData.MagicPowerSkill_TechnoBit.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoBit_ver").level;
@@ -111,7 +112,7 @@ namespace TorannMagic
                     }
                 }
 
-                CompAbilityUserMagic comp = this.Pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = this.Pawn.GetCompAbilityUserMagic();
 
                 if (this.ticksBitWorking > 0 && this.nextBitEffect < Find.TickManager.TicksGame && this.moteLoc != Vector3.zero)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Undead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Undead.cs
@@ -6,6 +6,7 @@ using AbilityUser;
 using Verse;
 using UnityEngine;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -74,7 +75,7 @@ namespace TorannMagic
         {
             if(this.linkedPawn != null)
             {
-                CompAbilityUserMagic comp = linkedPawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = linkedPawn.GetCompAbilityUserMagic();
                 try
                 {
                     if (comp != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Hediff_ApothecaryHerbs.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Hediff_ApothecaryHerbs.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
 using RimWorld.Planet;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -35,7 +36,7 @@ namespace TorannMagic
         private void Initialize()
         {
             bool spawned = pawn.Spawned;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             if (comp != null)
             {
                 herbPwr = comp.MightData.MightPowerSkill_Herbalist.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Herbalist_pwr").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/ITab_Pawn_Magic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ITab_Pawn_Magic.cs
@@ -3,6 +3,7 @@ using System;
 using UnityEngine;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -49,7 +50,7 @@ namespace TorannMagic
                 bool flag = base.SelPawn.story != null && base.SelPawn.IsColonist;
                 if (flag)
                 {
-                    CompAbilityUserMagic compMagic = base.SelPawn.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic compMagic = base.SelPawn.GetCompAbilityUserMagic();
                     if (compMagic != null && compMagic.customClass != null)
                     {
                         return true;

--- a/RimWorldOfMagic/RimWorldOfMagic/ITab_Pawn_Might.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ITab_Pawn_Might.cs
@@ -1,5 +1,6 @@
 ﻿using RimWorld;
 using System;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -42,7 +43,7 @@ namespace TorannMagic
                 bool flag = base.SelPawn.story != null && base.SelPawn.IsColonist;
                 if (flag)
                 {
-                    CompAbilityUserMight compMight = base.SelPawn.TryGetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight compMight = base.SelPawn.GetCompAbilityUserMight();
                     if (compMight != null && compMight.customClass != null)
                     {
                         return true;

--- a/RimWorldOfMagic/RimWorldOfMagic/Ideology/RitualAttachableOutcomeEffectWorker_ManaRecharge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Ideology/RitualAttachableOutcomeEffectWorker_ManaRecharge.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Ideology
 {
@@ -24,7 +25,7 @@ namespace TorannMagic.Ideology
 			{
 				if(TM_Calc.IsMagicUser(key))
                 {
-					CompAbilityUserMagic comp = key.TryGetComp<CompAbilityUserMagic>();
+					CompAbilityUserMagic comp = key.GetCompAbilityUserMagic();
 					if(comp != null)
                     {
 						mageCount++;

--- a/RimWorldOfMagic/RimWorldOfMagic/Ideology/ThoughtWorker_Precept_MagicUse_Mood_Approve.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Ideology/ThoughtWorker_Precept_MagicUse_Mood_Approve.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using RimWorld;
+using TorannMagic.Extensions;
 using Verse;
 
 namespace TorannMagic.Ideology
@@ -14,7 +15,7 @@ namespace TorannMagic.Ideology
         {
             if (p.IsColonist && !p.IsPrisoner && !p.IsQuestLodger() && TM_Calc.IsMagicUser(p))
             {
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 float totalPower = 0f;
                 foreach(TM_EventRecords er in comp.MagicUsed)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Channel_Discord.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Channel_Discord.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 using Verse.AI;
 using UnityEngine;
 
@@ -26,7 +27,7 @@ namespace TorannMagic
 
         protected override IEnumerable<Toil> MakeNewToils()
         {
-            CompAbilityUserMagic comp = this.pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.pawn.GetCompAbilityUserMagic();
             Toil discordance = new Toil();
             Pawn target = this.TargetThingA as Pawn;
             discordance.initAction = delegate

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_ChargePortal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_ChargePortal.cs
@@ -3,6 +3,7 @@ using Verse.AI;
 using System;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 
@@ -35,7 +36,7 @@ namespace TorannMagic
             this.FailOnDestroyedOrNull(building);
             Toil reserveTargetA = Toils_Reserve.Reserve(building);
             yield return reserveTargetA;
-            comp = this.pawn.GetComp<CompAbilityUserMagic>();
+            comp = this.pawn.GetCompAbilityUserMagic();
             portalBldg = TargetA.Thing as Building_TMPortal;
             arcaneCapacitor = TargetA.Thing as Building_TMArcaneCapacitor;
             dmp = TargetA.Thing as Building_TM_DMP;

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Command.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Command.cs
@@ -7,6 +7,7 @@ using RimWorld;
 using Verse.AI;
 using UnityEngine;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -134,7 +135,7 @@ namespace TorannMagic
 
         private void AssignXP()
         {
-            CompAbilityUserMight comp = this.pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.pawn.GetCompAbilityUserMight();
 
             if (comp != null)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Entertain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Entertain.cs
@@ -3,6 +3,7 @@ using Verse.AI;
 using Verse;
 using RimWorld;
 using System;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 
@@ -31,7 +32,7 @@ namespace TorannMagic
 
         protected override IEnumerable<Toil> MakeNewToils()
         {
-            comp = pawn.GetComp<CompAbilityUserMagic>();
+            comp = pawn.GetCompAbilityUserMagic();
             yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.Touch);
             this.FailOnDowned(TargetIndex.A);
             this.FailOnMentalState(TargetIndex.A);

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_GotoAndCast.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_GotoAndCast.cs
@@ -7,6 +7,7 @@ using RimWorld;
 using Verse.AI;
 using UnityEngine;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -117,7 +118,7 @@ namespace TorannMagic
 
         private void AssignXP()
         {
-            CompAbilityUserMight comp = this.pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.pawn.GetCompAbilityUserMight();
 
             if (comp != null)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Meditate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Meditate.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using UnityEngine;
 using System;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -43,7 +44,7 @@ namespace TorannMagic
                 initAction = () =>
                 {
                     chiHD = this.pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD, false);
-                    CompAbilityUserMight comp = this.pawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = this.pawn.GetCompAbilityUserMight();
                     if(comp != null && chiHD != null)
                     {
                         effVal = comp.MightData.MightPowerSkill_Meditate.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Meditate_eff").level;
@@ -96,7 +97,7 @@ namespace TorannMagic
                                 this.EndJobWith(JobCondition.InterruptForced);
                             }
                         }
-                        CompAbilityUserMight comp = this.pawn.GetComp<CompAbilityUserMight>();
+                        CompAbilityUserMight comp = this.pawn.GetCompAbilityUserMight();
                         if (TM_Calc.IsPawnInjured(this.pawn, 0))
                         {
                             TM_Action.DoAction_HealPawn(this.pawn, this.pawn, 1, Rand.Range(.25f, .4f) * chiMultiplier * (1+ (.1f *pwrVal)));

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PlaceLightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PlaceLightningTrap.cs
@@ -4,6 +4,7 @@ using RimWorld;
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -35,7 +36,7 @@ namespace TorannMagic
                 {
                     SpawnThings tempPod = new SpawnThings();
                     tempPod.def = TorannMagicDefOf.TM_Trap_Lightning;
-                    CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                     try
                     {
                         for (int i = 0; i < comp.lightningTraps.Count; i++)
@@ -96,7 +97,7 @@ namespace TorannMagic
                     }
                     Thing thing = ThingMaker.MakeThing(def, stuff);
                     thing.SetFaction(faction, null);
-                    CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                     GenPlace.TryPlaceThing(thing, position, map, ThingPlaceMode.Direct);
                     //GenSpawn.Spawn(thing, position, map, Rot4.North, WipeMode.Vanish, false);
                     comp.lightningTraps.Add(thing);

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PlacePoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PlacePoisonTrap.cs
@@ -4,6 +4,7 @@ using RimWorld;
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -35,13 +36,13 @@ namespace TorannMagic
                 {
                     SpawnThings tempPod = new SpawnThings();
                     tempPod.def = ThingDef.Named("TM_PoisonTrap");
-                    CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                     int verVal = 0;
                     try
                     {
                         //verVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_PoisonTrap, "TM_PoisonTrap", "_ver", true);
                         verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_PoisonTrap);
-                        MightPowerSkill ver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PoisonTrap.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PoisonTrap_ver");
+                        MightPowerSkill ver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PoisonTrap.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PoisonTrap_ver");
                         //verVal = ver.level;
                         //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                         //{
@@ -106,7 +107,7 @@ namespace TorannMagic
                     }
                     Thing thing = ThingMaker.MakeThing(def, stuff);
                     thing.SetFaction(faction, null);
-                    CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                     GenSpawn.Spawn(thing, position, map, Rot4.North, WipeMode.Vanish, false);
                     comp.combatItems.Add(thing);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PortalDestination.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PortalDestination.cs
@@ -4,6 +4,7 @@ using Verse.AI;
 using Verse;
 using RimWorld;
 using RimWorld.Planet;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 
@@ -101,7 +102,7 @@ namespace TorannMagic
                 Map myMap = portalBldg.Map;
                 Map map = mapParent.Map;
                 Current.Game.CurrentMap = map;
-                comp = pawn.GetComp<CompAbilityUserMagic>();
+                comp = pawn.GetCompAbilityUserMagic();
                 TargetingParameters portalTarget = new TargetingParameters();
                 portalTarget.canTargetLocations = true;
                 portalTarget.canTargetSelf = false;

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PsionicBarrier.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PsionicBarrier.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 using Verse.AI;
 using UnityEngine;
 
@@ -27,7 +28,7 @@ namespace TorannMagic
 
         protected override IEnumerable<Toil> MakeNewToils()
         {
-            CompAbilityUserMight comp = this.pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.pawn.GetCompAbilityUserMight();
             float radius = 2.5f;
             //radius += (.75f * TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_PsionicBarrier, "TM_PsionicBarrier", "_ver", true));
             radius += (.75f * TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_PsionicBarrier));
@@ -123,7 +124,7 @@ namespace TorannMagic
             {
                 if(this.pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {                    
-                    CompAbilityUserMight mightComp = this.pawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight mightComp = this.pawn.GetCompAbilityUserMight();
                     if (mightComp.mimicAbility != null)
                     {
                         mightComp.RemovePawnAbility(mightComp.mimicAbility);
@@ -155,13 +156,13 @@ namespace TorannMagic
                             TM_MoteMaker.ThrowGenericFleck(FleckDefOf.LightningGlow, displayEffect, this.Map, projectileDamage / 8f, .2f, .1f, .3f, 0, 0, 0, Rand.Range(0, 360));
                             if(usePsionicEnergy)
                             {
-                                int eff = this.pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicBarrier.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicBarrier_eff").level;
+                                int eff = this.pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicBarrier.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicBarrier_eff").level;
                                 float sevReduct = (projectileDamage / (12 + eff));
                                 HealthUtility.AdjustSeverity(this.pawn, HediffDef.Named("TM_PsionicHD"), -sevReduct);
                             }
                             else
                             {
-                                this.pawn.GetComp<CompAbilityUserMight>().Stamina.CurLevel -= (projectileDamage / 600);
+                                this.pawn.GetCompAbilityUserMight().Stamina.CurLevel -= (projectileDamage / 600);
                             }
                             if(cellList[j].def.projectile.explosionRadius > 0 && cellList[j].def != TorannMagicDefOf.Projectile_FogOfTorment)
                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_SummonDemon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_SummonDemon.cs
@@ -4,6 +4,7 @@ using RimWorld;
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -27,7 +28,7 @@ namespace TorannMagic
             {
                 initAction = () =>
                 {
-                    this.comp = this.pawn.GetComp<CompAbilityUserMagic>();
+                    this.comp = this.pawn.GetCompAbilityUserMagic();
                     this.markedPawn = comp.soulBondPawn;
                 },
                 tickAction = () =>

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Teach.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Teach.cs
@@ -7,6 +7,7 @@ using RimWorld;
 using Verse.AI;
 using UnityEngine;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -47,8 +48,8 @@ namespace TorannMagic
             Toil doTeaching = new Toil();
             doTeaching.initAction = delegate
             {
-                CompAbilityUserMagic compMagic = student.GetComp<CompAbilityUserMagic>();
-                CompAbilityUserMight compMight = student.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMagic compMagic = student.GetCompAbilityUserMagic();
+                CompAbilityUserMight compMight = student.GetCompAbilityUserMight();
                 if(compMagic != null && compMagic.IsMagicUser && !student.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
                     this.isMageTeaching = true;
@@ -253,8 +254,8 @@ namespace TorannMagic
 
         private void AssignMagicXP(Pawn student)
         {
-            CompAbilityUserMagic studentComp = student.GetComp<CompAbilityUserMagic>();
-            CompAbilityUserMagic mentorComp = this.pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic studentComp = student.GetCompAbilityUserMagic();
+            CompAbilityUserMagic mentorComp = this.pawn.GetCompAbilityUserMagic();
 
             if (studentComp != null && mentorComp != null)
             {
@@ -295,8 +296,8 @@ namespace TorannMagic
 
         private void AssignMightXP(Pawn student)
         {
-            CompAbilityUserMight studentComp = student.GetComp<CompAbilityUserMight>();
-            CompAbilityUserMight mentorComp = this.pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight studentComp = student.GetCompAbilityUserMight();
+            CompAbilityUserMight mentorComp = this.pawn.GetCompAbilityUserMight();
 
             if (studentComp != null && mentorComp != null)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/JobGiver_AIAbilityUser.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobGiver_AIAbilityUser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -12,12 +13,12 @@ namespace TorannMagic
     {
         public override float GetPriority(Pawn pawn)
         {
-            CompAbilityUserMagic magicComp = pawn.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic magicComp = pawn.GetCompAbilityUserMagic();
             if(magicComp != null)// && magicComp.AIAbilityJob != null)
             {
                 return 100f;
             }
-            CompAbilityUserMight mightComp = pawn.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight mightComp = pawn.GetCompAbilityUserMight();
             if(mightComp != null && false)
             {
 
@@ -27,14 +28,14 @@ namespace TorannMagic
 
         protected override Job TryGiveJob(Pawn pawn)
         {
-            CompAbilityUserMagic magicComp = pawn.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic magicComp = pawn.GetCompAbilityUserMagic();
             if (magicComp != null)// && magicComp.AIAbilityJob != null)
             {
                 Log.Message("giving ai job");
                 pawn.jobs.debugLog = true;
                 return null;
             }
-            CompAbilityUserMight mightComp = pawn.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight mightComp = pawn.GetCompAbilityUserMight();
             if (mightComp != null && false)
             {
 

--- a/RimWorldOfMagic/RimWorldOfMagic/JobGiver_MonkMeditate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobGiver_MonkMeditate.cs
@@ -6,6 +6,7 @@ using RimWorld;
 using System.Collections.Generic;
 using System.Linq;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -16,7 +17,7 @@ namespace TorannMagic
         {
             
             Hediff chiHD = pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD);
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             if (chiHD == null)
             {
                 return 0f;
@@ -108,7 +109,7 @@ namespace TorannMagic
                 {
                     return null;
                 }
-                CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                 if (comp != null)
                 {
                     MightPower mightPower = comp.MightData.MightPowersM.FirstOrDefault<MightPower>((MightPower x) => x.abilityDef == TorannMagicDefOf.TM_Meditate);
@@ -124,7 +125,7 @@ namespace TorannMagic
                     }
 
                     Hediff hediff = pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD);
-                    PawnAbility ability = pawn.GetComp<CompAbilityUserMight>().AbilityData.Powers.FirstOrDefault((PawnAbility x) => x.Def == TorannMagicDefOf.TM_Meditate);
+                    PawnAbility ability = pawn.GetCompAbilityUserMight().AbilityData.Powers.FirstOrDefault((PawnAbility x) => x.Def == TorannMagicDefOf.TM_Meditate);
 
                     if (ability.CooldownTicksLeft > 0 || hediff.Severity >= 70)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Laser_LightningBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Laser_LightningBolt.cs
@@ -3,6 +3,7 @@ using Verse;
 using Verse.Sound;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -24,17 +25,17 @@ namespace TorannMagic
             
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
-                this.arcaneDmg = pawn.GetComp<CompAbilityUserMight>().mightPwr;
+                this.arcaneDmg = pawn.GetCompAbilityUserMight().mightPwr;
             }
             else
             {
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningBolt_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningBolt_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningBolt_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningBolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningBolt_ver");
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/MagicAbility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MagicAbility.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 using TorannMagic.Ideology;
@@ -149,7 +150,7 @@ namespace TorannMagic
                 }
                 else if (this.MagicUser.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    CompAbilityUserMight mightComp = this.MagicUser.Pawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight mightComp = this.MagicUser.Pawn.GetCompAbilityUserMight();
                     mightComp.Stamina.UseMightPower(magicDef.manaCost);
                     mightComp.MightUserXP += (int)((magicDef.manaCost * 180) * mightComp.xpGain * settingsRef.xpMultiplier);
                 }
@@ -478,7 +479,7 @@ namespace TorannMagic
                     }
                     else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                     {
-                        CompAbilityUserMight mightComp = this.Pawn.GetComp<CompAbilityUserMight>();
+                        CompAbilityUserMight mightComp = this.Pawn.GetCompAbilityUserMight();
                         bool flag7 = mightComp != null && mightComp.Stamina != null && magicDef.manaCost > 0f && this.magicDef.manaCost > mightComp.Stamina.CurLevel;
                         if (flag7)
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/MagicCardUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MagicCardUtility.cs
@@ -3,6 +3,7 @@ using RimWorld;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -64,7 +65,7 @@ namespace TorannMagic
         public static void DrawMagicCard(Rect rect, Pawn pawn)
         {
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             int sizeY = 0;
             if (comp.customClass != null)
             {
@@ -97,7 +98,7 @@ namespace TorannMagic
                     Rect rect9 = new Rect(rect.x, rect2.yMax + MagicCardUtility.Padding, rect2.width, MagicCardUtility.SkillsColumnHeight);
                     Rect inRect = new Rect(rect9.x, rect9.y + MagicCardUtility.Padding, MagicCardUtility.SkillsColumnDivider, MagicCardUtility.SkillsColumnHeight);
                     Rect inRect2 = new Rect(rect9.x + MagicCardUtility.SkillsColumnDivider, rect9.y + MagicCardUtility.Padding, rect9.width - MagicCardUtility.SkillsColumnDivider, MagicCardUtility.SkillsColumnHeight);
-                    MagicCardUtility.InfoPane(inRect, pawn.GetComp<CompAbilityUserMagic>(), pawn);
+                    MagicCardUtility.InfoPane(inRect, pawn.GetCompAbilityUserMagic(), pawn);
                     float x5 = Text.CalcSize("TM_Spells".Translate()).x;
                     Rect rect10 = new Rect(rect.width / 2f - x5 / 2f, rect9.yMax - 60f, rect.width, MagicCardUtility.HeaderSize);
                     Text.Font = GameFont.Small;
@@ -108,171 +109,171 @@ namespace TorannMagic
                     if (comp.customClass != null)
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                        MagicCardUtility.CustomPowersHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.AllMagicPowersWithSkills, comp.customClass, TexButton.TMTex_SkillPointUsed);
+                        MagicCardUtility.CustomPowersHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.AllMagicPowersWithSkills, comp.customClass, TexButton.TMTex_SkillPointUsed);
                     }
                     else
                     {
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.InnerFire))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_Firestorm == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_Firestorm == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersIF, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RayofHope, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Firebolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Fireclaw, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Fireball, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Firestorm, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersIF, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RayofHope, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Firebolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Fireclaw, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Fireball, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Firestorm, null, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersIF, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RayofHope, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Firebolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Fireclaw, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Fireball, null, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersIF, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RayofHope, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Firebolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Fireclaw, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Fireball, null, null, TexButton.TMTex_SkillPointUsed);
                             }
 
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.HeartOfFrost))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_Blizzard == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_Blizzard == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersHoF, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Soothe, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Rainmaker, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Icebolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_FrostRay, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Snowball, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Blizzard, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersHoF, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Soothe, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Rainmaker, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Icebolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_FrostRay, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Snowball, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Blizzard, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersHoF, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Soothe, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Rainmaker, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Icebolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_FrostRay, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Snowball, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersHoF, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Soothe, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Rainmaker, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Icebolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_FrostRay, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Snowball, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.StormBorn))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_EyeOfTheStorm == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_EyeOfTheStorm == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersSB, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AMP, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningBolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningCloud, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningStorm, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EyeOfTheStorm, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersSB, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AMP, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningBolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningCloud, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningStorm, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EyeOfTheStorm, null, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersSB, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AMP, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningBolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningCloud, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningStorm, null, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersSB, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AMP, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningBolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningCloud, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningStorm, null, null, TexButton.TMTex_SkillPointUsed);
                             }
 
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Arcanist))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_FoldReality == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_FoldReality == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Shadow, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_MagicMissile, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Blink, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Summon, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Teleport, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_FoldReality, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersA, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Shadow, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_MagicMissile, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Blink, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Summon, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Teleport, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_FoldReality, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Shadow, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_MagicMissile, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Blink, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Summon, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Teleport, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersA, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Shadow, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_MagicMissile, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Blink, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Summon, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Teleport, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Paladin))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_HolyWrath == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_HolyWrath == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersP, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_P_RayofHope, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Heal, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Shield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ValiantCharge, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overwhelm, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_HolyWrath, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersP, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_P_RayofHope, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Heal, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Shield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ValiantCharge, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overwhelm, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_HolyWrath, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersP, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_P_RayofHope, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Heal, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Shield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ValiantCharge, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overwhelm, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersP, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_P_RayofHope, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Heal, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Shield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ValiantCharge, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overwhelm, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Summoner))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_SummonPoppi == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_SummonPoppi == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersS, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonMinion, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonPylon, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonExplosive, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonElemental, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonPoppi, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersS, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonMinion, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonPylon, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonExplosive, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonElemental, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonPoppi, null, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersS, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonMinion, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonPylon, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonExplosive, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonElemental, null, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersS, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonMinion, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonPylon, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonExplosive, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonElemental, null, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Druid))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_RegrowLimb == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_RegrowLimb == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersD, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Poison, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SootheAnimal, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Regenerate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_CureDisease, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RegrowLimb, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersD, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Poison, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SootheAnimal, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Regenerate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_CureDisease, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RegrowLimb, null, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersD, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Poison, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SootheAnimal, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Regenerate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_CureDisease, null, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersD, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Poison, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SootheAnimal, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Regenerate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_CureDisease, null, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Necromancer))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_LichForm == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_LichForm == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersN, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RaiseUndead, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_DeathMark, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_FogOfTorment, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ConsumeCorpse, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_CorpseExplosion, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LichForm, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersN, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RaiseUndead, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_DeathMark, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_FogOfTorment, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ConsumeCorpse, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_CorpseExplosion, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LichForm, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersN, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RaiseUndead, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_DeathMark, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_FogOfTorment, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ConsumeCorpse, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_CorpseExplosion, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersN, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RaiseUndead, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_DeathMark, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_FogOfTorment, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ConsumeCorpse, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_CorpseExplosion, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Lich))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersN, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RaiseUndead, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_DeathMark, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_FogOfTorment, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ConsumeCorpse, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_CorpseExplosion, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_DeathBolt, TexButton.TMTex_SkillPointUsed);
+                            MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersN, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RaiseUndead, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_DeathMark, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_FogOfTorment, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ConsumeCorpse, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_CorpseExplosion, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_DeathBolt, TexButton.TMTex_SkillPointUsed);
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Priest))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_Resurrection == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_Resurrection == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersPR, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AdvancedHeal, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Purify, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_HealingCircle, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BestowMight, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersPR, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AdvancedHeal, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Purify, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_HealingCircle, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BestowMight, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Resurrection, null, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersPR, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AdvancedHeal, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Purify, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_HealingCircle, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BestowMight, null, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersPR, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AdvancedHeal, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Purify, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_HealingCircle, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BestowMight, null, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Bard))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_BattleHymn == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_BattleHymn == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersB, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BardTraining, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Entertain, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Inspire, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Lullaby, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BattleHymn, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersB, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BardTraining, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Entertain, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Inspire, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Lullaby, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BattleHymn, null, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersB, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BardTraining, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Entertain, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Inspire, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Lullaby, null, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersB, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BardTraining, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Entertain, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Inspire, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Lullaby, null, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Succubus))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_Scorn == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_Scorn == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersSD, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SoulBond, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ShadowBolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Dominate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Attraction, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Scorn, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersSD, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SoulBond, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ShadowBolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Dominate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Attraction, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Scorn, null, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersSD, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SoulBond, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ShadowBolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Dominate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Attraction, null, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersSD, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SoulBond, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ShadowBolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Dominate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Attraction, null, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Warlock))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_PsychicShock == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_PsychicShock == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersWD, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SoulBond, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ShadowBolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Dominate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Repulsion, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_PsychicShock, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersWD, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SoulBond, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ShadowBolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Dominate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Repulsion, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_PsychicShock, null, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersWD, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SoulBond, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ShadowBolt, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Dominate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Repulsion, null, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersWD, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SoulBond, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ShadowBolt, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Dominate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Repulsion, null, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Geomancer))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_Meteor == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_Meteor == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersG, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Stoneskin, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Encase, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EarthSprites, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EarthernHammer, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Sentinel, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Meteor, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersG, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Stoneskin, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Encase, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EarthSprites, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EarthernHammer, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Sentinel, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Meteor, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersG, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Stoneskin, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Encase, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EarthSprites, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EarthernHammer, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Sentinel, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersG, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Stoneskin, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Encase, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EarthSprites, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EarthernHammer, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Sentinel, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Technomancer))
@@ -280,83 +281,83 @@ namespace TorannMagic
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
                             if (comp.MagicData.MagicPowersT.FirstOrDefault<MagicPower>((MagicPower mp) => mp.abilityDef == TorannMagicDefOf.TM_TechnoBit).learned == true)
                             {
-                                if (pawn.GetComp<CompAbilityUserMagic>().spell_OrbitalStrike == true)
+                                if (pawn.GetCompAbilityUserMagic().spell_OrbitalStrike == true)
                                 {
-                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersT, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoBit, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoShield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overdrive, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Sabotage, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_OrbitalStrike, null, TexButton.TMTex_SkillPointUsed);
+                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersT, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoBit, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoShield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overdrive, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Sabotage, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_OrbitalStrike, null, TexButton.TMTex_SkillPointUsed);
                                 }
                                 else
                                 {
-                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersT, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoBit, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoShield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overdrive, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Sabotage, null, null, TexButton.TMTex_SkillPointUsed);
+                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersT, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoBit, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoShield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overdrive, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Sabotage, null, null, TexButton.TMTex_SkillPointUsed);
                                 }
                             }
                             else if (comp.MagicData.MagicPowersT.FirstOrDefault<MagicPower>((MagicPower mp) => mp.abilityDef == TorannMagicDefOf.TM_TechnoTurret).learned == true)
                             {
-                                if (pawn.GetComp<CompAbilityUserMagic>().spell_OrbitalStrike == true)
+                                if (pawn.GetCompAbilityUserMagic().spell_OrbitalStrike == true)
                                 {
-                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersT, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoTurret, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoShield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overdrive, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Sabotage, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_OrbitalStrike, null, TexButton.TMTex_SkillPointUsed);
+                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersT, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoTurret, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoShield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overdrive, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Sabotage, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_OrbitalStrike, null, TexButton.TMTex_SkillPointUsed);
                                 }
                                 else
                                 {
-                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersT, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoTurret, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoShield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overdrive, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Sabotage, null, null, TexButton.TMTex_SkillPointUsed);
+                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersT, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoTurret, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoShield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overdrive, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Sabotage, null, null, TexButton.TMTex_SkillPointUsed);
                                 }
                             }
                             else if (comp.MagicData.MagicPowersT.FirstOrDefault<MagicPower>((MagicPower mp) => mp.abilityDef == TorannMagicDefOf.TM_TechnoWeapon).learned == true)
                             {
-                                if (pawn.GetComp<CompAbilityUserMagic>().spell_OrbitalStrike == true)
+                                if (pawn.GetCompAbilityUserMagic().spell_OrbitalStrike == true)
                                 {
-                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersT, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoWeapon, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoShield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overdrive, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Sabotage, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_OrbitalStrike, null, TexButton.TMTex_SkillPointUsed);
+                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersT, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoWeapon, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoShield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overdrive, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Sabotage, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_OrbitalStrike, null, TexButton.TMTex_SkillPointUsed);
                                 }
                                 else
                                 {
-                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersT, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoWeapon, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoShield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overdrive, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Sabotage, null, null, TexButton.TMTex_SkillPointUsed);
+                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersT, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoWeapon, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoShield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overdrive, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Sabotage, null, null, TexButton.TMTex_SkillPointUsed);
                                 }
                             }
                             else
                             {
-                                if (pawn.GetComp<CompAbilityUserMagic>().spell_OrbitalStrike == true)
+                                if (pawn.GetCompAbilityUserMagic().spell_OrbitalStrike == true)
                                 {
-                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersT, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoBit, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoTurret, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoWeapon, null, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_OrbitalStrike, null, TexButton.TMTex_SkillPointUsed);
+                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersT, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoBit, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoTurret, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoWeapon, null, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_OrbitalStrike, null, TexButton.TMTex_SkillPointUsed);
                                 }
                                 else
                                 {
-                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersT, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoBit, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoTurret, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoWeapon, null, null, null, TexButton.TMTex_SkillPointUsed);
+                                    MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersT, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoBit, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoTurret, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoWeapon, null, null, null, TexButton.TMTex_SkillPointUsed);
                                 }
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.BloodMage))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_BloodMoon == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_BloodMoon == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersBM, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodGift, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_IgniteBlood, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodForBlood, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodShield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Rend, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodMoon, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersBM, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodGift, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_IgniteBlood, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodForBlood, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodShield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Rend, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodMoon, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersBM, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodGift, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_IgniteBlood, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodForBlood, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodShield, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Rend, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersBM, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodGift, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_IgniteBlood, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodForBlood, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodShield, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Rend, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Enchanter))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_Shapeshift == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_Shapeshift == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersE, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchantedBody, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Transmutate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchanterStone, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchantWeapon, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Polymorph, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Shapeshift, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersE, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchantedBody, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Transmutate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchanterStone, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchantWeapon, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Polymorph, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Shapeshift, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersE, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchantedBody, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Transmutate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchanterStone, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchantWeapon, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Polymorph, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersE, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchantedBody, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Transmutate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchanterStone, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchantWeapon, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Polymorph, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.Chronomancer))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            if (pawn.GetComp<CompAbilityUserMagic>().spell_Recall == true)
+                            if (pawn.GetCompAbilityUserMagic().spell_Recall == true)
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersC, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Prediction, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AlterFate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AccelerateTime, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ReverseTime, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ChronostaticField, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Recall, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersC, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Prediction, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AlterFate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AccelerateTime, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ReverseTime, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ChronostaticField, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Recall, TexButton.TMTex_SkillPointUsed);
                             }
                             else
                             {
-                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersC, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Prediction, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AlterFate, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AccelerateTime, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ReverseTime, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ChronostaticField, null, TexButton.TMTex_SkillPointUsed);
+                                MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersC, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Prediction, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AlterFate, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AccelerateTime, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ReverseTime, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ChronostaticField, null, TexButton.TMTex_SkillPointUsed);
                             }
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.ChaosMage))
@@ -372,14 +373,14 @@ namespace TorannMagic
 
                                 CMList.Add(mp);
                             }
-                            //MagicCardUtility.CustomPowersHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersCM, comp.customClass, TexButton.TMTex_SkillPointUsed);
+                            //MagicCardUtility.CustomPowersHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersCM, comp.customClass, TexButton.TMTex_SkillPointUsed);
                             //MagicCardUtility.PowersGUIHandler_CM(inRect3, comp, comp.MagicData.AllMagicPowersForChaosMage, comp.MagicData.MagicPowerSkill_ChaosTradition, comp.chaosPowers[0].Skills, comp.chaosPowers[1].Skills, comp.chaosPowers[2].Skills, comp.chaosPowers[3].Skills, comp.chaosPowers[4].Skills, TexButton.TMTex_SkillPointUsed);
                             MagicCardUtility.PowersGUIHandler_CM(inRect3, comp, CMList, comp.MagicData.MagicPowerSkill_ChaosTradition, comp.chaosPowers[0].Skills, comp.chaosPowers[1].Skills, comp.chaosPowers[2].Skills, comp.chaosPowers[3].Skills, comp.chaosPowers[4].Skills, TexButton.TMTex_SkillPointUsed);
                         }
                         if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer))
                         {
                             Rect inRect3 = new Rect(rect.x, rect11.y, MagicCardUtility.PowersColumnWidth, MagicCardUtility.PowersColumnHeight);
-                            MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMagic>(), pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersW, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_WandererCraft, pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips, null, null, null, null, TexButton.TMTex_SkillPointUsed);
+                            MagicCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMagic(), pawn.GetCompAbilityUserMagic().MagicData.MagicPowersW, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_WandererCraft, pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips, null, null, null, null, TexButton.TMTex_SkillPointUsed);
                         }
                     }
                 }
@@ -511,9 +512,9 @@ namespace TorannMagic
             Rect rect5 = new Rect(rect2.x + 272f + MagicCardUtility.MagicButtonPointSize, rectG.yMin + 24f, 136f, MagicCardUtility.TextSize);
             Rect rect51 = new Rect(rect2.x + 272f, rectG.yMin + 24f, MagicCardUtility.MagicButtonPointSize, MagicCardUtility.TextSize);
 
-            List<MagicPowerSkill> skill1 = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_regen;
-            List<MagicPowerSkill> skill2 = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_eff;
-            List<MagicPowerSkill> skill3 = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_spirit;
+            List<MagicPowerSkill> skill1 = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_global_regen;
+            List<MagicPowerSkill> skill2 = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_global_eff;
+            List<MagicPowerSkill> skill3 = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_global_spirit;
 
             using (List<MagicPowerSkill>.Enumerator enumerator1 = skill1.GetEnumerator())
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/MagicUserUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MagicUserUtility.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using TorannMagic.Extensions;
+using Verse;
 
 namespace TorannMagic
 {
@@ -7,7 +8,7 @@ namespace TorannMagic
         public static Need_Mana GetMana(Pawn pawn)
         {
             CompAbilityUserMagic comp;
-            bool flag = (comp = pawn.GetComp<CompAbilityUserMagic>()) != null;
+            bool flag = (comp = pawn.GetCompAbilityUserMagic()) != null;
             Need_Mana result;
             if (flag)
             {
@@ -23,7 +24,7 @@ namespace TorannMagic
         public static CompAbilityUserMagic GetMagicUser(Pawn pawn)
         {
             CompAbilityUserMagic comp;
-            bool flag = (comp = pawn.GetComp<CompAbilityUserMagic>()) != null;
+            bool flag = (comp = pawn.GetCompAbilityUserMagic()) != null;
             CompAbilityUserMagic result;
             if (flag)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/MightCardUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MightCardUtility.cs
@@ -3,6 +3,7 @@ using RimWorld;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -65,7 +66,7 @@ namespace TorannMagic
         public static void DrawMightCard(Rect rect, Pawn pawn)
         {
             //GUI.BeginGroup(rect);
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             int sizeY = 0;
             if (comp.customClass != null)
             {
@@ -94,7 +95,7 @@ namespace TorannMagic
                 Rect rect9 = new Rect(rect.x, rect2.yMax + MightCardUtility.Padding, rect2.width, MightCardUtility.SkillsColumnHeight);
                 Rect inRect = new Rect(rect9.x, rect9.y + MightCardUtility.Padding, MightCardUtility.SkillsColumnDivider, MightCardUtility.SkillsColumnHeight);
                 Rect inRect2 = new Rect(rect9.x + MightCardUtility.SkillsColumnDivider, rect9.y + MightCardUtility.Padding, rect9.width - MightCardUtility.SkillsColumnDivider, MightCardUtility.SkillsColumnHeight);
-                MightCardUtility.InfoPane(inRect, pawn.GetComp<CompAbilityUserMight>(), pawn);
+                MightCardUtility.InfoPane(inRect, pawn.GetCompAbilityUserMight(), pawn);
                 float x5 = Text.CalcSize("TM_Skills".Translate()).x;
                 Rect rect10 = new Rect(rect.width / 2f - x5 / 2f, rect9.yMax - 60f, rect.width, MightCardUtility.HeaderSize);
                 Text.Font = GameFont.Small;
@@ -105,78 +106,78 @@ namespace TorannMagic
                 if (comp.customClass != null)
                 {
                     Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                    MightCardUtility.CustomPowersHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.AllMightPowersWithSkills, comp.customClass, TexButton.TMTex_SkillPointUsed);
+                    MightCardUtility.CustomPowersHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.AllMightPowersWithSkills, comp.customClass, TexButton.TMTex_SkillPointUsed);
                 }
                 else
                 {
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.Gladiator))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersG, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Sprint, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Fortitude, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Grapple, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Cleave, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Whirlwind, null, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersG, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Sprint, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Fortitude, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Grapple, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Cleave, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Whirlwind, null, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Sniper))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersS, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_SniperFocus, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Headshot, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_DisablingShot, comp.MightData.MightPowerSkill_AntiArmor, comp.MightData.MightPowerSkill_ShadowSlayer, null, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersS, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_SniperFocus, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Headshot, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_DisablingShot, comp.MightData.MightPowerSkill_AntiArmor, comp.MightData.MightPowerSkill_ShadowSlayer, null, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.Bladedancer))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersB, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BladeFocus, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BladeArt, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_SeismicSlash, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BladeSpin, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PhaseStrike, null, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersB, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BladeFocus, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BladeArt, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_SeismicSlash, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BladeSpin, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PhaseStrike, null, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.Ranger))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersR, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_RangerTraining, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BowTraining, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PoisonTrap, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_AnimalFriend, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ArrowStorm, null, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersR, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_RangerTraining, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BowTraining, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PoisonTrap, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_AnimalFriend, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ArrowStorm, null, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersF, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Disguise, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Reversal, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Transpose, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Possess, null, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersF, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Disguise, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Reversal, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Transpose, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Possess, null, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Psionic))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersP, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicAugmentation, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicBarrier, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicBlast, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicDash, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicStorm, null, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersP, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicAugmentation, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicBarrier, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicBlast, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicDash, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicStorm, null, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.DeathKnight))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersDK, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Shroud, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_WaveOfFear, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Spite, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_LifeSteal, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_GraveBlade, null, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersDK, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Shroud, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_WaveOfFear, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Spite, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_LifeSteal, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_GraveBlade, null, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Monk))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersM, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Chi, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_MindOverBody, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Meditate, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_TigerStrike, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_DragonStrike, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ThunderStrike, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersM, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Chi, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_MindOverBody, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Meditate, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_TigerStrike, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_DragonStrike, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ThunderStrike, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersW, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_WayfarerCraft, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_FieldTraining, null, null, null, null, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersW, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_WayfarerCraft, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining, null, null, null, null, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Commander))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
-                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersC, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ProvisionerAura, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_TaskMasterAura, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_CommanderAura, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_StayAlert, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_MoveOut, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_HoldTheLine, TexButton.TMTex_SkillPointUsed);
+                        MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersC, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ProvisionerAura, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_TaskMasterAura, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_CommanderAura, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_StayAlert, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_MoveOut, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_HoldTheLine, TexButton.TMTex_SkillPointUsed);
                     }
                     if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_SuperSoldier))
                     {
                         Rect inRect3 = new Rect(rect.x, rect11.y, MightCardUtility.PowersColumnWidth, MightCardUtility.PowersColumnHeight);
                         if (comp.MightData.MightPowersSS.FirstOrDefault<MightPower>((MightPower mp) => mp.abilityDef == TorannMagicDefOf.TM_PistolSpec).learned == true)
                         {
-                            MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersSS, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PistolSpec, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_CQC, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_FirstAid, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_60mmMortar, null, null, TexButton.TMTex_SkillPointUsed);
+                            MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersSS, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PistolSpec, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_CQC, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_FirstAid, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_60mmMortar, null, null, TexButton.TMTex_SkillPointUsed);
                         }
                         else if (comp.MightData.MightPowersSS.FirstOrDefault<MightPower>((MightPower mp) => mp.abilityDef == TorannMagicDefOf.TM_RifleSpec).learned == true)
                         {
-                            MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersSS, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_RifleSpec, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_CQC, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_FirstAid, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_60mmMortar, null, null, TexButton.TMTex_SkillPointUsed);
+                            MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersSS, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_RifleSpec, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_CQC, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_FirstAid, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_60mmMortar, null, null, TexButton.TMTex_SkillPointUsed);
                         }
                         else if (comp.MightData.MightPowersSS.FirstOrDefault<MightPower>((MightPower mp) => mp.abilityDef == TorannMagicDefOf.TM_ShotgunSpec).learned == true)
                         {
-                            MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersSS, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ShotgunSpec, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_CQC, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_FirstAid, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_60mmMortar, null, null, TexButton.TMTex_SkillPointUsed);
+                            MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersSS, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ShotgunSpec, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_CQC, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_FirstAid, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_60mmMortar, null, null, TexButton.TMTex_SkillPointUsed);
                         }
                         else
                         {
-                            MightCardUtility.PowersGUIHandler(inRect3, pawn.GetComp<CompAbilityUserMight>(), pawn.GetComp<CompAbilityUserMight>().MightData.MightPowersSS, null, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PistolSpec, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_RifleSpec, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ShotgunSpec, null, null, TexButton.TMTex_SkillPointUsed);
+                            MightCardUtility.PowersGUIHandler(inRect3, pawn.GetCompAbilityUserMight(), pawn.GetCompAbilityUserMight().MightData.MightPowersSS, null, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PistolSpec, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_RifleSpec, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ShotgunSpec, null, null, TexButton.TMTex_SkillPointUsed);
                         }
                     }
                 }
@@ -275,10 +276,10 @@ namespace TorannMagic
             Rect rect61 = new Rect(rect5.x + rect5.width + MightCardUtility.MagicButtonPointSize, rectG.y + 24f, MightCardUtility.MagicButtonPointSize, MightCardUtility.TextSize);
 
 
-            List<MightPowerSkill> skill1 = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_global_refresh;
-            List<MightPowerSkill> skill2 = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_global_seff;
-            List<MightPowerSkill> skill3 = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_global_strength;
-            List<MightPowerSkill> skill4 = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_global_endurance;
+            List<MightPowerSkill> skill1 = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_global_refresh;
+            List<MightPowerSkill> skill2 = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_global_seff;
+            List<MightPowerSkill> skill3 = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_global_strength;
+            List<MightPowerSkill> skill4 = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_global_endurance;
 
             using (List<MightPowerSkill>.Enumerator enumerator1 = skill1.GetEnumerator())
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/MightUserUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MightUserUtility.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using TorannMagic.Extensions;
+using Verse;
 
 namespace TorannMagic
 {
@@ -22,7 +23,7 @@ namespace TorannMagic
         public static Need_Stamina GetStamina(Pawn pawn)
         {
             CompAbilityUserMight comp;
-            bool flag = (comp = pawn.GetComp<CompAbilityUserMight>()) != null;
+            bool flag = (comp = pawn.GetCompAbilityUserMight()) != null;
             Need_Stamina result;
             if (flag)
             {
@@ -38,7 +39,7 @@ namespace TorannMagic
         public static CompAbilityUserMight GetMightUser(Pawn pawn)
         {
             CompAbilityUserMight comp;
-            bool flag = (comp = pawn.GetComp<CompAbilityUserMight>()) != null;
+            bool flag = (comp = pawn.GetCompAbilityUserMight()) != null;
             CompAbilityUserMight result;
             if (flag)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/ModOptions/TM_DebugTools.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ModOptions/TM_DebugTools.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 using Verse;
 using Verse.AI;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.ModOptions
 {
@@ -37,7 +38,7 @@ namespace TorannMagic.ModOptions
             {
                 bool addMagicComp = false;
                 bool addMightComp = false;
-                CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic();
                 if(compMagic != null && compMagic.IsMagicUser)
                 {
                     RemoveMagicComp(compMagic);
@@ -51,7 +52,7 @@ namespace TorannMagic.ModOptions
                         Log.Warning("failed to remove magic comp");
                     }
                 }
-                CompAbilityUserMight compMight = pawn.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight compMight = pawn.GetCompAbilityUserMight();
                 if(compMight != null && compMight.IsMightUser)
                 {
                     RemoveMightComp(compMight);

--- a/RimWorldOfMagic/RimWorldOfMagic/MovingObject.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MovingObject.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using Verse;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -191,7 +192,7 @@ namespace TorannMagic
                             {
                                 cleaveVictim.TakeDamage(dinfo);
                                 FleckMaker.ThrowMicroSparks(cleaveVictim.Position.ToVector3(), map);
-                                CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+                                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                                 MightPowerSkill ver = comp.MightData.MightPowerSkill_Whirlwind.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Whirlwind_ver");
                                 DamageInfo dinfo2 = new DamageInfo(TMDamageDefOf.DamageDefOf.TM_Whirlwind, weaponDmg, 0, (float)-1, caster, null, null, DamageInfo.SourceCategory.ThingOrUnknown);
                                 System.Random random = new System.Random();
@@ -211,7 +212,7 @@ namespace TorannMagic
         private int GetWeaponDmg(Pawn caster)
         {
             int dmgNum = 1;
-            CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             MightPowerSkill pwr = comp.MightData.MightPowerSkill_Whirlwind.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Whirlwind_pwr");
             ThingWithComps arg_3C_0;
             if (caster == null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Need_Mana.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Need_Mana.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Verse;
 using RimWorld.Planet;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -56,10 +57,10 @@ namespace TorannMagic
         public override float CurLevel
         {            
             get => curLevelInt;
-            set => curLevelInt = Mathf.Clamp(value, 0f, 2f*this.pawn.GetComp<CompAbilityUserMagic>().maxMP);            
+            set => curLevelInt = Mathf.Clamp(value, 0f, 2f*this.pawn.GetCompAbilityUserMagic().maxMP);
         }
 
-        public override float MaxLevel => this.pawn.GetComp<CompAbilityUserMagic>().maxMP;
+        public override float MaxLevel => this.pawn.GetCompAbilityUserMagic().maxMP;
 
         public override void ExposeData()
         {
@@ -204,7 +205,7 @@ namespace TorannMagic
             if (!base.pawn.Dead && base.pawn.story != null && base.pawn.story.traits != null && !base.pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {                
                 Pawn pawn = base.pawn;
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp != null && comp.MagicData != null && comp.IsMagicUser && pawn.Faction != null)
                 {                    
                     if (!pawn.Faction.IsPlayer && pawn.Map != null)
@@ -216,7 +217,7 @@ namespace TorannMagic
                     else
                     {
                         ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();                        
-                        MagicPowerSkill manaRegen = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
+                        MagicPowerSkill manaRegen = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
                         this.baseManaGain = (amount * (0.0012f) * settingsRef.needMultiplier);
                         amount *= (((0.0012f * comp.mpRegenRate)) * settingsRef.needMultiplier);
                         this.modifiedManaGain = amount - this.baseManaGain;
@@ -334,7 +335,7 @@ namespace TorannMagic
                                 {
                                     if (mapPawns[i] != null && mapPawns[i].Spawned && !mapPawns[i].Dead && !mapPawns[i].AnimalOrWildMan())
                                     {
-                                        CompAbilityUserMagic mageCheck = mapPawns[i].GetComp<CompAbilityUserMagic>();
+                                        CompAbilityUserMagic mageCheck = mapPawns[i].GetCompAbilityUserMagic();
                                         if (mageCheck != null && mageCheck.IsMagicUser && !mapPawns[i].story.traits.HasTrait(TorannMagicDefOf.Faceless))
                                         {
                                             mageCount++;
@@ -359,7 +360,7 @@ namespace TorannMagic
                         //Summoned minion modifier
                         if (comp.summonedMinions.Count > 0)
                         {
-                            MagicPowerSkill summonerEff = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonMinion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonMinion_eff");
+                            MagicPowerSkill summonerEff = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonMinion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonMinion_eff");
                             this.drainMinion = (0.0012f * (comp.summonedMinions.Count * (.2f - (.01f * summonerEff.level))));
                             amount -= this.drainMinion;
                         }
@@ -371,7 +372,7 @@ namespace TorannMagic
                         //Earth sprite modifier
                         if(comp.earthSpriteType != 0)
                         {
-                            MagicPowerSkill manaDeviant = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EarthSprites.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthSprites_ver");
+                            MagicPowerSkill manaDeviant = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EarthSprites.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthSprites_ver");
                             this.drainSprites = (0.0012f * (.6f - (.07f * manaDeviant.level)));
                             amount -= this.drainSprites;
                         }
@@ -552,7 +553,7 @@ namespace TorannMagic
             //else
             //{                
             //    Pawn pawn = base.pawn;
-            //    CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            //    CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             //    if (comp != null)
             //    {
             //        if (comp.IsMagicUser && comp.Mana != null)
@@ -570,7 +571,7 @@ namespace TorannMagic
 
         public void UseMagicPower(float amount)
         {
-            this.curLevelInt = Mathf.Clamp(this.curLevelInt - amount, 0f, 2f*this.pawn.GetComp<CompAbilityUserMagic>().maxMP);
+            this.curLevelInt = Mathf.Clamp(this.curLevelInt - amount, 0f, 2f*this.pawn.GetCompAbilityUserMagic().maxMP);
             if ((amount) > .25f && (amount) < .45f)
             {
                 //0.0 to 0.2 max

--- a/RimWorldOfMagic/RimWorldOfMagic/Need_Stamina.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Need_Stamina.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -77,10 +78,10 @@ namespace TorannMagic
         public override float CurLevel
         {
             get => base.CurLevel;
-            set => base.CurLevel = Mathf.Clamp(value, 0f, this.pawn.GetComp<CompAbilityUserMight>().maxSP);
+            set => base.CurLevel = Mathf.Clamp(value, 0f, this.pawn.GetCompAbilityUserMight().maxSP);
         }
 
-        public override float MaxLevel => this.pawn.GetComp<CompAbilityUserMight>().maxSP;
+        public override float MaxLevel => this.pawn.GetCompAbilityUserMight().maxSP;
 
         public override int GUIChangeArrow
         {
@@ -173,7 +174,7 @@ namespace TorannMagic
             if (!base.pawn.NonHumanlikeOrWildMan())
             {
                 Pawn pawn = base.pawn;
-                CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 amount = amount * (0.015f);
                 this.baseStaminaGain = amount * settingsRef.needMultiplier;
@@ -199,7 +200,7 @@ namespace TorannMagic
 
         public void UseMightPower(float amount)
         {
-            this.curLevelInt = Mathf.Clamp(this.curLevelInt - amount, 0f, this.pawn.GetComp<CompAbilityUserMight>().maxSP); //change for max sp
+            this.curLevelInt = Mathf.Clamp(this.curLevelInt - amount, 0f, this.pawn.GetCompAbilityUserMight().maxSP); //change for max sp
         }
 
         public override void NeedInterval()

--- a/RimWorldOfMagic/RimWorldOfMagic/PawnCapacityWorker_MagicManipulation.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/PawnCapacityWorker_MagicManipulation.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Verse;
 using UnityEngine;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -12,7 +13,7 @@ namespace TorannMagic
     {
         public override float CalculateCapacityLevel(HediffSet diffSet, List<PawnCapacityUtility.CapacityImpactor> impactors = null)
         {
-            CompAbilityUserMagic comp = diffSet.pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = diffSet.pawn.GetCompAbilityUserMagic();
             float num = 0;
             if(comp != null && comp.IsMagicUser && !comp.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_AccelerateTime.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_AccelerateTime.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System;
 using RimWorld;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -59,16 +60,16 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 this.pawn = this.launcher as Pawn;
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AccelerateTime.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AccelerateTime_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AccelerateTime.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AccelerateTime_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_AccelerateTime.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AccelerateTime_pwr");
+                MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_AccelerateTime.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AccelerateTime_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_AntiArmor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_AntiArmor.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using System.Linq;
 using UnityEngine;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -36,19 +37,19 @@ namespace TorannMagic
             Pawn victim = hitThing as Pawn;
             try
             {
-                CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
-                //MightPowerSkill pwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_AntiArmor.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AntiArmor_pwr");
+                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
+                //MightPowerSkill pwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_AntiArmor.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AntiArmor_pwr");
                 //verVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_AntiArmor, "TM_AntiArmor", "_ver", true);
                 //pwrVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_AntiArmor, "TM_AntiArmor", "_pwr", true);
-                //MightPowerSkill ver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_AntiArmor.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AntiArmor_ver");
+                //MightPowerSkill ver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_AntiArmor.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AntiArmor_ver");
                 MightPowerSkill str = comp.MightData.MightPowerSkill_global_strength.FirstOrDefault((MightPowerSkill x) => x.label == "TM_global_strength_pwr");
                 //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 //pwrVal = pwr.level;
                 //verVal = ver.level;
                 //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 //{
-                //    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                //    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                //    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                //    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 //    pwrVal = mpwr.level;
                 //    verVal = mver.level;
                 //}
@@ -120,7 +121,7 @@ namespace TorannMagic
 
         public static int GetWeaponDmg(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
 
             float dmg = comp.weaponDamage;
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
@@ -136,8 +137,8 @@ namespace TorannMagic
         public static int GetWeaponDmgMech(Pawn pawn, int dmg)
         {
 
-            //MightPowerSkill pwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_AntiArmor.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AntiArmor_pwr");
-            //int pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_AntiArmor, "TM_AntiArmor", "_pwr", true);
+            //MightPowerSkill pwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_AntiArmor.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AntiArmor_pwr");
+            //int pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_AntiArmor, "TM_AntiArmor", "_pwr", true);
             int pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_AntiArmor);
             int mechDmg = dmg + Mathf.RoundToInt(dmg * (1 + .5f * pwrVal));
             return mechDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ArcaneBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ArcaneBolt.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using UnityEngine;
 using RimWorld;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -19,7 +20,7 @@ namespace TorannMagic
             ThingDef def = this.def;
             Pawn pawn = this.launcher as Pawn;
             Pawn victim = hitThing as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius, TMDamageDefOf.DamageDefOf.TM_Arcane, this.launcher,  Mathf.RoundToInt(Rand.Range(5,this.def.projectile.GetDamageAmount(1, null))* comp.arcaneDmg), 1, this.def.projectile.soundExplode, def, this.equipmentDef, this.intendedTarget.Thing, null, 0f, 1, false, null, 0f, 1, 0.0f, false);
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ArrowStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ArrowStorm.cs
@@ -3,6 +3,7 @@ using System;
 using RimWorld;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -53,12 +54,12 @@ namespace TorannMagic
         {
             float weaponAccuracy = pawn.equipment.Primary.GetStatValue(StatDefOf.AccuracyMedium, true);
             verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_ArrowStorm);
-            //verVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ArrowStorm, "TM_ArrowStorm", "_ver", true);
-            //MightPowerSkill ver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ArrowStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_ArrowStorm_ver");
+            //verVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ArrowStorm, "TM_ArrowStorm", "_ver", true);
+            //MightPowerSkill ver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ArrowStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_ArrowStorm_ver");
             //verVal = ver.level;
             //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    verVal = mver.level;
             //}
             weaponAccuracy = Mathf.Min(1f, (.8f * weaponAccuracy) + (.05f * verVal));
@@ -67,8 +68,8 @@ namespace TorannMagic
 
         public static int GetWeaponDmg(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
-            //pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ArrowStorm, "TM_ArrowStorm", "_pwr", true);   
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
+            //pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ArrowStorm, "TM_ArrowStorm", "_pwr", true);   
             pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_ArrowStorm);
 
             float dmg = comp.weaponDamage;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Attraction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Attraction.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 using System;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -60,16 +61,16 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 pawn = this.launcher as Pawn;
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Attraction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Attraction_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Attraction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Attraction_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_Attraction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Attraction_pwr");
+                MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_Attraction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Attraction_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Blizzard.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Blizzard.cs
@@ -2,6 +2,7 @@
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 
@@ -41,9 +42,9 @@ namespace TorannMagic
         public void Initialize(Map map)
         {
             pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Blizzard.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Blizzard_pwr");
-            ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Blizzard.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Blizzard_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            pwr = comp.MagicData.MagicPowerSkill_Blizzard.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Blizzard_pwr");
+            ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Blizzard.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Blizzard_ver");
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             pwrVal = pwr.level;
             verVal = ver.level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_BloodMoon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_BloodMoon.cs
@@ -4,6 +4,7 @@ using RimWorld;
 using AbilityUser;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -88,11 +89,11 @@ namespace TorannMagic
                 this.wolfDmg.Clear();
 
                 caster = this.launcher as Pawn;
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
                 MagicPowerSkill bpwr = comp.MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_pwr");
-                pwrVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodMoon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodMoon_pwr").level;
-                verVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodMoon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodMoon_ver").level;
-                effVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodMoon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodMoon_eff").level;
+                pwrVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodMoon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodMoon_pwr").level;
+                verVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodMoon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodMoon_ver").level;
+                effVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodMoon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodMoon_eff").level;
                 this.arcaneDmg = comp.arcaneDmg;
                 this.arcaneDmg *= (1f + (.1f * bpwr.level));
                 this.attackFrequency *= (1 - (.05f * effVal));

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_BreachingCharge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_BreachingCharge.cs
@@ -3,6 +3,7 @@ using System;
 using RimWorld;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -24,7 +25,7 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 caster = this.launcher as Pawn;
-                CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                 //verVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_ShotgunSpec, "TM_ShotgunSpec", "_ver", true); 
                 verVal = TM_Calc.GetSkillVersatilityLevel(caster, TorannMagicDefOf.TM_ShotgunSpec);
                 this.explosionCount = 5;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChainLightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChainLightning.cs
@@ -5,6 +5,7 @@ using Verse;
 using UnityEngine;
 using System.Collections.Generic;
 using System;
+using TorannMagic.Extensions;
 using Verse.Sound;
 
 namespace TorannMagic
@@ -63,7 +64,7 @@ namespace TorannMagic
             if(!p.DestroyedOrNull())
             {
                 GenClamor.DoClamor(this, 2f, ClamorDefOf.Ability);
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 if (comp != null && comp.MagicData != null)
                 {
                     //pwrVal = TM_Calc.GetMagicSkillLevel(p, comp.MagicData.MagicPowerSkill_ChainLightning, "TM_ChainLightning", "_pwr", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChargeBattery.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChargeBattery.cs
@@ -1,5 +1,6 @@
 ﻿using AbilityUser;
 using RimWorld;
+using TorannMagic.Extensions;
 using Verse;
 using TorannMagic.Golems;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             cellRect.ClipInsideMap(map);
             Building bldg = new Building();
             Pawn caster = this.launcher as Pawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
 
             IntVec3 c = cellRect.CenterCell;
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChronostaticField.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChronostaticField.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -59,7 +60,7 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 this.casterPawn = this.launcher as Pawn;
-                CompAbilityUserMagic comp = casterPawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = casterPawn.GetCompAbilityUserMagic();
                 MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_ChronostaticField.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ChronostaticField_pwr");
                 MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_ChronostaticField.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ChronostaticField_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
@@ -67,8 +68,8 @@ namespace TorannMagic
                 verVal = ver.level;
                 if (this.casterPawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = casterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = casterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = casterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = casterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Cooler.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Cooler.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -21,7 +22,7 @@ namespace TorannMagic
             IntVec3 arg_pos_1;
 
             Pawn pawn = this.launcher as Pawn;
-            comp = pawn.GetComp<CompAbilityUserMagic>();
+            comp = pawn.GetCompAbilityUserMagic();
 
             CellRect cellRect = CellRect.CenteredOn(base.Position, 1);
             cellRect.ClipInsideMap(map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_CorpseExplosion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_CorpseExplosion.cs
@@ -3,6 +3,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -48,16 +49,16 @@ namespace TorannMagic
 
             if (!this.initialized)
             {
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_CorpseExplosion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_CorpseExplosion_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_CorpseExplosion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_CorpseExplosion_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_CorpseExplosion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_CorpseExplosion_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_CorpseExplosion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_CorpseExplosion_ver");
                 this.arcaneDmg = comp.arcaneDmg;
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_DisablingShot.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_DisablingShot.cs
@@ -4,6 +4,7 @@ using System;
 using AbilityUser;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using Verse.AI;
 using Verse.AI.Group;
 
@@ -25,8 +26,8 @@ namespace TorannMagic
             Pawn victim = hitThing as Pawn;
             try
             {
-                CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
-                //MightPowerSkill ver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_DisablingShot.FirstOrDefault((MightPowerSkill x) => x.label == "TM_DisablingShot_ver");
+                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
+                //MightPowerSkill ver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_DisablingShot.FirstOrDefault((MightPowerSkill x) => x.label == "TM_DisablingShot_ver");
                 //verVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_DisablingShot, "TM_DisablingShot", "_ver", true);
                 verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_DisablingShot);
                 MightPowerSkill str = comp.MightData.MightPowerSkill_global_strength.FirstOrDefault((MightPowerSkill x) => x.label == "TM_global_strength_pwr");
@@ -34,7 +35,7 @@ namespace TorannMagic
                 //verVal = ver.level;
                 //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 //{
-                //    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                //    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 //    verVal = mver.level;
                 //}
                 //if (settingsRef.AICasting && !pawn.IsColonist)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_EMP.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_EMP.cs
@@ -3,6 +3,7 @@ using RimWorld;
 using Verse;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -11,7 +12,7 @@ namespace TorannMagic
         protected override void Impact(Thing hitThing)
         {
             Pawn caster = this.launcher as Pawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             Map map = base.Map;
             base.Impact(hitThing);
             ThingDef def = this.def;            

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ES_Fire.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ES_Fire.cs
@@ -3,6 +3,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -17,8 +18,8 @@ namespace TorannMagic
             ThingDef def = this.def;
 
             Pawn pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoWeapon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoWeapon_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoWeapon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoWeapon_ver");
             verVal = ver.level;
 
             GenExplosion.DoExplosion(base.Position, map, 1f + (verVal * .05f), DamageDefOf.Burn, this.launcher, Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1,null) * comp.arcaneDmg * (1f + .02f * verVal)), 0, this.def.projectile.soundExplode, def, this.equipmentDef, this.intendedTarget.Thing, null, 0f, 1, false, null, 0f, 1, 0.0f, false);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_EarthernHammer.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_EarthernHammer.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 using System;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -59,14 +60,14 @@ namespace TorannMagic
         private void Initialize()
         {
             caster = this.launcher as Pawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-            pwrVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EarthernHammer.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthernHammer_pwr").level;
-            verVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EarthernHammer.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthernHammer_ver").level;
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
+            pwrVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EarthernHammer.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthernHammer_pwr").level;
+            verVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EarthernHammer.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthernHammer_ver").level;
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
-                verVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
+                pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
+                verVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
             }
             this.arcaneDmg = comp.arcaneDmg;
             if (settingsRef.AIHardMode && !caster.IsColonist)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Encase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Encase.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Verse.AI;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -54,14 +55,14 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 caster = this.launcher as Pawn;
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-                pwrVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Encase.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Encase_pwr").level;
-                verVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Encase.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Encase_ver").level;
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
+                pwrVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Encase.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Encase_pwr").level;
+                verVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Encase.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Encase_ver").level;
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
-                    verVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
+                    pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
+                    verVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
                 }
                 if (settingsRef.AIHardMode && !caster.IsColonist)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Explosion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Explosion.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -74,7 +75,7 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 caster = this.launcher as Pawn;
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
                 //verVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_Custom, "TM_Explosion", "_ver", true);
                 //pwrVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_Custom, "TM_Explosion", "_pwr", true);
                 verVal = TM_Calc.GetSkillVersatilityLevel(caster, TorannMagicDefOf.TM_Explosion);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Extinguish.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Extinguish.cs
@@ -4,6 +4,7 @@ using Verse;
 using System.Collections.Generic;
 using System.Linq;
 using System;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -19,7 +20,7 @@ namespace TorannMagic
             Pawn p = this.launcher as Pawn;
             if (p != null)
             {
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 if (comp != null)
                 {
                     if (comp.MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level >= 4)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_FertileLands.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_FertileLands.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using System.Linq;
 using System.Collections.Generic;
 using System;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -25,7 +26,7 @@ namespace TorannMagic
                 this.initialized = true;
             }
 
-            CompAbilityUserMagic comp = this.caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.caster.GetCompAbilityUserMagic();
             comp.fertileLands = new List<IntVec3>();
             comp.fertileLands.Clear();
             List<IntVec3> affectedCells = new List<IntVec3>();

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireball.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireball.cs
@@ -2,6 +2,7 @@
 using RimWorld;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -24,15 +25,15 @@ namespace TorannMagic
 			cellRect.ClipInsideMap(map);
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             Pawn pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Fireball.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Fireball_pwr");
-            MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Fireball.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Fireball_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Fireball.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Fireball_pwr");
+            MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Fireball.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Fireball_ver");
             pwrVal = pwr.level;
             verVal = ver.level;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firebolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firebolt.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -21,13 +22,13 @@ namespace TorannMagic
             Pawn victim = hitThing as Pawn;
             if (pawn != null)
             {
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Firebolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Firebolt_pwr");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Firebolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Firebolt_pwr");
                 pwrVal = pwr.level;
                 arcaneDmg = comp.arcaneDmg;
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
                     pwrVal = mpwr.level;
                 }
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireclaw.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireclaw.cs
@@ -3,6 +3,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -114,15 +115,15 @@ namespace TorannMagic
             base.Impact(hitThing);
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             Pawn pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Fireclaw.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Fireclaw_pwr");
-            MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Fireclaw.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Fireclaw_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Fireclaw.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Fireclaw_pwr");
+            MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Fireclaw.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Fireclaw_ver");
             pwrVal = pwr.level;
             verVal = ver.level;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firestorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firestorm.cs
@@ -2,6 +2,7 @@
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -43,9 +44,9 @@ namespace TorannMagic
         {
             
             pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Firestorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Firestorm_pwr");
-            ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Firestorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Firestorm_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Firestorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Firestorm_pwr");
+            ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Firestorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Firestorm_ver");
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             pwrVal = pwr.level;
             verVal = ver.level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 using System;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -42,18 +43,18 @@ namespace TorannMagic
 
             Pawn pawn = this.launcher as Pawn;
             Pawn victim = null;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if (comp != null)
             {
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_FogOfTorment.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_FogOfTorment_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_FogOfTorment.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_FogOfTorment_ver");
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_FogOfTorment.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_FogOfTorment_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_FogOfTorment.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_FogOfTorment_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_GraveBlade.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_GraveBlade.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -67,9 +68,9 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 this.caster = this.launcher as Pawn;               
-                CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
-                //pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_GraveBlade.FirstOrDefault((MightPowerSkill x) => x.label == "TM_GraveBlade_pwr").level;
-                //verVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_GraveBlade.FirstOrDefault((MightPowerSkill x) => x.label == "TM_GraveBlade_ver").level;
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
+                //pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_GraveBlade.FirstOrDefault((MightPowerSkill x) => x.label == "TM_GraveBlade_pwr").level;
+                //verVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_GraveBlade.FirstOrDefault((MightPowerSkill x) => x.label == "TM_GraveBlade_ver").level;
                 //verVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_GraveBlade, "TM_GraveBlade", "_ver", true);
                 //pwrVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_GraveBlade, "TM_GraveBlade", "_pwr", true);
                 //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Headshot.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Headshot.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI;
 using Verse.AI.Group;
@@ -30,9 +31,9 @@ namespace TorannMagic
             
             try
             {
-                CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                 //verVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_Headshot, "TM_Headshot", "_ver", true);
-                //MightPowerSkill ver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Headshot.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Headshot_ver");
+                //MightPowerSkill ver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Headshot.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Headshot_ver");
                 //verVal = ver.level;
                 //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 //{
@@ -62,7 +63,7 @@ namespace TorannMagic
 
         public static int GetWeaponDmg(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             //pwrVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_Headshot, "TM_Headshot", "_pwr", true);
             pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_Headshot);
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_HealingCircle.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_HealingCircle.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using System.Linq;
 using System.Collections.Generic;
 using System;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -67,15 +68,15 @@ namespace TorannMagic
 
             if(!this.initialized)
             {
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_HealingCircle.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_HealingCircle_pwr");
-                MagicPowerSkill ver = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_HealingCircle.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_HealingCircle_ver");
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_HealingCircle.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_HealingCircle_pwr");
+                MagicPowerSkill ver = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_HealingCircle.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_HealingCircle_ver");
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Heater.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Heater.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -21,7 +22,7 @@ namespace TorannMagic
             IntVec3 arg_pos_1;
 
             Pawn pawn = this.launcher as Pawn;
-            comp = pawn.GetComp<CompAbilityUserMagic>();
+            comp = pawn.GetCompAbilityUserMagic();
 
             CellRect cellRect = CellRect.CenteredOn(base.Position, 1);
             cellRect.ClipInsideMap(map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -64,7 +65,7 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 caster = this.launcher as Pawn;
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
                 MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_HolyWrath.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_HolyWrath_pwr");
                 MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_HolyWrath.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_HolyWrath_ver");
                 verVal = ver.level;
@@ -102,7 +103,7 @@ namespace TorannMagic
                 {
                     TM_MoteMaker.MakePowerBeamMoteColor(smitePos[j], base.Map, this.radius * 3f, 2f, .5f, .1f, .5f, colorInt.ToColor);
                     this.caster = this.launcher as Pawn;
-                    CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
                     GenExplosion.DoExplosion(smitePos[j], map, 3f, TMDamageDefOf.DamageDefOf.TM_Overwhelm, this.launcher as Pawn, Mathf.RoundToInt((12 + TMDamageDefOf.DamageDefOf.TM_Overwhelm.defaultDamage + 3*pwrVal) * this.arcaneDmg), 0, TorannMagicDefOf.TM_Lightning, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
                 }
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Icebolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Icebolt.cs
@@ -2,6 +2,7 @@
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -23,15 +24,15 @@ namespace TorannMagic
             ThingDef def = this.def;
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             Pawn pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Icebolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Icebolt_pwr");
-            MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Icebolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Icebolt_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Icebolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Icebolt_pwr");
+            MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Icebolt.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Icebolt_ver");
             pwrVal = pwr.level;
             verVal = ver.level;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_IgniteBlood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_IgniteBlood.cs
@@ -4,6 +4,7 @@ using Verse;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -86,16 +87,16 @@ namespace TorannMagic
                 this.BF.Clear();
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 Pawn pawn = this.launcher as Pawn;
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill bpwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_pwr");
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_IgniteBlood.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_IgniteBlood_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_IgniteBlood.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_IgniteBlood_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill bpwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_pwr");
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_IgniteBlood.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_IgniteBlood_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_IgniteBlood.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_IgniteBlood_ver");
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightLance.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightLance.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -64,7 +65,7 @@ namespace TorannMagic
         {
             caster = this.launcher as Pawn;
             this.launchPosition = caster.Position;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             //pwrVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_LightLance, "TM_LightLance", "_pwr", true);
             //verVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_LightLance, "TM_LightLance", "_ver", true);
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, TorannMagicDefOf.TM_LightLance);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightSkip.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightSkip.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System;
 using RimWorld;
 using RimWorld.Planet;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -69,8 +70,8 @@ namespace TorannMagic
             {
                 this.pawn = this.launcher as Pawn;
                 this.map = this.pawn.Map;
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightSkip.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightSkip_pwr");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightSkip.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightSkip_pwr");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightSkipMass.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightSkipMass.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System;
 using RimWorld;
 using RimWorld.Planet;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -81,7 +82,7 @@ namespace TorannMagic
             {
                 this.pawn = this.launcher as Pawn;
                 launcherPosition = this.Launcher.Position;
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 //pwrVal = TM_Calc.GetMagicSkillLevel(this.pawn, comp.MagicData.MagicPowerSkill_LightSkip, "TM_LightSkip", "_pwr", false);
                 pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_LightSkip, false);
                 this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
@@ -5,6 +5,7 @@ using Verse;
 using UnityEngine;
 using System.Collections.Generic;
 using System;
+using TorannMagic.Extensions;
 using Verse.Sound;
 
 namespace TorannMagic
@@ -64,7 +65,7 @@ namespace TorannMagic
             if (!t.DestroyedOrNull() && t is Pawn)
             {
                 Pawn p = t as Pawn;
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 if (comp != null && comp.MagicData != null)
                 {
                     //pwrVal = TM_Calc.GetMagicSkillLevel(p, comp.MagicData.MagicPowerSkill_ChainLightning, "TM_ChainLightning", "_pwr", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningCloud.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningCloud.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -57,17 +58,17 @@ namespace TorannMagic
             
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
-                this.arcaneDmg = pawn.GetComp<CompAbilityUserMight>().mightPwr;
+                this.arcaneDmg = pawn.GetCompAbilityUserMight().mightPwr;
             }
             else
             {
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningCloud.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningCloud_pwr");
-                ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningCloud.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningCloud_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningCloud.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningCloud_pwr");
+                ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningCloud.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningCloud_ver");
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_LightningStorm.cs
@@ -1,6 +1,7 @@
 ﻿using AbilityUser;
 using RimWorld;
 using System.Linq;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -48,17 +49,17 @@ namespace TorannMagic
             
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
-                this.arcaneDmg = pawn.GetComp<CompAbilityUserMight>().mightPwr;
+                this.arcaneDmg = pawn.GetCompAbilityUserMight().mightPwr;
             }
             else
             {
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningStorm_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_LightningStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningStorm_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningStorm_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_LightningStorm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_LightningStorm_ver");
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Mk203GL.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Mk203GL.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -28,7 +29,7 @@ namespace TorannMagic
             {
                 caster = this.launcher as Pawn;
                 this.strikePos = base.Position;
-                CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                 //verVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_RifleSpec, "TM_RifleSpec", "_ver", true);
                 verVal = TM_Calc.GetSkillVersatilityLevel(caster, TorannMagicDefOf.TM_RifleSpec, true);
                 this.radius = this.def.projectile.explosionRadius;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_OrbitalStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_OrbitalStrike.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -64,9 +65,9 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 caster = this.launcher as Pawn;
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_OrbitalStrike.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_OrbitalStrike_pwr");
-                MagicPowerSkill ver = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_OrbitalStrike.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_OrbitalStrike_ver");
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_OrbitalStrike.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_OrbitalStrike_pwr");
+                MagicPowerSkill ver = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_OrbitalStrike.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_OrbitalStrike_ver");
                 verVal = ver.level;
                 pwrVal = pwr.level;
                 this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Overwhelm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Overwhelm.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using System.Linq;
 using UnityEngine;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -22,16 +23,16 @@ namespace TorannMagic
         private void Initialize(Pawn pawn)
         {
             GenClamor.DoClamor(this.launcher, 5f, ClamorDefOf.Impact);
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overwhelm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Overwhelm_pwr");
-            ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Overwhelm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Overwhelm_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overwhelm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Overwhelm_pwr");
+            ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Overwhelm.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Overwhelm_ver");
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             pwrVal = pwr.level;
             verVal = ver.level;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Poison.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Poison.cs
@@ -3,6 +3,7 @@ using Verse;
 using AbilityUser;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 
@@ -45,19 +46,19 @@ namespace TorannMagic
             ThingDef def = this.def;
                         
             caster = this.launcher as Pawn;
-            pwr = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Poison.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Poison_pwr");
-            ver = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Poison.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Poison_ver");
+            pwr = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Poison.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Poison_pwr");
+            ver = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Poison.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Poison_ver");
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             pwrVal = pwr.level;
             verVal = ver.level;
             if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }
-            this.arcaneDmg = caster.GetComp<CompAbilityUserMagic>().arcaneDmg;
+            this.arcaneDmg = caster.GetCompAbilityUserMagic().arcaneDmg;
             if (settingsRef.AIHardMode && !caster.IsColonist)
             {
                 pwrVal = 3;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_PoisonFlask.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_PoisonFlask.cs
@@ -3,6 +3,7 @@ using RimWorld;
 using Verse;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -31,7 +32,7 @@ namespace TorannMagic
                 if (caster != null && !initialized)
                 {
                     initialized = true;
-                    CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                     int verVal = TM_Calc.GetSkillVersatilityLevel(caster, TorannMagicDefOf.TM_PoisonFlask, false);
                     int pwrVal = TM_Calc.GetSkillPowerLevel(caster, TorannMagicDefOf.TM_PoisonFlask, false);
                     Map map = base.Map;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Possess.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Possess.cs
@@ -7,6 +7,7 @@ using RimWorld;
 using Verse.AI;
 using Verse.AI.Group;
 using System;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -55,8 +56,8 @@ namespace TorannMagic
                 caster = this.launcher as Pawn;
                 hitPawn = hitThing as Pawn;
                 this.oldPosition = caster.Position;
-                MightPowerSkill pwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Possess.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Possess_pwr");
-                MightPowerSkill ver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Possess.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Possess_ver");
+                MightPowerSkill pwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Possess.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Possess_pwr");
+                MightPowerSkill ver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Possess.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Possess_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;
@@ -305,7 +306,7 @@ namespace TorannMagic
                             {
                                 hitPawn.workSettings.SetPriority(allWorkTypes[i], hitPawnWorkSetting[i]);
                             }
-                            CompAbilityUserMagic comp = hitPawn.GetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic comp = hitPawn.GetCompAbilityUserMagic();
                             if(comp != null && comp.IsMagicUser)
                             {
                                 comp.magicPowersInitializedForColonist = true;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_PowerNode.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_PowerNode.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -21,7 +22,7 @@ namespace TorannMagic
             IntVec3 arg_pos_1;
 
             Pawn pawn = this.launcher as Pawn;
-            comp = pawn.GetComp<CompAbilityUserMagic>();
+            comp = pawn.GetCompAbilityUserMagic();
 
             CellRect cellRect = CellRect.CenteredOn(base.Position, 1);
             cellRect.ClipInsideMap(map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsionicBlast.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsionicBlast.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using UnityEngine;
 using RimWorld;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -25,23 +26,23 @@ namespace TorannMagic
             Pawn victim = hitThing as Pawn;
             if(!pawn.Spawned)
             {
-                //pwrVal = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_pwr").level;
-                //pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicStorm, "TM_PsionicStorm", "_pwr", true);
+                //pwrVal = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_pwr").level;
+                //pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicStorm, "TM_PsionicStorm", "_pwr", true);
                 pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_PsionicStorm, false);
-                arcaneDmg = pawn.GetComp<CompAbilityUserMight>().mightPwr;
+                arcaneDmg = pawn.GetCompAbilityUserMight().mightPwr;
             }
             else
             {
-                //MightPowerSkill pwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicBlast.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicBlast_pwr");
-                //pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicBlast, "TM_PsionicBlast", "_pwr", true);
+                //MightPowerSkill pwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicBlast.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicBlast_pwr");
+                //pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicBlast, "TM_PsionicBlast", "_pwr", true);
                 //pwrVal = pwr.level;
                 pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_PsionicBlast, false);
-                arcaneDmg = pawn.GetComp<CompAbilityUserMight>().mightPwr;
+                arcaneDmg = pawn.GetCompAbilityUserMight().mightPwr;
             }
            
             //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
             //    pwrVal = mpwr.level;
             //}
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsychicShock.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsychicShock.cs
@@ -4,6 +4,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -48,9 +49,9 @@ namespace TorannMagic
             {
                 pawn = this.launcher as Pawn;
                 float psychicEnergy = pawn.GetStatValue(StatDefOf.PsychicSensitivity, false);
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_PsychicShock.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_PsychicShock_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_PsychicShock.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_PsychicShock_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_PsychicShock.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_PsychicShock_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_PsychicShock.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_PsychicShock_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -23,7 +24,7 @@ namespace TorannMagic
 
             Pawn pawn = this.launcher as Pawn;
             Pawn victim = hitThing as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             pwr = comp.MagicData.MagicPowerSkill_RaiseUndead.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RaiseUndead_pwr");
             ver = comp.MagicData.MagicPowerSkill_RaiseUndead.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RaiseUndead_ver");
 
@@ -170,13 +171,13 @@ namespace TorannMagic
                                                 undeadPawn.guest.SetGuestStatus(pawn.Faction, GuestStatus.Slave);
                                             }
 
-                                            CompAbilityUserMagic compMagic = undeadPawn.GetComp<CompAbilityUserMagic>();
+                                            CompAbilityUserMagic compMagic = undeadPawn.GetCompAbilityUserMagic();
                                             if (compMagic != null && TM_Calc.IsMagicUser(undeadPawn)) //(compMagic.IsMagicUser && !undeadPawn.story.traits.HasTrait(TorannMagicDefOf.Faceless)) || 
                                             {
                                                 compMagic.Initialize();
                                                 compMagic.RemovePowers(true);
                                             }
-                                            CompAbilityUserMight compMight = undeadPawn.GetComp<CompAbilityUserMight>();
+                                            CompAbilityUserMight compMight = undeadPawn.GetCompAbilityUserMight();
                                             if (compMight != null && TM_Calc.IsMightUser(undeadPawn)) //compMight.IsMightUser || 
                                             {
                                                 compMight.Initialize();
@@ -208,7 +209,7 @@ namespace TorannMagic
                                             
                                             //Color undeadColor = new Color(.2f, .4f, 0);
                                             //undeadPawn.story.hairColor = undeadColor;
-                                            //CompAbilityUserMagic undeadComp = undeadPawn.GetComp<CompAbilityUserMagic>();
+                                            //CompAbilityUserMagic undeadComp = undeadPawn.GetCompAbilityUserMagic();
                                             //if (undeadComp.IsMagicUser)
                                             //{
                                             //    undeadComp.ClearPowers();

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Refraction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Refraction.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using Verse.AI;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -90,7 +91,7 @@ namespace TorannMagic
         {
             if (caster != null)
             {
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
                 //pwrVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_Refraction, "TM_Refraction", "_pwr", TorannMagicDefOf.TM_Refraction.canCopy);
                 //verVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_Refraction, "TM_Refraction", "_ver", TorannMagicDefOf.TM_Refraction.canCopy);
                 pwrVal = TM_Calc.GetSkillPowerLevel(caster, TorannMagicDefOf.TM_Refraction);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Repulsion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Repulsion.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -63,16 +64,16 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 this.pawn = this.launcher as Pawn;
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Repulsion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Repulsion_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Repulsion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Repulsion_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Repulsion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Repulsion_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Repulsion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Repulsion_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
@@ -4,6 +4,7 @@ using RimWorld;
 using AbilityUser;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -67,9 +68,9 @@ namespace TorannMagic
                 if (this.launcher is Pawn)
                 {
                     caster = this.launcher as Pawn;
-                    CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-                    MagicPowerSkill ver = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_ver");
-                    MagicPowerSkill pwr = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_eff");
+                    CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
+                    MagicPowerSkill ver = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_ver");
+                    MagicPowerSkill pwr = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Resurrection_eff");
                     verVal = ver.level;
                     pwrVal = pwr.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sabotage.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sabotage.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System;
 using RimWorld;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -67,14 +68,14 @@ namespace TorannMagic
             if (!this.initialized)
             {
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
 
                 pwrVal = comp.MagicData.MagicPowerSkill_Sabotage.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Sabotage_pwr").level;
                 verVal = comp.MagicData.MagicPowerSkill_Sabotage.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Sabotage_ver").level;
                 if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Scorn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Scorn.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -75,9 +76,9 @@ namespace TorannMagic
             {
                 this.pawn = this.launcher as Pawn;
                 this.map = this.pawn.Map;                
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Scorn.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Scorn_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Scorn.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Scorn_ver");
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Scorn.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Scorn_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Scorn.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Scorn_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sentinel.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 using System;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -42,8 +43,8 @@ namespace TorannMagic
             }
             else
             {
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-                verVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Sentinel.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Sentinel_ver").level;
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
+                verVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Sentinel.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Sentinel_ver").level;
 
                 if (comp.summonedSentinels.Count > verVal + 1)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -54,7 +55,7 @@ namespace TorannMagic
             {
                 this.initialized = true;
                 this.caster = this.launcher as Pawn;               
-                CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                 //verVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_ShadowStrike, "TM_ShadowStrike", "_ver", true);    
                 verVal = TM_Calc.GetSkillVersatilityLevel(caster, TorannMagicDefOf.TM_ShadowStrike);
                 this.startPos = caster.Position;
@@ -285,7 +286,7 @@ namespace TorannMagic
 
         public static int GetWeaponDmg(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             int pwrVal = comp.MightData.MightPowerSkill_ShadowStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_ShadowStrike_pwr").level;
             float dmg = comp.weaponDamage;
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SiphonMana.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SiphonMana.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using System.Linq;
 using RimWorld;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -16,8 +17,8 @@ namespace TorannMagic
 
             Pawn hitPawn = hitThing as Pawn;
             Pawn caster = this.launcher as Pawn;
-            CompAbilityUserMagic compHitPawn = hitPawn.GetComp<CompAbilityUserMagic>();            
-            CompAbilityUserMagic compCaster = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compHitPawn = hitPawn.GetCompAbilityUserMagic();
+            CompAbilityUserMagic compCaster = caster.GetCompAbilityUserMagic();
 
             if (hitPawn != null && !hitPawn.Dead && !caster.Dead && !caster.Downed && caster != null)
             {
@@ -27,7 +28,7 @@ namespace TorannMagic
                     {
                         if (compHitPawn != null && compHitPawn.IsMagicUser)
                         {
-                            MagicPowerSkill regen = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
+                            MagicPowerSkill regen = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
                             float manaDrained = compHitPawn.Mana.CurLevel;
                             if (manaDrained > (.5f * compCaster.arcaneDmg))
                             {
@@ -74,7 +75,7 @@ namespace TorannMagic
                 {
                     if (compHitPawn != null && compHitPawn.IsMagicUser)
                     {
-                        MagicPowerSkill regen = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
+                        MagicPowerSkill regen = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
                         float manaDrained = compHitPawn.Mana.CurLevel;
                         if (manaDrained > .5f)
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SmokeCloud.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SmokeCloud.cs
@@ -4,6 +4,7 @@ using Verse;
 using System.Linq;
 using System;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -18,11 +19,11 @@ namespace TorannMagic
             float explosionRadius = this.def.projectile.explosionRadius;
             if (p != null)
             {
-                if (p.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level >= 2)
+                if (p.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level >= 2)
                 {
                     explosionRadius += 2f;
                 }
-                if (p.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level >= 1)
+                if (p.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level >= 1)
                 {
                     List<Pawn> blindedPawns = TM_Calc.FindAllPawnsAround(map, base.Position, explosionRadius);
                     if (blindedPawns != null && blindedPawns.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Snowball.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Snowball.cs
@@ -2,6 +2,7 @@
 using RimWorld;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -20,16 +21,16 @@ namespace TorannMagic
 			ThingDef def = this.def;
             
             Pawn pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Snowball.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Snowball_pwr");
-            MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Snowball.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Snowball_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Snowball.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Snowball_pwr");
+            MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Snowball.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Snowball_ver");
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             pwrVal = pwr.level;
             verVal = ver.level;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spinning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spinning.cs
@@ -6,6 +6,7 @@ using RimWorld;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -21,7 +22,7 @@ namespace TorannMagic
             if(Find.TickManager.TicksGame % 2 == 0 && daggerCount > 0 && this.launcher != null && this.launcher is Pawn)
             {
                 Pawn caster = this.launcher as Pawn;
-                CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                 if(comp != null)
                 {
                     ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
@@ -55,7 +56,7 @@ namespace TorannMagic
                 if (pawn != null)
                 {
                     Pawn victim = hitThing as Pawn;
-                    CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
 
                     if (victim != null && comp != null && Rand.Chance(.8f))
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spite.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Spite.cs
@@ -3,6 +3,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -21,15 +22,15 @@ namespace TorannMagic
 
             Pawn pawn = this.launcher as Pawn;
             Pawn victim = hitThing as Pawn;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
-            MightPowerSkill pwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Spite.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Spite_pwr");
-            MightPowerSkill ver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Spite.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Spite_ver");
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
+            MightPowerSkill pwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Spite.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Spite_pwr");
+            MightPowerSkill ver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Spite.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Spite_ver");
             pwrVal = pwr.level;
             verVal = ver.level;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonDemon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonDemon.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse;
 using Verse.Sound;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI.Group;
 
@@ -76,7 +77,7 @@ namespace TorannMagic
         private void Initialize()
         {
             this.casterPawn = this.launcher as Pawn;
-            this.comp = this.casterPawn.GetComp<CompAbilityUserMagic>();
+            this.comp = this.casterPawn.GetCompAbilityUserMagic();
             this.sacrificedPawn = comp.soulBondPawn;
             this.sacrificedPawn.TakeDamage(new DamageInfo(DamageDefOf.Stun, 50, 50, -1, null, null, null, DamageInfo.SourceCategory.ThingOrUnknown, this.sacrificedPawn));
             HealthUtility.AdjustSeverity(this.sacrificedPawn, HediffDef.Named("TM_HediffTimedInvulnerable"), 2);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonElemental.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonElemental.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Verse;
 using Verse.AI;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI.Group;
 
@@ -54,15 +55,15 @@ namespace TorannMagic
             {
                 SpawnThings spawnThing = new SpawnThings();
                 pawn = this.launcher as Pawn;
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonElemental.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonElemental_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonElemental.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonElemental_ver");
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonElemental.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonElemental_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonElemental.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonElemental_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
-                    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                     pwrVal = mpwr.level;
                     verVal = mver.level;
                 }
@@ -79,7 +80,7 @@ namespace TorannMagic
                 random = new System.Random();
  
                 duration += (verVal * 900);
-                duration = Mathf.RoundToInt(duration * pawn.GetComp<CompAbilityUserMagic>().arcaneDmg);
+                duration = Mathf.RoundToInt(duration * pawn.GetCompAbilityUserMagic().arcaneDmg);
 
                 int rnd = GenMath.RoundRandom(random.Next(0, 8));
                 if (rnd < 2)
@@ -342,7 +343,7 @@ namespace TorannMagic
                         }
                         catch
                         {
-                            pawn.GetComp<CompAbilityUserMagic>().Mana.CurLevel += pawn.GetComp<CompAbilityUserMagic>().ActualManaCost(TorannMagicDefOf.TM_SummonElemental);
+                            pawn.GetCompAbilityUserMagic().Mana.CurLevel += pawn.GetCompAbilityUserMagic().ActualManaCost(TorannMagicDefOf.TM_SummonElemental);
                             Log.Message("TM_Exception".Translate(
                                 pawn.LabelShort,
                                 this.def.defName

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonExplosive.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonExplosive.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -40,16 +41,16 @@ namespace TorannMagic
             IntVec3 arg_pos_1;
             GenClamor.DoClamor(this, 2.1f, ClamorDefOf.Impact);
             Pawn pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonExplosive.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonExplosive_pwr");
-            MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonExplosive.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonExplosive_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonExplosive.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonExplosive_pwr");
+            MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonExplosive.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonExplosive_ver");
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             pwrVal = pwr.level;
             verVal = ver.level;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonMinion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonMinion.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Verse;
 using Verse.AI;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse.AI.Group;
 
 namespace TorannMagic
@@ -59,9 +60,9 @@ namespace TorannMagic
             {
                 SpawnThings spawnThing = new SpawnThings();
                 pawn = this.launcher as Pawn;
-                comp = pawn.GetComp<CompAbilityUserMagic>();
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonMinion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonMinion_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonMinion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonMinion_ver");
+                comp = pawn.GetCompAbilityUserMagic();
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonMinion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonMinion_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonMinion.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonMinion_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;
@@ -72,9 +73,9 @@ namespace TorannMagic
                 }
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer) || (comp.customClass != null && comp.customClass.classMageAbilities.Contains(TorannMagicDefOf.TM_Cantrips)))
                 {
-                    int tmpPwrVal = (int)((pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level) / 5);
+                    int tmpPwrVal = (int)((pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level) / 5);
                     pwrVal = (tmpPwrVal > pwrVal) ? tmpPwrVal : pwrVal;
-                    int tmpVerVal = (int)((pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level) / 5);
+                    int tmpVerVal = (int)((pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level) / 5);
                     verVal = (tmpVerVal > verVal) ? tmpVerVal : verVal;
                 }
                 CellRect cellRect = CellRect.CenteredOn(this.Position, 1);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonPoppi.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonPoppi.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI.Group;
 
@@ -38,12 +39,12 @@ namespace TorannMagic
                 this.initialized = true;
                 SpawnThings spawnThing = new SpawnThings();
                 pawn = this.launcher as Pawn;
-                MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonPoppi.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonPoppi_pwr");
-                MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonPoppi.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonPoppi_ver");
+                MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonPoppi.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonPoppi_pwr");
+                MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonPoppi.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonPoppi_ver");
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 pwrVal = pwr.level;
                 verVal = ver.level;
-                this.arcaneDmg = pawn.GetComp<CompAbilityUserMagic>().arcaneDmg;
+                this.arcaneDmg = pawn.GetCompAbilityUserMagic().arcaneDmg;
                 if (settingsRef.AIHardMode && !pawn.IsColonist)
                 {
                     pwrVal = 1;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonPylon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SummonPylon.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -59,15 +60,15 @@ namespace TorannMagic
             IntVec3 arg_pos_1;
 
             Pawn pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonPylon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonPylon_pwr");
-            MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SummonPylon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonPylon_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonPylon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonPylon_pwr");
+            MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SummonPylon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SummonPylon_ver");
             verVal = ver.level;
             pwrVal = pwr.level;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sunfire.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sunfire.cs
@@ -6,6 +6,7 @@ using AbilityUser;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -70,7 +71,7 @@ namespace TorannMagic
         private void Initialize()
         {
             caster = this.launcher as Pawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             if (comp != null && comp.MagicData != null)
             {
                 //pwrVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_Sunfire, "TM_Sunfire", "_pwr", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sunlight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sunlight.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -20,7 +21,7 @@ namespace TorannMagic
             IntVec3 arg_pos_1;
 
             Pawn pawn = this.launcher as Pawn;
-            comp = pawn.GetComp<CompAbilityUserMagic>();
+            comp = pawn.GetCompAbilityUserMagic();
 
             CellRect cellRect = CellRect.CenteredOn(base.Position, 1);
             cellRect.ClipInsideMap(map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_TechnoTurret.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_TechnoTurret.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse.AI;
 using UnityEngine;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -23,17 +24,17 @@ namespace TorannMagic
             Map map = this.launcher.Map;
             Pawn pawn = this.launcher as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoTurret_pwr");
-            MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoTurret_ver");
-            effVal = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoTurret_eff").level;
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoTurret_pwr");
+            MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoTurret_ver");
+            effVal = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoTurret_eff").level;
             verVal = ver.level;
             pwrVal = pwr.level;
             arcaneDmg = comp.arcaneDmg;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Teleport.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Teleport.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using Verse;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 
@@ -45,7 +46,7 @@ namespace TorannMagic
             IntVec3 arg_pos_3;
 
             Pawn pawn = this.launcher as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_Teleport.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Teleport_pwr");
             MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_Teleport.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Teleport_ver");
             pwrVal = pwr.level;
@@ -55,8 +56,8 @@ namespace TorannMagic
             IntVec3 centerCell = cellRect.CenterCell;
             if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer) || (comp.customClass != null && comp.customClass.classMageAbilities.Contains(TorannMagicDefOf.TM_Cantrips)))
             {
-                int tmpPwrVal = (int)((pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level) / 5);
-                int tmpVerVal = (int)((pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level) / 5);
+                int tmpPwrVal = (int)((pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level) / 5);
+                int tmpVerVal = (int)((pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level) / 5);
                 pwrVal = (tmpPwrVal > pwrVal) ? tmpPwrVal : pwrVal;
                 verVal = (tmpVerVal > verVal) ? tmpVerVal : verVal;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_TempestStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_TempestStrike.cs
@@ -6,6 +6,7 @@ using RimWorld;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -27,7 +28,7 @@ namespace TorannMagic
                 if (pawn != null)
                 {
                     Pawn victim = hitThing as Pawn;
-                    CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
 
                     if (victim != null && comp != null)
                     {
@@ -78,7 +79,7 @@ namespace TorannMagic
         {
             if (pawn != null)
             {
-                CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                 if (comp != null)
                 {
                     float dmgNum = 0;                    

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ThunderStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ThunderStrike.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Linq;
 using RimWorld;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -119,18 +120,18 @@ namespace TorannMagic
             {
                 verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_ThunderStrike, false);
                 pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_ThunderStrike, false);
-                //verVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ThunderStrike, "TM_ThunderStrike", "_ver", true);
-                //pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ThunderStrike, "TM_ThunderStrike", "_pwr", true);
-                //this.verVal = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ThunderStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_ThunderStrike_ver").level;
-                //this.pwrVal = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_ThunderStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_ThunderStrike_pwr").level;
+                //verVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ThunderStrike, "TM_ThunderStrike", "_ver", true);
+                //pwrVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ThunderStrike, "TM_ThunderStrike", "_pwr", true);
+                //this.verVal = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ThunderStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_ThunderStrike_ver").level;
+                //this.pwrVal = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_ThunderStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_ThunderStrike_pwr").level;
                 //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 //{
-                //    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
-                //    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                //    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                //    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
                 //    verVal = mver.level;
                 //    pwrVal = mpwr.level;
                 //}
-                this.arcaneDmg = pawn.GetComp<CompAbilityUserMight>().mightPwr;
+                this.arcaneDmg = pawn.GetCompAbilityUserMight().mightPwr;
                 this.origin = pawn.Position.ToVector3Shifted();
                 this.destination = target.ToVector3Shifted();
                 this.direction = TM_Calc.GetVector(this.origin, this.destination);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_TransferMana.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_TransferMana.cs
@@ -1,6 +1,7 @@
 ﻿using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -15,14 +16,14 @@ namespace TorannMagic
 
             Pawn hitPawn = hitThing as Pawn;
             Pawn caster = this.launcher as Pawn;
-            CompAbilityUserMagic compHitPawn = hitPawn.GetComp<CompAbilityUserMagic>();            
-            CompAbilityUserMagic compCaster = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compHitPawn = hitPawn.GetCompAbilityUserMagic();
+            CompAbilityUserMagic compCaster = caster.GetCompAbilityUserMagic();
 
             if (hitPawn != null && compHitPawn != null)
             {
                 if (compHitPawn.IsMagicUser && compHitPawn.MagicData != null && compHitPawn.Mana != null)
                 {
-                    MagicPowerSkill regen = hitPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
+                    MagicPowerSkill regen = hitPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
                     compHitPawn.Mana.CurLevel += (.2f + (.01f * regen.level)) * compCaster.arcaneDmg;
                     TM_MoteMaker.ThrowManaPuff(hitPawn.DrawPos, hitPawn.Map, 1f);
                     TM_MoteMaker.ThrowManaPuff(hitPawn.DrawPos, hitPawn.Map, 1f);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ValiantCharge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ValiantCharge.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Linq;
 using RimWorld;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -65,9 +66,9 @@ namespace TorannMagic
             pawn = this.launcher as Pawn;
             pawn.health.AddHediff(invul, null, null);
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ValiantCharge_pwr");
-            MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ValiantCharge_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ValiantCharge_pwr");
+            MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ValiantCharge_ver");
 
             if (initialize)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_WaveOfFear.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_WaveOfFear.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using System.Linq;
 using System.Collections.Generic;
 using System;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.Sound;
 using Verse.AI;
@@ -70,16 +71,16 @@ namespace TorannMagic
 
             if(!this.initialized)
             {
-                CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
-                //pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_WaveOfFear.FirstOrDefault((MightPowerSkill x) => x.label == "TM_WaveOfFear_pwr").level;
-                //verVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_WaveOfFear.FirstOrDefault((MightPowerSkill x) => x.label == "TM_WaveOfFear_ver").level;
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
+                //pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_WaveOfFear.FirstOrDefault((MightPowerSkill x) => x.label == "TM_WaveOfFear_pwr").level;
+                //verVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_WaveOfFear.FirstOrDefault((MightPowerSkill x) => x.label == "TM_WaveOfFear_ver").level;
                 //verVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_WaveOfFear, "TM_WaveOfFear", "_ver", true);
                 //pwrVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_WaveOfFear, "TM_WaveOfFear", "_pwr", true);
-                //effVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_WaveOfFear.FirstOrDefault((MightPowerSkill x) => x.label == "TM_WaveOfFear_eff").level;
+                //effVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_WaveOfFear.FirstOrDefault((MightPowerSkill x) => x.label == "TM_WaveOfFear_eff").level;
                 //if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 //{
-                //    MightPowerSkill mpwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                //    MightPowerSkill mver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                //    MightPowerSkill mpwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                //    MightPowerSkill mver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 //    pwrVal = mpwr.level;
                 //    verVal = mver.level;
                 //}

--- a/RimWorldOfMagic/RimWorldOfMagic/Recipe_RegrowBodyPart.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Recipe_RegrowBodyPart.cs
@@ -2,6 +2,7 @@
 using Verse;
 using RimWorld;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -38,7 +39,7 @@ namespace TorannMagic
         public bool CheckDruidSurgeryFail(Pawn surgeon, Pawn patient, List<Thing> ingredients, BodyPartRecord part, Bill bill)
         {
 
-            CompAbilityUserMagic comp = surgeon.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = surgeon.GetCompAbilityUserMagic();
 
             string reason;
             if (comp.IsMagicUser)
@@ -54,7 +55,7 @@ namespace TorannMagic
                 }
                 if (canRegrow)
                 {
-                    MagicPowerSkill eff = surgeon.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RegrowLimb.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RegrowLimb_eff");
+                    MagicPowerSkill eff = surgeon.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RegrowLimb.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RegrowLimb_eff");
                     if (comp.Mana.CurLevel < (.9f - ((eff.level * TorannMagicDefOf.TM_RegrowLimb.efficiencyReductionPercent) * .9f)))
                     {
                         comp.Mana.CurLevel = comp.Mana.CurLevel / 2;
@@ -112,7 +113,7 @@ namespace TorannMagic
         public void ApplyHediff(Pawn patient, BodyPartRecord part, Pawn billdoer)
         {
 
-            CompAbilityUserMagic comp = billdoer.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = billdoer.GetCompAbilityUserMagic();
             switch (part.def.defName)
             {
                 case "Foot":

--- a/RimWorldOfMagic/RimWorldOfMagic/Recipe_RegrowUniversalBodyPart.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Recipe_RegrowUniversalBodyPart.cs
@@ -2,6 +2,7 @@
 using Verse;
 using RimWorld;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -75,7 +76,7 @@ namespace TorannMagic
         public bool CheckDruidSurgeryFail(Pawn surgeon, Pawn patient, List<Thing> ingredients, BodyPartRecord part, Bill bill)
         {
 
-            CompAbilityUserMagic comp = surgeon.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = surgeon.GetCompAbilityUserMagic();
 
             string reason;
             if (comp.IsMagicUser)
@@ -91,7 +92,7 @@ namespace TorannMagic
                 }
                 if (canRegrow)
                 {
-                    MagicPowerSkill eff = surgeon.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RegrowLimb.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RegrowLimb_eff");
+                    MagicPowerSkill eff = surgeon.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RegrowLimb.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RegrowLimb_eff");
                     if (comp.Mana.CurLevel < (.9f - ((eff.level * .08f) * .9f)))
                     {
                         comp.Mana.CurLevel = comp.Mana.CurLevel / 2;

--- a/RimWorldOfMagic/RimWorldOfMagic/Recipe_RuneCarving.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Recipe_RuneCarving.cs
@@ -7,6 +7,7 @@ using RimWorld;
 using Verse;
 using UnityEngine;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -86,7 +87,7 @@ namespace TorannMagic
 
 		public bool CheckRuneCarvingFail(Pawn surgeon, Pawn patient, List<Thing> ingredients, BodyPartRecord part, Bill bill)
 		{
-			CompAbilityUserMagic comp = surgeon.GetComp<CompAbilityUserMagic>();
+			CompAbilityUserMagic comp = surgeon.GetCompAbilityUserMagic();
 			if (bill.recipe.surgerySuccessChanceFactor >= 1f)
 			{
 				return false;
@@ -110,7 +111,7 @@ namespace TorannMagic
                 }
 				if (canRuneCarve)
 				{
-					MagicPowerSkill eff = surgeon.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RuneCarving.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RuneCarving_eff");
+					MagicPowerSkill eff = surgeon.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RuneCarving.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RuneCarving_eff");
 					float manaNeeded = TorannMagicDefOf.TM_RuneCarving.manaCost - ((eff.level * TorannMagicDefOf.TM_RuneCarving.efficiencyReductionPercent) * TorannMagicDefOf.TM_RuneCarving.manaCost);
 					if (comp.Mana.CurLevel < manaNeeded)
 					{
@@ -135,8 +136,8 @@ namespace TorannMagic
 					{						
 						float runeChance = surgeon.GetStatValue(TorannMagicDefOf.TM_RuneCarvingEfficiency);
 						float num = bill.recipe.surgerySuccessChanceFactor * runeChance;
-						int pwrVal = surgeon.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RuneCarving.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RuneCarving_pwr").level;
-						int verVal = surgeon.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RuneCarving.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RuneCarving_ver").level;
+						int pwrVal = surgeon.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RuneCarving.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RuneCarving_pwr").level;
+						int verVal = surgeon.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RuneCarving.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RuneCarving_ver").level;
 						float successChance = num + (pwrVal * -.05f) + (verVal * .1f);
 						comp.Mana.CurLevel -= manaNeeded;
 						int xpGain = Mathf.RoundToInt(TorannMagicDefOf.TM_RuneCarving.manaCost * 180 * comp.xpGain);
@@ -195,7 +196,7 @@ namespace TorannMagic
 
 		public virtual void RunePart(Pawn pawn, Pawn carver, BodyPartRecord part)
 		{
-			int pwrVal = carver.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_RuneCarving.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RuneCarving_pwr").level;
+			int pwrVal = carver.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_RuneCarving.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_RuneCarving_pwr").level;
             Hediff hd = null;
             if (part.IsCorePart)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
+    <Compile Include="Extensions\ThingWithCompsExtensions.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />
     <Compile Include="TMDefs\TM_Branding.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/SihvRMagicScrollScribe/CompUseEffect_WriteFullScript.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/SihvRMagicScrollScribe/CompUseEffect_WriteFullScript.cs
@@ -1,4 +1,5 @@
 ﻿using RimWorld;
+using TorannMagic.Extensions;
 using Verse;
 
 namespace TorannMagic.SihvRMagicScrollScribe
@@ -11,7 +12,7 @@ namespace TorannMagic.SihvRMagicScrollScribe
             ThingDef tempPod = null;
             IntVec3 currentPos = parent.PositionHeld;
             Map map = parent.Map;
-            CompAbilityUserMagic comp = user.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = user.GetCompAbilityUserMagic();
 
             if (parent.def != null && comp != null)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/SihvRMagicScrollScribe/CompUseEffect_WriteMartialScript.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/SihvRMagicScrollScribe/CompUseEffect_WriteMartialScript.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using Verse;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 using TorannMagic.TMDefs;
 
@@ -16,7 +17,7 @@ namespace TorannMagic.SihvRMagicScrollScribe
             Map map = parent.Map;
             List<TMDefs.TM_CustomClass> cFighters = TM_ClassUtility.CustomFighterClasses;
             
-            CompAbilityUserMight comp = user.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = user.GetCompAbilityUserMight();
             if (parent.def != null && comp != null && user.IsSlave)
             {
                 Messages.Message("TM_SlaveScribeFail".Translate(

--- a/RimWorldOfMagic/RimWorldOfMagic/SihvRMagicScrollScribe/CompUseEffect_WriteSpell_Rain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/SihvRMagicScrollScribe/CompUseEffect_WriteSpell_Rain.cs
@@ -1,4 +1,5 @@
 ﻿using RimWorld;
+using TorannMagic.Extensions;
 using Verse;
 
 namespace TorannMagic.SihvRMagicScrollScribe
@@ -7,7 +8,7 @@ namespace TorannMagic.SihvRMagicScrollScribe
     {
         public override void DoEffect(Pawn user)
         {
-            CompAbilityUserMagic comp = user.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = user.GetCompAbilityUserMagic();
 
             if (parent.def != null && comp.spell_Rain == true)
             {}

--- a/RimWorldOfMagic/RimWorldOfMagic/SihvRMagicScrollScribe/CompUseEffect_WriteTornScript.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/SihvRMagicScrollScribe/CompUseEffect_WriteTornScript.cs
@@ -1,4 +1,5 @@
 ﻿using RimWorld;
+using TorannMagic.Extensions;
 using Verse;
 
 namespace TorannMagic.SihvRMagicScrollScribe
@@ -12,7 +13,7 @@ namespace TorannMagic.SihvRMagicScrollScribe
             ThingDef tempPod = null;
             IntVec3 currentPos = parent.PositionHeld;
             Map map = parent.Map;
-            CompAbilityUserMagic comp = user.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = user.GetCompAbilityUserMagic();
             if (parent.def != null && comp != null && user.IsSlave)
             {
                 Messages.Message("TM_SlaveScribeFail".Translate(

--- a/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilitySelf.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilitySelf.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse;
 using Verse.AI;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -30,8 +31,8 @@ namespace TorannMagic
             if (this.verb.Ability.Def is TMAbilityDef)
             {
                 TMAbilityDef tmAbility = (TMAbilityDef)(this.verb.Ability.Def);
-                CompAbilityUserMight compMight = this.pawn.TryGetComp<CompAbilityUserMight>();
-                CompAbilityUserMagic compMagic = this.pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMight compMight = this.pawn.GetCompAbilityUserMight();
+                CompAbilityUserMagic compMagic = this.pawn.GetCompAbilityUserMagic();
                 if (tmAbility.manaCost > 0 && pawn.story != null && pawn.story.traits != null && !pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 {
                     if (this.pawn.Map.gameConditionManager.ConditionIsActive(TorannMagicDefOf.TM_ManaStorm))
@@ -124,7 +125,7 @@ namespace TorannMagic
                     if (this.pawn.story != null && this.pawn.story.traits != null && this.pawn.story.traits.HasTrait(TorannMagicDefOf.ChaosMage) && Rand.Chance(.1f))
                     {
                         verb.Ability.PostAbilityAttempt();
-                        TM_Action.DoWildSurge(this.pawn, this.pawn.GetComp<CompAbilityUserMagic>(), (MagicAbility)verb.Ability, (TMAbilityDef)verb.Ability.Def, TargetA);
+                        TM_Action.DoWildSurge(this.pawn, this.pawn.GetCompAbilityUserMagic(), (MagicAbility)verb.Ability, (TMAbilityDef)verb.Ability.Def, TargetA);
                         EndJobWith(JobCondition.InterruptForced);
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse;
 using Verse.AI;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -48,8 +49,8 @@ namespace TorannMagic
             if(this.verb.Ability.Def is TMAbilityDef)
             { 
                 TMAbilityDef tmAbility = (TMAbilityDef)(this.verb.Ability.Def);
-                CompAbilityUserMight compMight = this.pawn.TryGetComp<CompAbilityUserMight>();
-                CompAbilityUserMagic compMagic = this.pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMight compMight = this.pawn.GetCompAbilityUserMight();
+                CompAbilityUserMagic compMagic = this.pawn.GetCompAbilityUserMagic();
                 //if (compMagic != null)
                 //{
                 //    compMagic.AIAbilityJob = null;
@@ -113,7 +114,7 @@ namespace TorannMagic
                 //combatToil.FailOnDestroyedOrNull(TargetIndex.A);
                 //combatToil.FailOnDespawnedOrNull(TargetIndex.A);
                 //combatToil.FailOnDowned(TargetIndex.A);
-                //CompAbilityUserMagic comp = this.pawn.GetComp<CompAbilityUserMagic>();                
+                //CompAbilityUserMagic comp = this.pawn.GetCompAbilityUserMagic();
                 //JobDriver curDriver = this.pawn.jobs.curDriver;
                 combatToil.initAction = delegate
                 {
@@ -192,7 +193,7 @@ namespace TorannMagic
                         if (this.pawn.story != null && this.pawn.story.traits != null && this.pawn.story.traits.HasTrait(TorannMagicDefOf.ChaosMage) && Rand.Chance(.1f))
                         {
                             verb.Ability.PostAbilityAttempt();
-                            TM_Action.DoWildSurge(this.pawn, this.pawn.GetComp<CompAbilityUserMagic>(), (MagicAbility)verb.Ability, (TMAbilityDef)verb.Ability.Def, TargetA);
+                            TM_Action.DoWildSurge(this.pawn, this.pawn.GetCompAbilityUserMagic(), (MagicAbility)verb.Ability, (TMAbilityDef)verb.Ability.Def, TargetA);
                             EndJobWith(JobCondition.InterruptForced);
                         }
                     }
@@ -324,7 +325,7 @@ namespace TorannMagic
                                     wildCheck = true;
                                     if (this.pawn.story != null && this.pawn.story.traits != null && this.pawn.story.traits.HasTrait(TorannMagicDefOf.ChaosMage) && Rand.Chance(.1f))
                                     {                                        
-                                        bool completeJob = TM_Action.DoWildSurge(this.pawn, this.pawn.GetComp<CompAbilityUserMagic>(), (MagicAbility)verb.Ability, (TMAbilityDef)verb.Ability.Def, TargetA);
+                                        bool completeJob = TM_Action.DoWildSurge(this.pawn, this.pawn.GetCompAbilityUserMagic(), (MagicAbility)verb.Ability, (TMAbilityDef)verb.Ability.Def, TargetA);
                                         if (!completeJob)
                                         {
                                             verb.Ability.PostAbilityAttempt();
@@ -387,12 +388,12 @@ namespace TorannMagic
             }
             else if (verbCast.AbilityProjectileDef.defName == "Projectile_PsionicDash")
             {
-                float sevReduct = 8f - this.pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicDash.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicDash_eff").level;
+                float sevReduct = 8f - this.pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicDash.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicDash_eff").level;
                 HealthUtility.AdjustSeverity(this.pawn, HediffDef.Named("TM_PsionicHD"), -sevReduct);
             }
             else if(verbCast.AbilityProjectileDef.defName == "Projectile_PsionicStorm")
             {
-                //float sevReduct = 65 - (5 * this.pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_eff").level);
+                //float sevReduct = 65 - (5 * this.pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicStorm.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicStorm_eff").level);
                 HealthUtility.AdjustSeverity(this.pawn, HediffDef.Named("TM_PsionicHD"), -100);
             }
         }
@@ -415,8 +416,8 @@ namespace TorannMagic
 
         private void RemoveMimicAbility(Verb_UseAbility verbCast)
         {
-            CompAbilityUserMight mightComp = this.pawn.GetComp<CompAbilityUserMight>();
-            CompAbilityUserMagic magicComp = this.pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMight mightComp = this.pawn.GetCompAbilityUserMight();
+            CompAbilityUserMagic magicComp = this.pawn.GetCompAbilityUserMagic();
             if (mightComp.mimicAbility != null && mightComp.mimicAbility.MainVerb.verbClass == verbCast.verbProps.verbClass)
             {
                 mightComp.RemovePawnAbility(mightComp.mimicAbility);

--- a/RimWorldOfMagic/RimWorldOfMagic/TMPawnSummoned.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMPawnSummoned.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse;
 
@@ -41,7 +42,7 @@ namespace TorannMagic
         {
             get
             {
-                return spawner.GetComp<CompAbilityUserMagic>();
+                return spawner.GetCompAbilityUserMagic();
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
@@ -10,6 +10,7 @@ using System;
 using AbilityUser;
 using HarmonyLib;
 using TorannMagic.Enchantment;
+using TorannMagic.Extensions;
 using TorannMagic.TMDefs;
 
 namespace TorannMagic
@@ -194,7 +195,7 @@ namespace TorannMagic
 
         public static void DoAction_TechnoWeaponCopy(Pawn caster, Thing thing, ThingDef td = null, QualityCategory _qc = QualityCategory.Normal)
         {
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             bool destroyThingAtEnd = false;
             if (thing != null && comp != null)
@@ -304,7 +305,7 @@ namespace TorannMagic
 
         public static void DoAction_PistolSpecCopy(Pawn caster, ThingWithComps thing)
         {
-            CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
 
             if (thing != null && thing.def != null && thing.def.IsRangedWeapon)
@@ -405,7 +406,7 @@ namespace TorannMagic
 
         public static void DoAction_RifleSpecCopy(Pawn caster, ThingWithComps thing)
         {
-            CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
 
             if (thing != null && thing.def != null && thing.def.IsRangedWeapon)
@@ -506,7 +507,7 @@ namespace TorannMagic
         //public static void DoAction_ShotgunSpecCopy(Pawn caster, ThingDef thingDef, int wpnQuality, ThingDef stuff = null)
         public static void DoAction_ShotgunSpecCopy(Pawn caster, ThingWithComps thing)
         {
-            CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
 
             if (thing != null && thing.def != null && thing.def.IsRangedWeapon)
@@ -646,7 +647,7 @@ namespace TorannMagic
         {
             bool multiplePawns = false;
             bool flag = !dinfo.InstantPermanentInjury;
-            CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             MightPowerSkill eff = comp.MightData.MightPowerSkill_DragonStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_DragonStrike_eff");
             MightPowerSkill globalSkill = comp.MightData.MightPowerSkill_global_seff.FirstOrDefault((MightPowerSkill x) => x.label == "TM_global_seff_pwr");
             float actualStaminaCost = .1f * (1 - (.1f * eff.level) * (1 - (.03f * globalSkill.level)));
@@ -1384,7 +1385,7 @@ namespace TorannMagic
         {
             if (p != null)
             {
-                CompAbilityUserMagic comp = p.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 if (comp != null && comp.Mana != null)
                 {
@@ -1569,7 +1570,7 @@ namespace TorannMagic
                         {
                             if (TM_Calc.IsMagicUser(allPawns[i]))
                             {
-                                CompAbilityUserMagic apComp = allPawns[i].TryGetComp<CompAbilityUserMagic>();
+                                CompAbilityUserMagic apComp = allPawns[i].GetCompAbilityUserMagic();
                                 if (apComp != null)
                                 {
                                     for (int j = 0; j < apComp.AbilityData.AllPowers.Count; j++)
@@ -1821,7 +1822,7 @@ namespace TorannMagic
 
         public static void DoTransmutate(Pawn caster, Thing transmutateThing, bool flagNoStuffItem, bool flagRawResource, bool flagStuffItem, bool flagNutrition, bool flagCorpse)
         {
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             int pwrVal = comp.MagicData.MagicPowerSkill_Transmutate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Transmutate_pwr").level;
             int verVal = comp.MagicData.MagicPowerSkill_Transmutate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Transmutate_ver").level;
 
@@ -2603,8 +2604,8 @@ namespace TorannMagic
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();            
             if (settingsRef.autocastEnabled && com.pawnAbility.Def.defName.StartsWith("TM_"))
             {
-                CompAbilityUserMagic comp = com.pawnAbility.Pawn.GetComp<CompAbilityUserMagic>();
-                CompAbilityUserMight mightComp = com.pawnAbility.Pawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMagic comp = com.pawnAbility.Pawn.GetCompAbilityUserMagic();
+                CompAbilityUserMight mightComp = com.pawnAbility.Pawn.GetCompAbilityUserMight();
                 MagicPower magicPower = null;
                 MightPower mightPower = null;
                 TMAbilityDef tmAbilityDef = com.pawnAbility.Def as TMAbilityDef;
@@ -3425,7 +3426,7 @@ namespace TorannMagic
                 HediffComp_BrandingBase hdc = hd_br.TryGetComp<HediffComp_BrandingBase>();
                 if (hdc != null && hdc.BranderPawn != null)
                 {
-                    CompAbilityUserMagic branderComp = hdc.BranderPawn.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic branderComp = hdc.BranderPawn.GetCompAbilityUserMagic();
                     if (branderComp != null)
                     {
                         TMDefs.TM_Branding tmpBranding = null;

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -210,13 +210,40 @@ namespace TorannMagic
             return false;
         }
 
+        // Get first Hate Hediff encountered
+        public static Hediff GetHateHediff(Pawn pawn)
+        {
+            for (int i = 0; i < pawn.health.hediffSet.hediffs.Count; i++)
+            {
+                if (
+                    pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_I
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_II
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_III
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_IV
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_V
+                )
+                    return pawn.health.hediffSet.hediffs[i];
+            }
+
+            return default;
+        }
+
         public static bool HasHateHediff(Pawn pawn)
         {
-            if(pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_HateHD_I"), false) || pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_HateHD_II"), false) || pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_HateHD_III"), false) ||
-                pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_HateHD"), false) || pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_HateHD_IV"), false) || pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_HateHD_V"), false))
+            for (int i = 0; i < pawn.health.hediffSet.hediffs.Count; i++)
             {
-                return true;
+                if (
+                    pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_I
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_II
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_III
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_IV
+                    || pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HateHD_V
+                )
+                    return true;
             }
+
             return false;
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -13,6 +13,7 @@ using TorannMagic.Enchantment;
 using System.Text;
 using TorannMagic.TMDefs;
 using System.Reflection;
+using TorannMagic.Extensions;
 using TorannMagic.Golems;
 
 namespace TorannMagic
@@ -25,12 +26,12 @@ namespace TorannMagic
             bool flag_AndroidTiers = (pawn.def.defName.StartsWith("Android") || pawn.def.defName == "M7Mech" || pawn.def.defName == "MicroScyther");
             bool flag_Androids = pawn.RaceProps.FleshType.defName == "ChJDroid" || pawn.def.defName == "ChjAndroid";
             bool flag_AndroidClass = false;
-            CompAbilityUserMight compMight = pawn.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight compMight = pawn.GetCompAbilityUserMight();
             if (compMight != null && compMight.customClass != null && compMight.customClass.isAndroid)
             {
                 flag_AndroidClass = true;
             }
-            CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic();
             if (compMagic != null && compMagic.customClass != null && compMagic.customClass.isAndroid)
             {
                 flag_AndroidClass = true;
@@ -57,12 +58,12 @@ namespace TorannMagic
                     }
                 }
                 bool flag_Class = false;
-                CompAbilityUserMight compMight = pawn.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight compMight = pawn.GetCompAbilityUserMight();
                 if (compMight != null && compMight.customClass != null && compMight.customClass.isNecromancer)
                 {
                     flag_Class = true;
                 }
-                CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic();
                 if (compMagic != null && compMagic.customClass != null && compMagic.customClass.isNecromancer)
                 {
                     flag_Class = true;
@@ -112,12 +113,12 @@ namespace TorannMagic
                     }
                 }
                 bool flag_UndeadClass = false;
-                CompAbilityUserMight compMight = pawn.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight compMight = pawn.GetCompAbilityUserMight();
                 if(compMight != null && compMight.customClass != null && compMight.customClass.isUndead)
                 {
                     flag_UndeadClass = true;
                 }
-                CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic();
                 if (compMagic != null && compMagic.customClass != null && compMagic.customClass.isUndead)
                 {
                     flag_UndeadClass = true;
@@ -294,7 +295,7 @@ namespace TorannMagic
         {
             if (pawn != null)
             {
-                CompAbilityUserMight comp = pawn.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                 if (comp != null && comp.IsMightUser && comp.MightData != null && comp.Stamina != null)
                 {
                     return true;
@@ -337,7 +338,7 @@ namespace TorannMagic
                         return td;
                     }
                 }
-                CompAbilityUserMight comp = pawn.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
                 if(comp != null && comp.customClass != null)
                 {
                     return comp.customClass.classTrait;
@@ -368,7 +369,7 @@ namespace TorannMagic
                 {
                     return false;
                 }
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if(comp != null && comp.IsMagicUser && comp.MagicData != null && comp.Mana != null)
                 {
                     return true;
@@ -390,7 +391,7 @@ namespace TorannMagic
 
         public static bool IsWanderer(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             if (comp != null)
             {
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer))
@@ -411,7 +412,7 @@ namespace TorannMagic
 
         public static bool IsWayfarer(Pawn pawn)
         {
-            CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if (comp != null)
             {
                 if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer))
@@ -440,7 +441,7 @@ namespace TorannMagic
             {
                 return true;
             }
-            CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp != null && comp.customClass != null && comp.customClass.classAbilities.Contains(TorannMagicDefOf.TM_Empathy))
             {
                 return true;
@@ -475,7 +476,7 @@ namespace TorannMagic
         {
             if(ability.manaCost > 0)
             {
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 if(comp == null)
                 {
                     return false;
@@ -491,7 +492,7 @@ namespace TorannMagic
             }
             if(ability.staminaCost > 0)
             {
-                CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = p.GetCompAbilityUserMight();
                 if (comp == null)
                 {
                     return false;
@@ -507,7 +508,7 @@ namespace TorannMagic
             }
             if(ability.chiCost > 0)
             {
-                CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = p.GetCompAbilityUserMight();
                 if (comp == null)
                 {
                     return false;
@@ -528,7 +529,7 @@ namespace TorannMagic
             }
             if(ability.bloodCost > 0)
             {
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 if (comp == null)
                 {
                     return false;
@@ -666,7 +667,7 @@ namespace TorannMagic
             {
                 if(IsMagicUser(p) && p.IsSlave ? countSlaves : true)
                 {
-                    CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                     if(comp!= null && comp.MagicData != null)
                     {
                         MagicPower mp = comp.MagicData.ReturnMatchingMagicPower(TorannMagicDefOf.TM_RuneCarving);
@@ -692,7 +693,7 @@ namespace TorannMagic
             {
                 if (IsMagicUser(p))
                 {
-                    CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                     if (comp != null && comp.MagicData != null)
                     {
                         MagicPower mp = comp.MagicData.ReturnMatchingMagicPower(TorannMagicDefOf.TM_Golemancy);
@@ -1039,7 +1040,7 @@ namespace TorannMagic
                     {
                         if (pawn != targetPawn && targetPawn.HostileTo(pawn.Faction) && (pawn.Position - targetPawn.Position).LengthHorizontal <= radius)
                         {
-                            CompAbilityUserMagic targetComp = targetPawn.GetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic targetComp = targetPawn.GetCompAbilityUserMagic();
                             if (targetComp != null && targetComp.IsMagicUser && !TM_Calc.IsCrossClass(targetPawn, true))
                             {
                                 pawnList.Add(targetPawn);
@@ -1050,7 +1051,7 @@ namespace TorannMagic
                     {
                         if (pawn != targetPawn && !targetPawn.HostileTo(pawn.Faction) && (pawn.Position - targetPawn.Position).LengthHorizontal <= radius)
                         {
-                            CompAbilityUserMagic targetComp = targetPawn.GetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic targetComp = targetPawn.GetCompAbilityUserMagic();
                             if (targetComp != null && targetComp.IsMagicUser && !TM_Calc.IsCrossClass(targetPawn, true))
                             {
                                 pawnList.Add(targetPawn);                                
@@ -1126,7 +1127,7 @@ namespace TorannMagic
                     {
                         if (targetPawn.HostileTo(pawn.Faction) && (pawn.Position - targetPawn.Position).LengthHorizontal <= radius)
                         {
-                            CompAbilityUserMight targetComp = targetPawn.GetComp<CompAbilityUserMight>();
+                            CompAbilityUserMight targetComp = targetPawn.GetCompAbilityUserMight();
                             if (targetComp != null && targetComp.IsMightUser && !TM_Calc.IsCrossClass(targetPawn, false))
                             {
                                 pawnList.Add(targetPawn);
@@ -1137,7 +1138,7 @@ namespace TorannMagic
                     {
                         if (pawn != targetPawn && !targetPawn.HostileTo(pawn.Faction) && (pawn.Position - targetPawn.Position).LengthHorizontal <= radius)
                         {
-                            CompAbilityUserMight targetComp = targetPawn.GetComp<CompAbilityUserMight>();
+                            CompAbilityUserMight targetComp = targetPawn.GetCompAbilityUserMight();
                             if (targetComp != null && targetComp.IsMightUser && !TM_Calc.IsCrossClass(targetPawn, false))
                             {
                                 pawnList.Add(targetPawn);
@@ -1838,9 +1839,9 @@ namespace TorannMagic
 
         public static Thing GetTransmutableThingFromCell(IntVec3 cell, Pawn enchanter, out bool flagRawResource, out bool flagStuffItem, out bool flagNoStuffItem, out bool flagNutrition, out bool flagCorpse, bool manualCast = false)
         {
-            CompAbilityUserMagic comp = enchanter.GetComp<CompAbilityUserMagic>();
-            int pwrVal = enchanter.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Transmutate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Transmutate_pwr").level;
-            int verVal = enchanter.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Transmutate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Transmutate_ver").level;
+            CompAbilityUserMagic comp = enchanter.GetCompAbilityUserMagic();
+            int pwrVal = enchanter.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Transmutate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Transmutate_pwr").level;
+            int verVal = enchanter.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Transmutate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Transmutate_ver").level;
 
             List<Thing> thingList = cell.GetThingList(enchanter.Map);
             Thing transmutateThing = null;
@@ -1994,13 +1995,13 @@ namespace TorannMagic
         public static float GetArcaneResistance(Pawn pawn, bool includePsychicSensitivity)
         {
             float resistance = 0;
-            CompAbilityUserMagic compMagic = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic();
             if(compMagic != null)
             {
                 resistance += (compMagic.arcaneRes - 1);
             }
 
-            CompAbilityUserMight compMight = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight compMight = pawn.GetCompAbilityUserMight();
             if(compMight != null)
             {
                 resistance += (compMight.arcaneRes - 1);
@@ -2022,7 +2023,7 @@ namespace TorannMagic
         public static float GetSpellPenetration(Pawn pawn)
         {
             float penetration = 0;
-            CompAbilityUserMagic compMagic = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic();
             if (compMagic != null)
             {
                 penetration += (compMagic.arcaneDmg - 1);
@@ -2032,7 +2033,7 @@ namespace TorannMagic
                 }
             }
 
-            CompAbilityUserMight compMight = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight compMight = pawn.GetCompAbilityUserMight();
             if (compMight != null && penetration == 0)
             {
                 penetration += (compMight.mightPwr - 1);
@@ -2332,8 +2333,8 @@ namespace TorannMagic
 
         public static TMAbilityDef GetCopiedMightAbility(Pawn targetPawn, Pawn caster)
         {
-            CompAbilityUserMight mightPawn = targetPawn.GetComp<CompAbilityUserMight>();
-            CompAbilityUserMight casterComp = caster.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight mightPawn = targetPawn.GetCompAbilityUserMight();
+            CompAbilityUserMight casterComp = caster.GetCompAbilityUserMight();
             TMAbilityDef tempAbility = null;
             if (mightPawn.customClass != null && mightPawn.customClass.isFighter)
             {
@@ -2362,7 +2363,7 @@ namespace TorannMagic
                     if (rnd == 0)
                     {
                         int level = mightPawn.MightData.MightPowersG[2].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersG[2].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersG[2].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2394,7 +2395,7 @@ namespace TorannMagic
                     else if (rnd == 1)
                     {
                         int level = mightPawn.MightData.MightPowersS[2].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersS[2].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersS[2].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2427,7 +2428,7 @@ namespace TorannMagic
                     else if (rnd == 1)
                     {
                         int level = mightPawn.MightData.MightPowersB[4].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersB[4].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersB[4].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2455,7 +2456,7 @@ namespace TorannMagic
                     if (rnd == 0)
                     {
                         int level = mightPawn.MightData.MightPowersR[4].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersR[4].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersR[4].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2483,7 +2484,7 @@ namespace TorannMagic
                     if ((rnd == 0 || rnd == 3) && caster.story.DisabledWorkTagsBackstoryAndTraits != WorkTags.Violent)
                     {
                         int level = mightPawn.MightData.MightPowersP[1].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersP[1].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersP[1].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2507,7 +2508,7 @@ namespace TorannMagic
                     else
                     {
                         int level = mightPawn.MightData.MightPowersP[3].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersP[3].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersP[3].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2529,7 +2530,7 @@ namespace TorannMagic
                     else
                     {
                         int level = mightPawn.MightData.MightPowersDK[4].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersDK[4].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersDK[4].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2569,7 +2570,7 @@ namespace TorannMagic
                     if (rnd == 3)
                     {
                         int level = mightPawn.MightData.MightPowersC[3].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersC[3].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersC[3].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2589,7 +2590,7 @@ namespace TorannMagic
                     else if (rnd == 4)
                     {
                         int level = mightPawn.MightData.MightPowersC[4].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersC[4].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersC[4].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2609,7 +2610,7 @@ namespace TorannMagic
                     else
                     {
                         int level = mightPawn.MightData.MightPowersC[5].level;
-                        caster.GetComp<CompAbilityUserMight>().MightData.MightPowersC[5].level = level;
+                        caster.GetCompAbilityUserMight().MightData.MightPowersC[5].level = level;
                         switch (level)
                         {
                             case 0:
@@ -2649,8 +2650,8 @@ namespace TorannMagic
 
         public static TMAbilityDef GetCopiedMagicAbility(Pawn targetPawn, Pawn caster)
         {
-            CompAbilityUserMagic magicPawn = targetPawn.GetComp<CompAbilityUserMagic>();
-            CompAbilityUserMagic casterComp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic magicPawn = targetPawn.GetCompAbilityUserMagic();
+            CompAbilityUserMagic casterComp = caster.GetCompAbilityUserMagic();
             TMAbilityDef tempAbility = null;
             if (magicPawn.customClass != null && magicPawn.customClass.isMage)
             {
@@ -2683,7 +2684,7 @@ namespace TorannMagic
                             if (rnd == 0 && magicPawn.MagicData.MagicPowersA[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersA[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersA[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2704,7 +2705,7 @@ namespace TorannMagic
                             else if (rnd == 1 && magicPawn.MagicData.MagicPowersA[rnd].learned && caster.story.DisabledWorkTagsBackstoryAndTraits != WorkTags.Violent)
                             {
                                 int level = magicPawn.MagicData.MagicPowersA[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersA[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2725,7 +2726,7 @@ namespace TorannMagic
                             else if (rnd == 2 && magicPawn.MagicData.MagicPowersA[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersA[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersA[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2746,7 +2747,7 @@ namespace TorannMagic
                             else if (rnd == 3 && magicPawn.MagicData.MagicPowersA[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersA[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersA[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2774,7 +2775,7 @@ namespace TorannMagic
                             if (rnd == 0 && magicPawn.MagicData.MagicPowersSB[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersSB[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersSB[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersSB[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2817,7 +2818,7 @@ namespace TorannMagic
                             if (rnd == 0 && magicPawn.MagicData.MagicPowersIF[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersIF[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersIF[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersIF[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2860,7 +2861,7 @@ namespace TorannMagic
                             if (rnd == 0 && magicPawn.MagicData.MagicPowersHoF[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersHoF[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersHoF[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersHoF[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2891,7 +2892,7 @@ namespace TorannMagic
                             else if (rnd == 3 && magicPawn.MagicData.MagicPowersHoF[rnd].learned && caster.story.DisabledWorkTagsBackstoryAndTraits != WorkTags.Violent)
                             {
                                 int level = magicPawn.MagicData.MagicPowersHoF[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersHoF[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersHoF[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2929,7 +2930,7 @@ namespace TorannMagic
                             else if (rnd == 1 && magicPawn.MagicData.MagicPowersD[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersD[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersD[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersD[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2967,7 +2968,7 @@ namespace TorannMagic
                             if (rnd == 1 && magicPawn.MagicData.MagicPowersN[rnd].learned && caster.story.DisabledWorkTagsBackstoryAndTraits != WorkTags.Violent)
                             {
                                 int level = magicPawn.MagicData.MagicPowersN[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersN[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersN[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -2993,7 +2994,7 @@ namespace TorannMagic
                             else if (rnd == 3 && magicPawn.MagicData.MagicPowersN[rnd + 1].learned && caster.story.DisabledWorkTagsBackstoryAndTraits != WorkTags.Violent)
                             {
                                 int level = magicPawn.MagicData.MagicPowersN[rnd + 1].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersN[rnd + 1].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersN[rnd + 1].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3021,7 +3022,7 @@ namespace TorannMagic
                             if (rnd == 1 && magicPawn.MagicData.MagicPowersP[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersP[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersP[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersP[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3064,7 +3065,7 @@ namespace TorannMagic
                             if (rnd == 3 && magicPawn.MagicData.MagicPowersPR[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersPR[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersPR[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersPR[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3085,7 +3086,7 @@ namespace TorannMagic
                             else if (rnd == 2 && magicPawn.MagicData.MagicPowersPR[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersPR[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersPR[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersPR[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3140,7 +3141,7 @@ namespace TorannMagic
                     else if (targetPawn.story.traits.HasTrait(TorannMagicDefOf.TM_Bard))
                     {
                         int level = magicPawn.MagicData.MagicPowersB[3].level;
-                        caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersB[3].level = level;
+                        caster.GetCompAbilityUserMagic().MagicData.MagicPowersB[3].level = level;
                         switch (level)
                         {
                             case 0:
@@ -3165,7 +3166,7 @@ namespace TorannMagic
                             if (rnd == 1 && magicPawn.MagicData.MagicPowersWD[rnd].learned && caster.story.DisabledWorkTagsBackstoryAndTraits != WorkTags.Violent)
                             {
                                 int level = magicPawn.MagicData.MagicPowersWD[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersWD[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersWD[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3191,7 +3192,7 @@ namespace TorannMagic
                             else if (rnd == 3 && magicPawn.MagicData.MagicPowersWD[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersWD[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersWD[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersWD[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3219,7 +3220,7 @@ namespace TorannMagic
                             if (rnd == 1 && magicPawn.MagicData.MagicPowersSD[rnd].learned && caster.story.DisabledWorkTagsBackstoryAndTraits != WorkTags.Violent)
                             {
                                 int level = magicPawn.MagicData.MagicPowersSD[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersSD[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersSD[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3245,7 +3246,7 @@ namespace TorannMagic
                             else if (rnd == 3 && magicPawn.MagicData.MagicPowersSD[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersSD[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersSD[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersSD[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3282,7 +3283,7 @@ namespace TorannMagic
                             else if (rnd == 1 && magicPawn.MagicData.MagicPowersG[rnd].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersG[rnd].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersG[rnd].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersG[rnd].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3336,7 +3337,7 @@ namespace TorannMagic
                             if (magicPawn.MagicData.MagicPowersE[4].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersE[4].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersE[4].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersE[4].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3374,7 +3375,7 @@ namespace TorannMagic
                             else if (magicPawn.MagicData.MagicPowersC[4].learned)
                             {
                                 int level = magicPawn.MagicData.MagicPowersC[4].level;
-                                caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersC[4].level = level;
+                                caster.GetCompAbilityUserMagic().MagicData.MagicPowersC[4].level = level;
                                 switch (level)
                                 {
                                     case 0:
@@ -3446,7 +3447,7 @@ namespace TorannMagic
         {
             MightPowerSkill mightSkill = null;
             int level = 0;
-            CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             if (comp != null && comp.MightData != null)
             {
                 if (suffix == "_pwr")
@@ -3469,7 +3470,7 @@ namespace TorannMagic
                 {
                     level = mightSkill.level;
                 }
-                CompAbilityUserMight mimicComp = caster.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mimicComp = caster.GetCompAbilityUserMight();
                 if (canCopy && mimicComp != null && mimicComp.IsMightUser && ability == mimicComp.mimicAbility)
                 {
                     string mimicLabel = "TM_Mimic" + suffix;
@@ -3499,7 +3500,7 @@ namespace TorannMagic
 
             //int val = 0;
             //string label = skillLabel + suffix;
-            //CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+            //CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             //var mps = power.FirstOrDefault((MightPowerSkill x) => x.label == label);
             //if (mps != null)
             //{
@@ -3538,7 +3539,7 @@ namespace TorannMagic
         {
             MagicPowerSkill magicSkill = null;
             int level = 0;
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             if (comp != null && comp.MagicData != null)
             {
                 if (suffix == "_pwr")
@@ -3561,7 +3562,7 @@ namespace TorannMagic
                 {
                     level = magicSkill.level;
                 }
-                CompAbilityUserMight mimicComp = caster.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mimicComp = caster.GetCompAbilityUserMight();
                 if (canCopy && mimicComp != null && mimicComp.IsMightUser && ability == mimicComp.mimicAbility)
                 {
                     string mimicLabel = "TM_Mimic" + suffix;
@@ -3584,7 +3585,7 @@ namespace TorannMagic
 
             //int val = 0;
             //string label = skillLabel + suffix;
-            //CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            //CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             //if (comp != null && comp.IsMagicUser)
             //{
             //    var mps = power.FirstOrDefault((MagicPowerSkill x) => x.label == label);
@@ -3596,7 +3597,7 @@ namespace TorannMagic
             //            if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //            {
             //                label = "TM_Mimic" + suffix;
-            //                val = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == label).level;
+            //                val = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == label).level;
             //            }
             //            if ((caster.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer) || (caster.story.traits.HasTrait(TorannMagicDefOf.ChaosMage) || (comp.customClass != null && comp.customClass.classMageAbilities.Contains(TorannMagicDefOf.TM_Cantrips))) && comp.MagicData.MagicPowersW.FirstOrDefault((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Cantrips).learned))
             //            {
@@ -3825,7 +3826,7 @@ namespace TorannMagic
             if (TM_Calc.IsUsingRanged(p))
             {
                 Thing wpn = p.equipment.Primary;
-                CompAbilityUserMight mightComp = p.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mightComp = p.GetCompAbilityUserMight();
                 //Log.Message("" + p.LabelShort + " is using a " + wpn.def.defName);
                 if(mightComp != null && mightComp.equipmentContainer != null && mightComp.equipmentContainer.Count > 0)
                 {
@@ -3865,7 +3866,7 @@ namespace TorannMagic
             if (IsUsingRanged(p))
             {
                 Thing wpn = p.equipment.Primary;
-                CompAbilityUserMight mightComp = p.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mightComp = p.GetCompAbilityUserMight();
                 //Log.Message("" + p.LabelShort + " is using a " + wpn.def.defName);
                 if (mightComp != null && mightComp.equipmentContainer != null && mightComp.equipmentContainer.Count > 0)
                 {
@@ -3905,7 +3906,7 @@ namespace TorannMagic
             if (IsUsingRanged(p))
             {
                 Thing wpn = p.equipment.Primary;
-                CompAbilityUserMight mightComp = p.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mightComp = p.GetCompAbilityUserMight();
                 //Log.Message("" + p.LabelShort + " is using a " + wpn.def.defName);
                 if (mightComp != null && mightComp.equipmentContainer != null && mightComp.equipmentContainer.Count > 0)
                 {
@@ -3945,7 +3946,7 @@ namespace TorannMagic
             if (IsUsingRanged(p))
             {
                 Thing wpn = p.equipment.Primary;
-                CompAbilityUserMight mightComp = p.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mightComp = p.GetCompAbilityUserMight();
                 //Log.Message("" + p.LabelShort + " is using a " + wpn.def.defName);
                 if (mightComp != null && mightComp.equipmentContainer != null && mightComp.equipmentContainer.Count > 0)
                 {
@@ -3971,7 +3972,7 @@ namespace TorannMagic
             if (p != null && p.equipment != null && p.equipment.Primary != null && p.equipment.Primary.def.IsRangedWeapon)
             {
                 Thing wpn = p.equipment.Primary;
-                CompAbilityUserMight mightComp = p.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mightComp = p.GetCompAbilityUserMight();
                 //Log.Message("" + p.LabelShort + " is using a " + wpn.def.defName);
                 if (mightComp != null && mightComp.equipmentContainer != null && mightComp.equipmentContainer.Count > 0)
                 {
@@ -4010,8 +4011,8 @@ namespace TorannMagic
         {
             float result = 0;
 
-            CompAbilityUserMight compMight = p.GetComp<CompAbilityUserMight>();
-            CompAbilityUserMagic compMagic = p.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMight compMight = p.GetCompAbilityUserMight();
+            CompAbilityUserMagic compMagic = p.GetCompAbilityUserMagic();
             float strFactor = 1f;
             if (compMight != null && compMight.IsMightUser)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/Inspiration_MagicUser.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/Inspiration_MagicUser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Thoughts
 {
@@ -10,7 +11,7 @@ namespace TorannMagic.Thoughts
         {
             bool baseInspiration = base.InspirationCanOccur(pawn);
             bool magicInspiration = false;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if (!pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/Inspiration_MightUser.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/Inspiration_MightUser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Thoughts
 {
@@ -10,7 +11,7 @@ namespace TorannMagic.Thoughts
         {
             bool baseInspiration = base.InspirationCanOccur(pawn);
             bool mightInspiration = false;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             if(comp.IsMightUser)
             {
                 mightInspiration = true;

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_Bard.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_Bard.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using System;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using Verse;
 
 namespace TorannMagic.Thoughts
@@ -9,7 +10,7 @@ namespace TorannMagic.Thoughts
     {
         public override float RandomSelectionWeight(Pawn initiator, Pawn recipient)
         {
-            CompAbilityUserMagic compInit = initiator.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compInit = initiator.GetCompAbilityUserMagic();
             bool flag = !initiator.IsColonist || !recipient.IsColonist || compInit is null;
             float result = 0f;            
             if (flag)

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_Entertain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_Entertain.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using System;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using Verse;
 
 namespace TorannMagic.Thoughts
@@ -13,7 +14,7 @@ namespace TorannMagic.Thoughts
             letterLabel = null;
             letterDef = null;
             lookTargets = null;
-            CompAbilityUserMagic compInit = initiator.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compInit = initiator.GetCompAbilityUserMagic();
             // base.Interacted(initiator, recipient, extraSentencePacks, );
             int num =  Rand.Range(50, 100);
             compInit.MagicUserXP += num;

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_MagicLore.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_MagicLore.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using System;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -15,8 +16,8 @@ namespace TorannMagic.Thoughts
             letterLabel = null;
             letterDef = null;
             lookTargets = null;
-            CompAbilityUserMagic compInit = initiator.GetComp<CompAbilityUserMagic>();
-            CompAbilityUserMagic compRec = recipient.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compInit = initiator.GetCompAbilityUserMagic();
+            CompAbilityUserMagic compRec = recipient.GetCompAbilityUserMagic();
             //base.Interacted(initiator, recipient, extraSentencePacks);
             int num = compInit.MagicUserLevel - compRec.MagicUserLevel;
             int num2 = Mathf.RoundToInt(Mathf.Clamp((int)(25f + Rand.Range(5f, 75f) + num),0, 200) * compRec.xpGain);
@@ -26,8 +27,8 @@ namespace TorannMagic.Thoughts
 
         public override float RandomSelectionWeight(Pawn initiator, Pawn recipient)
         {
-            CompAbilityUserMagic compInit = initiator.GetComp<CompAbilityUserMagic>();
-            CompAbilityUserMagic compRec = recipient.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic compInit = initiator.GetCompAbilityUserMagic();
+            CompAbilityUserMagic compRec = recipient.GetCompAbilityUserMagic();
             bool flag = !initiator.IsColonist || !recipient.IsColonist;
             float result = 0f;
             if (flag)

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_MightLore.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_MightLore.cs
@@ -1,6 +1,7 @@
 ﻿using RimWorld;
 using System;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -15,8 +16,8 @@ namespace TorannMagic.Thoughts
             letterLabel = null;
             letterDef = null;
             lookTargets = null;
-            CompAbilityUserMight compInit = initiator.GetComp<CompAbilityUserMight>();
-            CompAbilityUserMight compRec = recipient.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight compInit = initiator.GetCompAbilityUserMight();
+            CompAbilityUserMight compRec = recipient.GetCompAbilityUserMight();
             //base.Interacted(initiator, recipient, extraSentencePacks);
             int num = compInit.MightUserLevel - compRec.MightUserLevel;
             int num2 = Mathf.RoundToInt(Mathf.Clamp((int)(25f + Rand.Range(25f, 100f) + num), 0, 250) * compRec.xpGain);
@@ -26,8 +27,8 @@ namespace TorannMagic.Thoughts
 
         public override float RandomSelectionWeight(Pawn initiator, Pawn recipient)
         {
-            CompAbilityUserMight compInit = initiator.GetComp<CompAbilityUserMight>();
-            CompAbilityUserMight compRec = recipient.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight compInit = initiator.GetCompAbilityUserMight();
+            CompAbilityUserMight compRec = recipient.GetCompAbilityUserMight();
             bool flag = !initiator.IsColonist || !recipient.IsColonist;
             float result = 0f;
             if (flag)

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/ThoughtWorker_TM_EnchantedAura.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/ThoughtWorker_TM_EnchantedAura.cs
@@ -2,6 +2,7 @@
 using Verse;
 using RimWorld;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Thoughts
 {
@@ -26,7 +27,7 @@ namespace TorannMagic.Thoughts
                 }
                 if (other.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EnchantedAuraHD, false))
                 {
-                    CompAbilityUserMagic comp = other.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = other.GetCompAbilityUserMagic();
 
                     if (comp != null)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/ThoughtWorker_TM_EnchantedBody.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/ThoughtWorker_TM_EnchantedBody.cs
@@ -2,6 +2,7 @@
 using Verse;
 using RimWorld;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Thoughts
 {
@@ -25,7 +26,7 @@ namespace TorannMagic.Thoughts
                 }
                 if (other.health.hediffSet.HasHediff(TorannMagicDefOf.TM_EnchantedBodyHD, false))
                 {
-                    CompAbilityUserMagic comp = other.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = other.GetCompAbilityUserMagic();
 
                     if (comp != null)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/ThoughtWorker_TM_MaleOpinionOfSuccubus.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/ThoughtWorker_TM_MaleOpinionOfSuccubus.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Thoughts
 {
@@ -31,8 +32,8 @@ namespace TorannMagic.Thoughts
                     }
                     else
                     {
-                        CompAbilityUserMagic magicComp = pawn.GetComp<CompAbilityUserMagic>();
-                        CompAbilityUserMight mightComp = pawn.GetComp<CompAbilityUserMight>();
+                        CompAbilityUserMagic magicComp = pawn.GetCompAbilityUserMagic();
+                        CompAbilityUserMight mightComp = pawn.GetCompAbilityUserMight();
                         if (mightComp.IsMightUser)
                         {
                             return ThoughtState.ActiveAtStage(0);

--- a/RimWorldOfMagic/RimWorldOfMagic/TorannMagicDefOf.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TorannMagicDefOf.cs
@@ -936,6 +936,11 @@ namespace TorannMagic
         public static TraitDef DeathKnight;
 
         public static HediffDef TM_HateHD;
+        public static HediffDef TM_HateHD_I;
+        public static HediffDef TM_HateHD_II;
+        public static HediffDef TM_HateHD_III;
+        public static HediffDef TM_HateHD_IV;
+        public static HediffDef TM_HateHD_V;
         public static TMAbilityDef TM_Shroud;
         public static TMAbilityDef TM_WaveOfFear;
         public static HediffDef TM_WaveOfFearHD;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_60mmMortar.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_60mmMortar.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse.AI;
 using Verse;
 using UnityEngine;
@@ -22,7 +23,7 @@ namespace TorannMagic
             Pawn pawn = base.CasterPawn;
             Map map = pawn.Map;
 
-            CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             //pwrVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_60mmMortar, "TM_60mmMortar", "_pwr", true);
             //verVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_60mmMortar, "TM_60mmMortar", "_ver", true);
             //effVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_60mmMortar, "TM_60mmMortar", "_eff", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_AdvancedHeal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_AdvancedHeal.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using AbilityUser;
 using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -42,17 +43,17 @@ namespace TorannMagic
             // power affects enumerator
             // DamageWorker.DamageResult result = DamageWorker.DamageResult.MakeNew();
             Pawn caster = this.CasterPawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef);
-            //MagicPowerSkill pwr = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AdvancedHeal_pwr");
-            //MagicPowerSkill ver = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AdvancedHeal_ver");
+            //MagicPowerSkill pwr = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AdvancedHeal_pwr");
+            //MagicPowerSkill ver = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AdvancedHeal_ver");
             //pwrVal = pwr.level;
             //verVal = ver.level;
             //if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mpwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
             //}

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_AlterFate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_AlterFate.cs
@@ -7,6 +7,7 @@ using Verse;
 using Verse.AI;
 using UnityEngine;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -26,7 +27,7 @@ namespace TorannMagic
             bool flag = false;
             Pawn caster = base.CasterPawn;
 
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             //pwrVal = comp.MagicData.MagicPowerSkill_AlterFate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AlterFate_pwr").level;
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_AlterStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_AlterStorm.cs
@@ -4,6 +4,7 @@ using Verse;
 using AbilityUser;
 using System.Linq;
 using TorannMagic.Conditions;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -15,7 +16,7 @@ namespace TorannMagic
         {
             Map map = base.CasterPawn.Map; 
             WeatherDef alterDef = new WeatherDef();
-            CompAbilityUserMagic comp = base.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = base.CasterPawn.GetCompAbilityUserMagic();
             if (map != null && comp != null && comp.MagicData != null)
             {
                 WeatherDef w = null;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_AnimalFriend.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_AnimalFriend.cs
@@ -5,6 +5,7 @@ using RimWorld;
 using AbilityUser;
 using Verse;
 using HarmonyLib;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 
@@ -38,9 +39,9 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool flag = false;
-            CompAbilityUserMight comp = base.CasterPawn.GetComp<CompAbilityUserMight>();
-            MightPowerSkill pwr = base.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_AnimalFriend.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AnimalFriend_pwr");
-            MightPowerSkill ver = base.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_AnimalFriend.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AnimalFriend_ver");
+            CompAbilityUserMight comp = base.CasterPawn.GetCompAbilityUserMight();
+            MightPowerSkill pwr = base.CasterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_AnimalFriend.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AnimalFriend_pwr");
+            MightPowerSkill ver = base.CasterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_AnimalFriend.FirstOrDefault((MightPowerSkill x) => x.label == "TM_AnimalFriend_ver");
             Pawn pawn = this.CasterPawn;
             Pawn animal = this.currentTarget.Thing as Pawn;
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ApplyAura.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ApplyAura.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -46,7 +47,7 @@ namespace TorannMagic
 
         private bool ApplyAura()
         {
-            CompAbilityUserMagic comp = this.CasterPawn.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             TMAbilityDef ability = (TMAbilityDef)this.Ability.Def;
             if (comp.maxMP >= ability.upkeepEnergyCost)
             {
@@ -131,67 +132,67 @@ namespace TorannMagic
             MagicPower magicPower = null;
             if (this.Ability.Def == TorannMagicDefOf.TM_Shadow)
             {
-               magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Shadow);
+               magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersA.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Shadow);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_Shadow_I)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Shadow_I);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersA.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Shadow_I);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_Shadow_II)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Shadow_II);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersA.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Shadow_II);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_Shadow_III)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersA.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Shadow_III);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersA.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Shadow_III);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_RayofHope)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersIF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RayofHope);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersIF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RayofHope);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_RayofHope_I)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersIF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RayofHope_I);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersIF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RayofHope_I);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_RayofHope_II)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersIF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RayofHope_II);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersIF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RayofHope_II);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_RayofHope_III)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersIF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RayofHope_III);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersIF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_RayofHope_III);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_Soothe)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersHoF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Soothe);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersHoF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Soothe);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_Soothe_I)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersHoF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Soothe_I);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersHoF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Soothe_I);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_Soothe_II)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersHoF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Soothe_II);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersHoF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Soothe_II);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_Soothe_III)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersHoF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Soothe_III);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersHoF.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Soothe_III);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_P_RayofHope)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersP.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_P_RayofHope);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersP.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_P_RayofHope);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_P_RayofHope_I)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersP.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_P_RayofHope_I);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersP.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_P_RayofHope_I);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_P_RayofHope_II)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersP.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_P_RayofHope_II);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersP.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_P_RayofHope_II);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_P_RayofHope_III)
             {
-                magicPower = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersP.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_P_RayofHope_III);
+                magicPower = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowersP.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_P_RayofHope_III);
             }
 
             if (magicPower != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ApplyRandomHediffFromList.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ApplyRandomHediffFromList.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -29,9 +30,9 @@ namespace TorannMagic
         Verb_ApplyRandomHediffFromList_Properties Properties => this.verbProps as Verb_ApplyRandomHediffFromList_Properties;
         List<HediffDef> Effects => Properties?.hediffDefs;
         int CountUpgrade => Properties.countUpgrade == null ? 0
-            : TM_ClassUtility.GetMightPowerSkillFromLabel(this.CasterPawn.TryGetComp<CompAbilityUserMight>(), Properties.countUpgrade).level;
+            : TM_ClassUtility.GetMightPowerSkillFromLabel(this.CasterPawn.GetCompAbilityUserMight(), Properties.countUpgrade).level;
         int SeverityUpgrade => Properties.severityUpgrade == null ? 0
-            : TM_ClassUtility.GetMightPowerSkillFromLabel(this.CasterPawn.TryGetComp<CompAbilityUserMight>(), Properties.severityUpgrade).level;
+            : TM_ClassUtility.GetMightPowerSkillFromLabel(this.CasterPawn.GetCompAbilityUserMight(), Properties.severityUpgrade).level;
 
         protected override bool TryCastShot()
         {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ArcaneBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ArcaneBolt.cs
@@ -2,6 +2,7 @@
 using AbilityUser;
 using UnityEngine;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -41,14 +42,14 @@ namespace TorannMagic
         {
             bool result = false;
             Pawn pawn = this.CasterPawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             int burstCountMin = 1;
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             
-            if (pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level >= 2)
+            if (pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level >= 2)
             {
                 burstCountMin++;
-                if (pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level >= 7)
+                if (pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level >= 7)
                 {
                     burstCountMin++;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeArt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeArt.cs
@@ -2,6 +2,7 @@
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -11,8 +12,8 @@ namespace TorannMagic
         {
             Map map = base.CasterPawn.Map;
             Pawn pawn = base.CasterPawn;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
-            MightPowerSkill pwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BladeArt.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeArt_pwr");
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
+            MightPowerSkill pwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BladeArt.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeArt_pwr");
 
             if (pawn != null && !pawn.Dead)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeFocus.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeFocus.cs
@@ -3,6 +3,7 @@ using Verse;
 using AbilityUser;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -39,8 +40,8 @@ namespace TorannMagic
         {
             Map map = base.CasterPawn.Map;
             Pawn pawn = base.CasterPawn;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
-            MightPowerSkill pwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_BladeFocus.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeFocus_pwr");
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
+            MightPowerSkill pwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_BladeFocus.FirstOrDefault((MightPowerSkill x) => x.label == "TM_BladeFocus_pwr");
 
             List<Trait> traits = this.CasterPawn.story.traits.allTraits;
             for (int i = 0; i < traits.Count; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeSpin.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BladeSpin.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using RimWorld;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -46,7 +47,7 @@ namespace TorannMagic
 
         public static int GetWeaponDmg(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             MightPowerSkill str = comp.MightData.MightPowerSkill_global_strength.FirstOrDefault((MightPowerSkill x) => x.label == "TM_global_strength_pwr");
             int dmgNum = 0;
             ThingWithComps weaponComp = pawn.equipment.Primary;
@@ -61,7 +62,7 @@ namespace TorannMagic
         {            
             if (this.CasterPawn.equipment.Primary != null && !this.CasterPawn.equipment.Primary.def.IsRangedWeapon)
             {
-                CompAbilityUserMight comp = this.CasterPawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = this.CasterPawn.GetCompAbilityUserMight();
                 //MightPowerSkill ver = comp.MightData.MightPowerSkill_SeismicSlash.FirstOrDefault((MightPowerSkill x) => x.label == "TM_SeismicSlash_ver");
                 //MightPowerSkill pwr = comp.MightData.MightPowerSkill_SeismicSlash.FirstOrDefault((MightPowerSkill x) => x.label == "TM_SeismicSlash_pwr");
                 //verVal = TM_Calc.GetMightSkillLevel(this.CasterPawn, comp.MightData.MightPowerSkill_BladeSpin, "TM_BladeSpin", "_ver", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Blink.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Blink.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -73,7 +74,7 @@ namespace TorannMagic
                             //p.SetPositionDirect(this.currentTarget.Cell);
                             GenSpawn.Spawn(p, this.currentTarget.Cell, map);
                             p.drafter.Drafted = draftFlag;
-                            if (base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level >= 1)
+                            if (base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level >= 1)
                             {
                                 List<Pawn> eList = TM_Calc.FindPawnsNearTarget(p, 2, this.currentTarget.Cell, true);
                                 if(eList != null && eList.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodForBlood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodForBlood.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -20,19 +21,20 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool flag = false;
-            MagicPowerSkill bpwr = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_pwr");
-            MagicPowerSkill pwr = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodForBlood.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodForBlood_pwr");
-            MagicPowerSkill ver = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodForBlood.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodForBlood_ver");
+            var compAbility = base.CasterPawn.GetCompAbilityUserMagic();
+            MagicPowerSkill bpwr = compAbility.MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_pwr");
+            MagicPowerSkill pwr = compAbility.MagicData.MagicPowerSkill_BloodForBlood.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodForBlood_pwr");
+            MagicPowerSkill ver = compAbility.MagicData.MagicPowerSkill_BloodForBlood.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodForBlood_ver");
             verVal = ver.level;
             pwrVal = pwr.level;
             if (base.CasterPawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = base.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = base.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = base.CasterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = base.CasterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }
-            this.arcaneDmg = base.CasterPawn.GetComp<CompAbilityUserMagic>().arcaneDmg;
+            this.arcaneDmg = base.CasterPawn.GetCompAbilityUserMagic().arcaneDmg;
             this.arcaneDmg *= (1 + (.1f * bpwr.level));
             if(this.currentTarget.Thing != null && this.currentTarget.Thing is Pawn)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodGift.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodGift.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -17,8 +18,8 @@ namespace TorannMagic
 
             Pawn pawn = this.CasterPawn;
             Map map = this.CasterPawn.Map;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            int verVal = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_ver").level;
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            int verVal = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_ver").level;
             int bloodGain = 0;
             List<BodyPartRecord> bodyparts = new List<BodyPartRecord>();
             bodyparts.Clear();

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodShield.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BloodShield.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse;
 using Verse.Sound;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI.Group;
 
@@ -49,14 +50,14 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            comp = caster.GetComp<CompAbilityUserMagic>();
+            comp = caster.GetCompAbilityUserMagic();
             MagicPowerSkill bpwr = comp.MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodGift_pwr");
             MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_BloodShield.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_BloodShield_pwr");
             pwrVal = pwr.level;
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
+                pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
             }
             if (settingsRef.AIHardMode && !caster.IsColonist)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Blur.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Blur.cs
@@ -4,6 +4,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -40,7 +41,7 @@ namespace TorannMagic
                 }
                 else
                 {
-                    CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                     if (comp != null)
                     {
                         if (comp.maxMP >= TorannMagicDefOf.TM_Blur.upkeepEnergyCost)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BowTraining.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BowTraining.cs
@@ -2,6 +2,7 @@
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -11,7 +12,7 @@ namespace TorannMagic
         {
             Map map = base.CasterPawn.Map;
             Pawn pawn = base.CasterPawn;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             int pwrVal = TM_Calc.GetSkillPowerLevel(pawn, this.Ability.Def as TMAbilityDef);
 
             if (pawn != null && !pawn.Dead)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandAwareness.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandAwareness.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 using TorannMagic.TMDefs;
@@ -46,7 +47,7 @@ namespace TorannMagic
             if(caster != null && this.CurrentTarget.HasThing && this.CurrentTarget.Thing is Pawn)
             {
                 Pawn hitPawn = this.currentTarget.Thing as Pawn;
-                CompAbilityUserMagic casterComp = caster.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic casterComp = caster.GetCompAbilityUserMagic();
 
                 if (casterComp != null && hitPawn.health != null && hitPawn.health.hediffSet != null && hitPawn != caster)
                 {
@@ -104,7 +105,7 @@ namespace TorannMagic
         //        {
         //            if (!hd_br.BranderPawn.DestroyedOrNull())
         //            {
-        //                CompAbilityUserMagic branderComp = hd_br.BranderPawn.TryGetComp<CompAbilityUserMagic>();
+        //                CompAbilityUserMagic branderComp = hd_br.BranderPawn.GetCompAbilityUserMagic();
         //                if (branderComp != null && branderComp.BrandedPawns != null && branderComp.BrandedPawns.Contains(hitPawn))
         //                {
         //                    branderComp.BrandedPawns.Remove(hitPawn);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandEmotion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandEmotion.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -45,7 +46,7 @@ namespace TorannMagic
             if(caster != null && this.CurrentTarget.HasThing && this.CurrentTarget.Thing is Pawn)
             {
                 Pawn hitPawn = this.currentTarget.Thing as Pawn;                
-                CompAbilityUserMagic casterComp = caster.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic casterComp = caster.GetCompAbilityUserMagic();
 
                 if (casterComp != null && hitPawn.health != null && hitPawn.health.hediffSet != null && hitPawn != caster)
                 {
@@ -114,7 +115,7 @@ namespace TorannMagic
         //        HediffComp_BrandingEmotion hd_br = oldBrand.TryGetComp<HediffComp_BrandingEmotion>();
         //        if (hd_br != null && hd_br.BranderPawn != null && !hd_br.BranderPawn.DestroyedOrNull() && !hd_br.BranderPawn.Dead)
         //        {
-        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.TryGetComp<CompAbilityUserMagic>();
+        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.GetCompAbilityUserMagic();
         //            if (branderComp != null && branderComp.BrandedPawns != null && branderComp.BrandedPawns.Contains(hitPawn))
         //            {
         //                branderComp.BrandedPawns.Remove(hitPawn);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandFitness.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandFitness.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -45,7 +46,7 @@ namespace TorannMagic
             if(caster != null && this.CurrentTarget.HasThing && this.CurrentTarget.Thing is Pawn)
             {
                 Pawn hitPawn = this.currentTarget.Thing as Pawn;
-                CompAbilityUserMagic casterComp = caster.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic casterComp = caster.GetCompAbilityUserMagic();
 
                 if (casterComp != null && hitPawn.health != null && hitPawn.health.hediffSet != null && hitPawn != caster)
                 {
@@ -112,7 +113,7 @@ namespace TorannMagic
         //        HediffComp_BrandingBase hd_br = oldBrand.TryGetComp<HediffComp_BrandingBase>();
         //        if (hd_br != null && hd_br.BranderPawn != null && !hd_br.BranderPawn.DestroyedOrNull() && !hd_br.BranderPawn.Dead)
         //        {
-        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.TryGetComp<CompAbilityUserMagic>();
+        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.GetCompAbilityUserMagic();
         //            if (branderComp != null && branderComp.BrandedPawns != null && branderComp.BrandedPawns.Contains(hitPawn))
         //            {
         //                branderComp.BrandedPawns.Remove(hitPawn);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandProtection.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandProtection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 using UnityEngine;
@@ -45,7 +46,7 @@ namespace TorannMagic
             if(caster != null && this.CurrentTarget.HasThing && this.CurrentTarget.Thing is Pawn)
             {
                 Pawn hitPawn = this.currentTarget.Thing as Pawn;
-                CompAbilityUserMagic casterComp = caster.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic casterComp = caster.GetCompAbilityUserMagic();
 
                 if (casterComp != null && hitPawn.health != null && hitPawn.health.hediffSet != null && hitPawn != caster)
                 {
@@ -116,7 +117,7 @@ namespace TorannMagic
         //        HediffComp_BrandingProtection hd_br = oldBrand.TryGetComp<HediffComp_BrandingProtection>();
         //        if (hd_br != null && hd_br.BranderPawn != null && !hd_br.BranderPawn.DestroyedOrNull() && !hd_br.BranderPawn.Dead)
         //        {
-        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.TryGetComp<CompAbilityUserMagic>();
+        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.GetCompAbilityUserMagic();
         //            if (branderComp != null && branderComp.BrandedPawns != null && branderComp.BrandedPawns.Contains(hitPawn))
         //            {
         //                branderComp.BrandedPawns.Remove(hitPawn);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandSiphon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandSiphon.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -47,8 +48,8 @@ namespace TorannMagic
                 Pawn hitPawn = this.currentTarget.Thing as Pawn;
                 if (hitPawn.RaceProps != null && hitPawn.RaceProps.Humanlike && !TM_Calc.IsUndead(hitPawn) && hitPawn != caster)
                 {
-                    CompAbilityUserMagic casterComp = caster.TryGetComp<CompAbilityUserMagic>();
-                    CompAbilityUserMagic targetComp = hitPawn.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic casterComp = caster.GetCompAbilityUserMagic();
+                    CompAbilityUserMagic targetComp = hitPawn.GetCompAbilityUserMagic();
                     if (casterComp != null && targetComp != null && targetComp.Mana != null && targetComp.IsMagicUser && hitPawn.health != null && hitPawn.health.hediffSet != null)
                     {
                         //RemoveOldBrand(hitPawn);
@@ -120,7 +121,7 @@ namespace TorannMagic
         //        HediffComp_BrandingSiphon hd_br = oldBrand.TryGetComp<HediffComp_BrandingSiphon>();
         //        if (hd_br != null && hd_br.BranderPawn != null && !hd_br.BranderPawn.DestroyedOrNull() && !hd_br.BranderPawn.Dead)
         //        {
-        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.TryGetComp<CompAbilityUserMagic>();
+        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.GetCompAbilityUserMagic();
         //            if (branderComp != null && branderComp.BrandedPawns != null && branderComp.BrandedPawns.Contains(hitPawn))
         //            {
         //                branderComp.BrandedPawns.Remove(hitPawn);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandVitality.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BrandVitality.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -45,7 +46,7 @@ namespace TorannMagic
             if(caster != null && this.CurrentTarget.HasThing && this.CurrentTarget.Thing is Pawn)
             {
                 Pawn hitPawn = this.currentTarget.Thing as Pawn;
-                CompAbilityUserMagic casterComp = caster.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic casterComp = caster.GetCompAbilityUserMagic();
 
                 if (casterComp != null && hitPawn.health != null && hitPawn.health.hediffSet != null && hitPawn != caster)
                 {
@@ -113,7 +114,7 @@ namespace TorannMagic
         //        HediffComp_BrandingVitality hd_br = oldBrand.TryGetComp<HediffComp_BrandingVitality>();
         //        if (hd_br != null && hd_br.BranderPawn != null && !hd_br.BranderPawn.DestroyedOrNull() && !hd_br.BranderPawn.Dead)
         //        {
-        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.TryGetComp<CompAbilityUserMagic>();
+        //            CompAbilityUserMagic branderComp = hd_br.BranderPawn.GetCompAbilityUserMagic();
         //            if (branderComp != null && branderComp.BrandedPawns != null && branderComp.BrandedPawns.Contains(hitPawn))
         //            {
         //                branderComp.BrandedPawns.Remove(hitPawn);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BriarPatch.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BriarPatch.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using System.Linq;
 using System;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -39,7 +40,7 @@ namespace TorannMagic
             bool result = false;
             Pawn p = this.CasterPawn;
             Pawn hitPawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             Faction hitPawnFaction = null;
 
             if (this.currentTarget != null && p != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Buckshot.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Buckshot.cs
@@ -3,6 +3,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -31,7 +32,7 @@ namespace TorannMagic
         public static int GetShotCount(Pawn pawn)
         {
             int shots = 0;
-            return shots = Mathf.RoundToInt((5 + TM_Calc.GetSkillEfficiencyLevel(pawn, TorannMagicDefOf.TM_ShotgunSpec, false)) * pawn.GetComp<CompAbilityUserMight>().mightPwr);
+            return shots = Mathf.RoundToInt((5 + TM_Calc.GetSkillEfficiencyLevel(pawn, TorannMagicDefOf.TM_ShotgunSpec, false)) * pawn.GetCompAbilityUserMight().mightPwr);
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_CauterizeWound.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_CauterizeWound.cs
@@ -6,6 +6,7 @@ using AbilityUser;
 using Verse;
 using UnityEngine;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -39,7 +40,7 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             bool flag = pawn != null && pawn.health != null && pawn.health.hediffSet != null && pawn.health.hediffSet.GetInjuredParts() != null;
             if (flag && comp != null)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ChaosTradition.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ChaosTradition.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -23,7 +24,7 @@ namespace TorannMagic
         {
             bool result = false;
             Map map = this.CasterPawn.Map;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();            
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
 
             if (this.CasterPawn != null && !this.CasterPawn.Downed && comp != null && comp.MagicData != null)
             {                

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ChiBurst.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ChiBurst.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System;
 using System.Collections.Generic;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -43,7 +44,7 @@ namespace TorannMagic
         {
             bool result = false;
             Pawn caster = this.CasterPawn;
-            this.pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Chi.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Chi_pwr").level;
+            this.pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Chi.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Chi_pwr").level;
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             if (!caster.IsColonist && settingsRef.AIHardMode)
             {
@@ -112,7 +113,7 @@ namespace TorannMagic
             float energyBurn = 0;
             if (TM_Calc.IsMightUser(pawn))
             {
-                CompAbilityUserMight mightComp = pawn.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight mightComp = pawn.GetCompAbilityUserMight();
                 classHediff = pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_PsionicHD);
                 classHediff = pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_HateHD);
                 classHediff = pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD);
@@ -125,7 +126,7 @@ namespace TorannMagic
             }
             else if (TM_Calc.IsMagicUser(pawn))
             {
-                CompAbilityUserMagic magicComp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic magicComp = pawn.GetCompAbilityUserMagic();
                 classHediff = pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_BloodHD);
                 if (magicComp != null && magicComp.Mana != null)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Cleave.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Cleave.cs
@@ -3,6 +3,7 @@ using AbilityUser;
 using UnityEngine;
 using RimWorld;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -61,7 +62,7 @@ namespace TorannMagic
             cellRect.ClipInsideMap(map);
 
             IntVec3 centerCell = cellRect.CenterCell;
-            CompAbilityUserMight comp = this.CasterPawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.CasterPawn.GetCompAbilityUserMight();
             pwr = comp.MightData.MightPowerSkill_Cleave.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Cleave_pwr");
             str = comp.MightData.MightPowerSkill_global_strength.FirstOrDefault((MightPowerSkill x) => x.label == "TM_global_strength_pwr");
             ver = comp.MightData.MightPowerSkill_Cleave.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Cleave_ver");

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_CommanderAuras.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_CommanderAuras.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -74,15 +75,15 @@ namespace TorannMagic
             MightPower mightPower = null;
             if (this.Ability.Def == TorannMagicDefOf.TM_ProvisionerAura)
             {
-               mightPower = this.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowersC.FirstOrDefault<MightPower>((MightPower x) => x.abilityDef == TorannMagicDefOf.TM_ProvisionerAura);
+               mightPower = this.CasterPawn.GetCompAbilityUserMight().MightData.MightPowersC.FirstOrDefault<MightPower>((MightPower x) => x.abilityDef == TorannMagicDefOf.TM_ProvisionerAura);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_TaskMasterAura)
             {
-                mightPower = this.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowersC.FirstOrDefault<MightPower>((MightPower x) => x.abilityDef == TorannMagicDefOf.TM_TaskMasterAura);
+                mightPower = this.CasterPawn.GetCompAbilityUserMight().MightData.MightPowersC.FirstOrDefault<MightPower>((MightPower x) => x.abilityDef == TorannMagicDefOf.TM_TaskMasterAura);
             }
             else if (this.Ability.Def == TorannMagicDefOf.TM_CommanderAura)
             {
-                mightPower = this.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowersC.FirstOrDefault<MightPower>((MightPower x) => x.abilityDef == TorannMagicDefOf.TM_CommanderAura);
+                mightPower = this.CasterPawn.GetCompAbilityUserMight().MightData.MightPowersC.FirstOrDefault<MightPower>((MightPower x) => x.abilityDef == TorannMagicDefOf.TM_CommanderAura);
             }            
 
             if (mightPower != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_CommanderOrders.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_CommanderOrders.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 using UnityEngine;
@@ -28,7 +29,7 @@ namespace TorannMagic
             this.TargetsAoE.Clear();
             //this.UpdateTargets();
             FindTargets();
-            CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef, true);
             if (this.Ability.Def == TorannMagicDefOf.TM_StayAlert || this.Ability.Def == TorannMagicDefOf.TM_StayAlert_I || this.Ability.Def == TorannMagicDefOf.TM_StayAlert_II || this.Ability.Def == TorannMagicDefOf.TM_StayAlert_III)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -38,9 +39,9 @@ namespace TorannMagic
         {
 
             Pawn caster = this.CasterPawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill ver = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ConsumeCorpse.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ConsumeCorpse_ver");
-            MagicPowerSkill manaRegen = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
+            MagicPowerSkill ver = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ConsumeCorpse.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ConsumeCorpse_ver");
+            MagicPowerSkill manaRegen = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_global_regen_pwr");
 
             Thing undeadThing = this.currentTarget.Thing;
             if (undeadThing is Pawn)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_CureDisease.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_CureDisease.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -19,7 +20,7 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef);
 
@@ -27,11 +28,11 @@ namespace TorannMagic
             //MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_CureDisease.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_CureDisease_ver");
             //verVal = ver.level;
             //pwrVal = pwr.level;
-            //this.arcaneDmg = caster.GetComp<CompAbilityUserMagic>().arcaneDmg;
+            //this.arcaneDmg = caster.GetCompAbilityUserMagic().arcaneDmg;
             //if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mpwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
             //}

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DeathMark.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DeathMark.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -42,7 +43,7 @@ namespace TorannMagic
         {
             bool result = false;
             Pawn p = this.CasterPawn;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             verVal = TM_Calc.GetSkillVersatilityLevel(p, this.Ability.Def as TMAbilityDef);
             pwrVal = TM_Calc.GetSkillPowerLevel(p, this.Ability.Def as TMAbilityDef);
             //MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_DeathMark.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_DeathMark_pwr");
@@ -52,8 +53,8 @@ namespace TorannMagic
             //this.arcaneDmg = comp.arcaneDmg;
             //if (p.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = p.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = p.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mpwr = p.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = p.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
             //}

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Disguise.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Disguise.cs
@@ -3,6 +3,7 @@ using System;
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -14,7 +15,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             MightPowerSkill pwr = comp.MightData.MightPowerSkill_Disguise.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Disguise_pwr");
             MightPowerSkill ver = comp.MightData.MightPowerSkill_Disguise.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Disguise_ver");
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissCooler.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissCooler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.summonedCoolers.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissEarthSprites.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissEarthSprites.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 
 
@@ -14,7 +15,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool flag = false;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
 
             if (comp.IsMagicUser)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissEnchanterStones.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissEnchanterStones.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.enchanterStones.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissFertileLands.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissFertileLands.cs
@@ -1,4 +1,5 @@
 ﻿using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 
 namespace TorannMagic
@@ -10,7 +11,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.fertileLands.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissGuardianSpirit.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissGuardianSpirit.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.bondedSpirit != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissHeater.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissHeater.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.summonedHeaters.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissLightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissLightningTrap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.lightningTraps.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissMinion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissMinion.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.summonedMinions.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissPowerNode.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissPowerNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.summonedPowerNodes.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissSunlight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissSunlight.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.summonedLights.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissUndead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DismissUndead.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -43,7 +44,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn target = this.currentTarget.Thing as Pawn;
             
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             if (comp.IsMagicUser && target != null)
             {
                 if (target.RaceProps.Humanlike)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelBranding.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelBranding.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 using TorannMagic.TMDefs;
@@ -15,7 +16,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool flag = false;
-            CompAbilityUserMagic comp = CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = CasterPawn.GetCompAbilityUserMagic();
 
             if (comp != null && comp.IsMagicUser && comp.BrandPawns != null && comp.BrandDefs != null)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelEnchantWeapon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelEnchantWeapon.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 
 
@@ -13,7 +14,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool flag = false;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
 
             if (comp.IsMagicUser)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelLivingWall.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelLivingWall.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 
 
@@ -13,7 +14,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool flag = false;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
 
             if (comp.IsMagicUser)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelStoneskin.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelStoneskin.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 
 
@@ -13,7 +14,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool flag = false;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
 
             if (comp.IsMagicUser)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Dominate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Dominate.cs
@@ -3,6 +3,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -42,7 +43,7 @@ namespace TorannMagic
             bool result = false;
             Pawn p = this.CasterPawn;
             Pawn hitPawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             verVal = TM_Calc.GetSkillVersatilityLevel(p, this.Ability.Def as TMAbilityDef, true);
             pwrVal = TM_Calc.GetSkillPowerLevel(p, this.Ability.Def as TMAbilityDef);
             effVal = TM_Calc.GetSkillEfficiencyLevel(p, this.Ability.Def as TMAbilityDef);
@@ -61,9 +62,9 @@ namespace TorannMagic
             //}
             //if (p.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = p.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = p.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
-            //    MightPowerSkill meff = p.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_eff");
+            //    MightPowerSkill mpwr = p.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = p.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill meff = p.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_eff");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
             //    effVal = meff.level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_EarthSprites.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_EarthSprites.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 using Verse.Sound;
@@ -40,9 +41,9 @@ namespace TorannMagic
 
         protected override bool TryCastShot()
         {
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
-            //MagicPowerSkill eff = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EarthSprites.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthSprites_eff");
-            //MagicPowerSkill ver = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EarthSprites.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthSprites_ver");
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
+            //MagicPowerSkill eff = base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EarthSprites.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthSprites_eff");
+            //MagicPowerSkill ver = base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EarthSprites.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EarthSprites_ver");
             //effVal = eff.level;
             //verVal = ver.level;
             effVal = TM_Calc.GetSkillEfficiencyLevel(CasterPawn, Ability.Def as TMAbilityDef);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Elixir.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Elixir.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.Sound;
 
@@ -42,7 +43,7 @@ namespace TorannMagic
 
             Pawn hitPawn = this.currentTarget.Thing as Pawn;
             Pawn caster = this.CasterPawn;
-            CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
 
             int verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef, false);
             int pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef, false);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchantWeapon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchantWeapon.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse;
 using Verse.Sound;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI.Group;
 
@@ -48,14 +49,14 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            comp = caster.GetComp<CompAbilityUserMagic>();
+            comp = caster.GetCompAbilityUserMagic();
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             //MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_EnchantWeapon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EnchantWeapon_pwr");
             //pwrVal = pwr.level;
             //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             //if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
+            //    pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
             //}
             //if (settingsRef.AIHardMode && !caster.IsColonist)
             //{
@@ -108,7 +109,7 @@ namespace TorannMagic
                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Shadow, pawn.DrawPos, pawn.Map, 1f, .2f, .1f, .8f, Rand.Range(-30, 30), .3f, Rand.Range(-30, 30), Rand.Range(0, 360));
             }
             HealthUtility.AdjustSeverity(pawn, hediff, .5f + pwrVal);
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();            
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             comp.weaponEnchants.Add(pawn);
             Hediff diff = pawn.health.hediffSet.GetFirstHediffOfDef(hediff, false);
             HediffComp_EnchantedWeapon ewComp = diff.TryGetComp<HediffComp_EnchantedWeapon>();
@@ -133,7 +134,7 @@ namespace TorannMagic
                         HediffComp_EnchantedWeapon ewComp = hediff.TryGetComp<HediffComp_EnchantedWeapon>();
                         if (ewComp != null)
                         {
-                            CompAbilityUserMagic comp = ewComp.enchanterPawn.GetComp<CompAbilityUserMagic>();
+                            CompAbilityUserMagic comp = ewComp.enchanterPawn.GetCompAbilityUserMagic();
                             if (comp != null)
                             {
                                 comp.weaponEnchants.Remove(pawn);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchantedAura.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchantedAura.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -18,8 +19,8 @@ namespace TorannMagic
 
             Pawn pawn = this.CasterPawn;
             Map map = this.CasterPawn.Map;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchantedBody.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EnchantedBody_pwr");            
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchantedBody.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EnchantedBody_pwr");
 
             if (pawn != null && !pawn.Downed)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchantedBody.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchantedBody.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -18,8 +19,8 @@ namespace TorannMagic
 
             Pawn pawn = this.CasterPawn;
             Map map = this.CasterPawn.Map;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            pwrVal = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchantedBody.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EnchantedBody_pwr").level;
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            pwrVal = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchantedBody.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EnchantedBody_pwr").level;
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             if (settingsRef.AIHardMode && !pawn.IsColonist)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchanterStone.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchanterStone.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 
 
@@ -38,9 +39,9 @@ namespace TorannMagic
 
         protected override bool TryCastShot()
         {
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
-            MagicPowerSkill eff = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchanterStone.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EnchanterStone_eff");
-            MagicPowerSkill ver = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_EnchanterStone.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EnchanterStone_ver");
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
+            MagicPowerSkill eff = base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchanterStone.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EnchanterStone_eff");
+            MagicPowerSkill ver = base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_EnchanterStone.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_EnchanterStone_ver");
             effVal = eff.level;
             verVal = ver.level;
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Enrage.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Enrage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -42,7 +43,7 @@ namespace TorannMagic
             bool flag = false;
             Pawn caster = this.CasterPawn;
             Pawn hitPawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             if (comp != null && comp.MagicData != null)
             {
                 //pwrVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_Enrage, "TM_Enrage", "_pwr", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Entertain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Entertain.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -15,7 +16,7 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             MagicPower magicPower = comp.MagicData.MagicPowersB.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Entertain);
             bool flag = pawn != null && !pawn.Dead;
             if (flag)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_FightersFocus.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_FightersFocus.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -29,7 +30,7 @@ namespace TorannMagic
                     float val = .5f;
                     if(caster.story != null)
                     {
-                        if (caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 1)
+                        if (caster.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 1)
                         {
                             val = 1.5f;
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_FirstAid.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_FirstAid.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -19,7 +20,7 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;
 
-            CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef);
             //pwrVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_FirstAid, "TM_FirstAid", "_pwr", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_FoldReality.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_FoldReality.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using UnityEngine;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -21,7 +22,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             Map map = base.CasterPawn.Map;
-            comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            comp = this.CasterPawn.GetCompAbilityUserMagic();
             StartChoosingDestination();
             return false;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Heal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Heal.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -41,27 +42,27 @@ namespace TorannMagic
             // power affects enumerator
             //DamageWorker.DamageResult result = DamageWorker.DamageResult.MakeNew();
             Pawn caster = this.CasterPawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
-            //pwrVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Heal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Heal_pwr").level;
-            //verVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Heal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Heal_ver").level;
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
+            //pwrVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Heal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Heal_pwr").level;
+            //verVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Heal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Heal_ver").level;
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef);
             if(caster.story.traits.HasTrait(TorannMagicDefOf.Priest))
             {
-                pwrVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AdvancedHeal_pwr").level;
-                verVal = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AdvancedHeal_ver").level;
+                pwrVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AdvancedHeal_pwr").level;
+                verVal = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_AdvancedHeal_ver").level;
             }            
             //else if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mpwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
             //}
             //else if (caster.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer) || (comp.customClass != null && comp.customClass.classMageAbilities.Contains(TorannMagicDefOf.TM_Cantrips)))
             //{
-            //    int tmpPwrVal = (int)((caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level) / 5);
-            //    int tmpVerVal = (int)((caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level) / 5);
+            //    int tmpPwrVal = (int)((caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_pwr").level) / 5);
+            //    int tmpVerVal = (int)((caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level) / 5);
             //    pwrVal = (tmpPwrVal > pwrVal) ? tmpPwrVal : pwrVal;
             //    verVal = (tmpVerVal > verVal) ? tmpVerVal : verVal;
             //}

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_HeavyBlow.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_HeavyBlow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -37,7 +38,7 @@ namespace TorannMagic
                 {
                     //if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer))
                     //{
-                        int lvl = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_pwr").level;
+                        int lvl = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_pwr").level;
                         HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_HediffHeavyBlow, .95f + (.19f * lvl));
                         FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
                     //}

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Hex.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Hex.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -42,7 +43,7 @@ namespace TorannMagic
             bool flag = false;
             this.TargetsAoE.Clear();
             this.FindTargets();
-            CompAbilityUserMagic comp = CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = CasterPawn.GetCompAbilityUserMagic();
             if (comp != null && comp.MagicData != null)
             {
                 pwrVal = TM_Calc.GetSkillPowerLevel(CasterPawn, this.Ability.Def as TMAbilityDef);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Hex_CriticalFail.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Hex_CriticalFail.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
             int verVal = 0;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             //verVal = TM_Calc.GetMagicSkillLevel(CasterPawn, comp.MagicData.MagicPowerSkill_Hex, "TM_Hex", "_ver", true);
             verVal = TM_Calc.GetSkillVersatilityLevel(CasterPawn, TorannMagicDefOf.TM_Hex);
             if (comp != null && comp.HexedPawns.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Hex_MentalAssault.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Hex_MentalAssault.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 using UnityEngine;
@@ -17,7 +18,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             int verVal = TM_Calc.GetSkillVersatilityLevel(CasterPawn, TorannMagicDefOf.TM_Hex);
             if (comp != null && comp.HexedPawns.Count > 0)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Hex_Pain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Hex_Pain.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             int verVal = TM_Calc.GetSkillVersatilityLevel(CasterPawn, TorannMagicDefOf.TM_Hex);
             if (comp != null && comp.HexedPawns.Count > 0)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Ignite.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Ignite.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using Verse.Sound;
 
 namespace TorannMagic
@@ -43,7 +44,7 @@ namespace TorannMagic
         {
             Pawn p = this.CasterPawn;
             Map map = this.CasterPawn.Map;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             corpses.Clear();
             pawns.Clear();
             plants.Clear();

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Invisibility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Invisibility.cs
@@ -5,6 +5,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -40,7 +41,7 @@ namespace TorannMagic
                 }
                 else
                 {
-                    HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_InvisibilityHD, Mathf.RoundToInt(20f * pawn.GetComp<CompAbilityUserMagic>().arcaneDmg));
+                    HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_InvisibilityHD, Mathf.RoundToInt(20f * pawn.GetCompAbilityUserMagic().arcaneDmg));
                     TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, .75f);
                     TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, 1);
                     TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, .75f);
@@ -52,7 +53,7 @@ namespace TorannMagic
                             allPawns[i].jobs.EndCurrentJob(Verse.AI.JobCondition.InterruptForced, true);
                         }
                     }
-                    if (this.CasterPawn.TryGetComp<CompAbilityUserMagic>()?.MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level >= 12)
+                    if (this.CasterPawn.GetCompAbilityUserMagic()?.MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level >= 12)
                     {
                         HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_InvisibilityHD, 5f);
                         TM_Action.DoAction_HealPawn(this.CasterPawn, this.CasterPawn, 3, 7);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Legion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Legion.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -61,10 +62,10 @@ namespace TorannMagic
                 Pawn targetPawn = this.currentTarget.Thing as Pawn;
                 if (targetPawn.RaceProps.Humanlike)
                 {
-                    CompAbilityUserMight mightPawn = targetPawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight mightPawn = targetPawn.GetCompAbilityUserMight();
 
                     TMAbilityDef tempAbility = null;
-                    CompAbilityUserMight mightComp = this.CasterPawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight mightComp = this.CasterPawn.GetCompAbilityUserMight();
                     
                     if (mightPawn.IsMightUser)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_LichForm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_LichForm.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -15,7 +16,7 @@ namespace TorannMagic
         {
             Map map = base.CasterPawn.Map;
             Pawn pawn = base.CasterPawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
 
             List<Trait> traits = pawn.story.traits.allTraits;
             for (int i = 0; i < traits.Count; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_LightBurst.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_LightBurst.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse.Sound;
 using RimWorld;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -19,7 +20,7 @@ namespace TorannMagic
 
         private void Initialize(Pawn pawn)
         {
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             //pwrVal = TM_Calc.GetMagicSkillLevel(pawn, comp.MagicData.MagicPowerSkill_LightBurst, "TM_LightBurst", "_pwr", TorannMagicDefOf.TM_LightBurst.canCopy);
             //verVal = TM_Calc.GetMagicSkillLevel(pawn, comp.MagicData.MagicPowerSkill_LightBurst, "TM_LightBurst", "_ver", TorannMagicDefOf.TM_LightBurst.canCopy);
             pwrVal = TM_Calc.GetSkillPowerLevel(pawn, this.Ability.Def as TMAbilityDef);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_LightSkipGlobal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_LightSkipGlobal.cs
@@ -7,6 +7,7 @@ using System;
 using RimWorld;
 using RimWorld.Planet;
 using System.Text;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -65,7 +66,7 @@ namespace TorannMagic
 
                 this.pawn = this.CasterPawn;
                 launcherPosition = this.CasterPawn.Position;
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 //pwrVal = TM_Calc.GetMagicSkillLevel(this.pawn, comp.MagicData.MagicPowerSkill_LightSkip, "TM_LightSkip", "_pwr", false);
                 pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_LightSkip, false);
                 this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_LivingWall.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_LivingWall.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -45,7 +46,7 @@ namespace TorannMagic
         {
             Pawn caster = this.CasterPawn;
             //Pawn pawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef);
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             //verVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_LivingWall, "TM_LivingWall", "_ver", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Lullaby.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Lullaby.cs
@@ -41,14 +41,14 @@ namespace TorannMagic
             bool flag = false;
             this.TargetsAoE.Clear();
             this.UpdateTargets();
-            //MagicPowerSkill pwr = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Lullaby.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Lullaby_pwr");
-            //MagicPowerSkill ver = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Lullaby.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Lullaby_ver");
+            //MagicPowerSkill pwr = base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Lullaby.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Lullaby_pwr");
+            //MagicPowerSkill ver = base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Lullaby.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Lullaby_ver");
             //verVal = ver.level;
             //pwrVal = pwr.level;
             //if (base.CasterPawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = base.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = base.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mpwr = base.CasterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = base.CasterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
             //}

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_MageLight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_MageLight.cs
@@ -3,6 +3,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -37,7 +38,7 @@ namespace TorannMagic
         {
             bool result = false;
             Pawn p = this.CasterPawn;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
 
             if (this.currentTarget != null && base.CasterPawn != null)
             {                

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_MagicWardrobe.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_MagicWardrobe.cs
@@ -6,6 +6,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -20,7 +21,7 @@ namespace TorannMagic
             
             if (pawn != null && !pawn.Downed)
             {
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if(comp != null && comp.MagicWardrobe != null && pawn.apparel != null)
                 {                    
                     List<ThingWithComps> tmpHolder = new List<ThingWithComps>();

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Meteor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Meteor.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -50,7 +51,7 @@ namespace TorannMagic
             Map map = base.CasterPawn.Map;
             IntVec3 centerCell = this.currentTarget.Cell;
 
-            verVal = this.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Meteor.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Meteor_ver").level;
+            verVal = this.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Meteor.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Meteor_ver").level;
             pwrVal = this.UseAbilityProps.TargetAoEProperties.range;
 
             bool result = false;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Mimic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Mimic.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -61,8 +62,8 @@ namespace TorannMagic
                 Pawn targetPawn = this.currentTarget.Thing as Pawn;
                 if (targetPawn.RaceProps.Humanlike)
                 {
-                    CompAbilityUserMagic magicPawn = targetPawn.GetComp<CompAbilityUserMagic>();
-                    CompAbilityUserMight mightPawn = targetPawn.GetComp<CompAbilityUserMight>();
+                    CompAbilityUserMagic magicPawn = targetPawn.GetCompAbilityUserMagic();
+                    CompAbilityUserMight mightPawn = targetPawn.GetCompAbilityUserMight();
                     bool copyMagic = false;
                     bool copyMight = false;
                     if(magicPawn != null && magicPawn.IsMagicUser)
@@ -79,8 +80,8 @@ namespace TorannMagic
                         copyMagic = false;
                     }
                     TMAbilityDef tempAbility = null;
-                    CompAbilityUserMight mightComp = this.CasterPawn.GetComp<CompAbilityUserMight>();
-                    CompAbilityUserMagic magicComp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMight mightComp = this.CasterPawn.GetCompAbilityUserMight();
+                    CompAbilityUserMagic magicComp = this.CasterPawn.GetCompAbilityUserMagic();
 
                     if (copyMagic)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_MindKiller.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_MindKiller.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 using Verse.Sound;
@@ -25,7 +26,7 @@ namespace TorannMagic
             bool flag = caster != null && !caster.Dead && !caster.Downed;
             if (flag)
             {
-                CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
                 int pwrVal = 0;
                 int verVal = 0;
                 if (comp != null && comp.MagicData != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_NanoStimulant.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_NanoStimulant.cs
@@ -4,6 +4,7 @@ using Verse;
 using Verse.Sound;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -13,7 +14,7 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;
 
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             //MagicPowerSkill eff = comp.MagicData.MagicPowerSkill_TechnoWeapon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoWeapon_eff");
             int effVal = TM_Calc.GetSkillEfficiencyLevel(caster, TorannMagicDefOf.TM_TechnoWeapon, false);
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Overdrive.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Overdrive.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse;
 using Verse.Sound;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI.Group;
 
@@ -43,14 +44,14 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;           
 
-            comp = caster.GetComp<CompAbilityUserMagic>();
+            comp = caster.GetCompAbilityUserMagic();
             //pwrVal = comp.MagicData.MagicPowerSkill_Overdrive.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Overdrive_pwr").level;
             //verVal = comp.MagicData.MagicPowerSkill_Overdrive.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Overdrive_ver").level;
             //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             //if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
-            //    verVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
+            //    pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
+            //    verVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
             //}
             //if (settingsRef.AIHardMode && !caster.IsColonist)
             //{

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_PhaseStrike.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -50,7 +51,7 @@ namespace TorannMagic
 
         public static int GetWeaponDmg(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             MightPowerSkill str = comp.MightData.MightPowerSkill_global_strength.FirstOrDefault((MightPowerSkill x) => x.label == "TM_global_strength_pwr");
             ThingWithComps weaponComp = pawn.equipment.Primary;
             float weaponDPS = weaponComp.GetStatValue(StatDefOf.MeleeWeapon_AverageDPS, false) * .7f;
@@ -65,7 +66,7 @@ namespace TorannMagic
             bool result = false;
             bool arg_40_0;
 
-            CompAbilityUserMight comp = this.CasterPawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.CasterPawn.GetCompAbilityUserMight();
             verVal = TM_Calc.GetSkillVersatilityLevel(CasterPawn, this.Ability.Def as TMAbilityDef);
             pwrVal = TM_Calc.GetSkillPowerLevel(CasterPawn, this.Ability.Def as TMAbilityDef);
             //pwr = comp.MightData.MightPowerSkill_PhaseStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PhaseStrike_pwr");

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_PistolWhip.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_PistolWhip.cs
@@ -5,6 +5,7 @@ using Verse;
 using UnityEngine;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -18,7 +19,7 @@ namespace TorannMagic
             if (caster != null && this.currentTarget != null && this.currentTarget.Thing != null && currentTarget.Thing is Pawn)
             { 
                 Pawn pawn = this.currentTarget.Thing as Pawn;
-                CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                 MightPowerSkill ver = comp.MightData.MightPowerSkill_PistolSpec.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PistolSpec_ver");
                 DamageInfo dinfo = new DamageInfo(DamageDefOf.Stun, Mathf.RoundToInt(comp.weaponDamage * TorannMagicDefOf.TM_PistolWhip.weaponDamageFactor + ver.level), 4, (float)-1, this.CasterPawn, null, null, DamageInfo.SourceCategory.ThingOrUnknown);
                 BodyPartRecord hitPart = pawn.health.hediffSet.GetRandomNotMissingPart(dinfo.Def, BodyPartHeight.Undefined, BodyPartDepth.Outside, null);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Polymorph.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Polymorph.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 using UnityEngine;
@@ -48,18 +49,19 @@ namespace TorannMagic
             bool flag = false;
             this.TargetsAoE.Clear();
             this.UpdateTargets();
-            MagicPowerSkill pwr = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Polymorph.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Polymorph_pwr");
-            MagicPowerSkill ver = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Polymorph.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Polymorph_ver");
+            CompAbilityUserMagic comp = base.CasterPawn.GetCompAbilityUserMagic();
+            MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_Polymorph.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Polymorph_pwr");
+            MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_Polymorph.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Polymorph_ver");
             verVal = ver.level;
             pwrVal = pwr.level;
-            CompAbilityUserMagic comp = base.CasterPawn.GetComp<CompAbilityUserMagic>();
-            this.arcaneDmg = base.CasterPawn.GetComp<CompAbilityUserMagic>().arcaneDmg;
+
+            this.arcaneDmg = base.CasterPawn.GetCompAbilityUserMagic().arcaneDmg;
             this.duration += Mathf.RoundToInt(600 * verVal * this.arcaneDmg); 
 
             if (base.CasterPawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             {
-                MightPowerSkill mpwr = base.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                MightPowerSkill mver = base.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                MightPowerSkill mpwr = base.CasterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                MightPowerSkill mver = base.CasterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 pwrVal = mpwr.level;
                 verVal = mver.level;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_PommelStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_PommelStrike.cs
@@ -5,6 +5,7 @@ using Verse;
 using UnityEngine;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -25,7 +26,7 @@ namespace TorannMagic
                 if(targetPawn != null)
                 {
                     float rnd = 2f;
-                    CompAbilityUserMight comp = this.CasterPawn.TryGetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight comp = this.CasterPawn.GetCompAbilityUserMight();
                     if(comp != null)
                     {
                         if(comp.MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_pwr").level >= 2)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Prediction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Prediction.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -17,10 +18,10 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
-            MagicPower magicPower = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowersC.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Prediction);
-            MagicPowerSkill pwr = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Prediction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Prediction_pwr");
+            MagicPower magicPower = caster.GetCompAbilityUserMagic().MagicData.MagicPowersC.FirstOrDefault<MagicPower>((MagicPower x) => x.abilityDef == TorannMagicDefOf.TM_Prediction);
+            MagicPowerSkill pwr = base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Prediction.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Prediction_pwr");
             pwrVal = pwr.level;
-            CompAbilityUserMagic comp = base.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = base.CasterPawn.GetCompAbilityUserMagic();
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             if (settingsRef.AIHardMode && !this.CasterPawn.IsColonist)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_PsionicBlast.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_PsionicBlast.cs
@@ -41,11 +41,11 @@ namespace TorannMagic
             bool result = false;
             Pawn pawn = this.CasterPawn;
             verVal = TM_Calc.GetSkillVersatilityLevel(pawn, this.Ability.Def as TMAbilityDef);
-            //verVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicBlast, "TM_PsionicBlast", "_ver", true);
-            //this.verVal = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_PsionicBlast.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicBlast_ver").level;
+            //verVal = TM_Calc.GetMightSkillLevel(pawn, pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicBlast, "TM_PsionicBlast", "_ver", true);
+            //this.verVal = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_PsionicBlast.FirstOrDefault((MightPowerSkill x) => x.label == "TM_PsionicBlast_ver").level;
             //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    this.verVal = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
+            //    this.verVal = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
             //}
             Map map = this.CasterPawn.Map;
             IntVec3 targetVariation = this.currentTarget.Cell;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Purify.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Purify.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -46,7 +47,7 @@ namespace TorannMagic
         {
             Pawn caster = this.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             arcaneDmg = comp.arcaneDmg;
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef);
@@ -61,11 +62,11 @@ namespace TorannMagic
             //else if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
 
-            //    MightPowerSkill mpwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mpwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
-            //    arcaneDmg = caster.GetComp<CompAbilityUserMight>().mightPwr;
+            //    arcaneDmg = caster.GetCompAbilityUserMight().mightPwr;
 
             //}
             bool flag = pawn != null && !pawn.Dead;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Rainmaker.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Rainmaker.cs
@@ -4,6 +4,7 @@ using Verse;
 using AbilityUser;
 using System.Linq;
 using TorannMagic.Conditions;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -16,7 +17,7 @@ namespace TorannMagic
         {
             Map map = base.CasterPawn.Map; 
             WeatherDef rainMakerDef = new WeatherDef();
-            CompAbilityUserMagic comp = base.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = base.CasterPawn.GetCompAbilityUserMagic();
             if (map != null && comp != null && comp.MagicData != null)
             {
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_RangerTraining.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_RangerTraining.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -15,8 +16,8 @@ namespace TorannMagic
         {
             Map map = base.CasterPawn.Map;
             Pawn pawn = base.CasterPawn;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
-            MightPowerSkill pwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_RangerTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_RangerTraining_pwr");
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
+            MightPowerSkill pwr = comp.MightData.MightPowerSkill_RangerTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_RangerTraining_pwr");
 
             List<Trait> traits = this.CasterPawn.story.traits.allTraits;
             for (int i = 0; i < traits.Count; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Recall.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Recall.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -18,7 +19,7 @@ namespace TorannMagic
         {
             bool result = false;
             map = this.CasterPawn.Map;
-            comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            comp = this.CasterPawn.GetCompAbilityUserMagic();
 
             if (this.CasterPawn != null && !this.CasterPawn.Downed && comp != null && comp.recallSet)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Regenerate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Regenerate.cs
@@ -47,15 +47,15 @@ namespace TorannMagic
 
             try
             {
-                //MagicPowerSkill pwr = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Regenerate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Regenerate_pwr");
-                //MagicPowerSkill ver = caster.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Regenerate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Regenerate_ver");
+                //MagicPowerSkill pwr = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Regenerate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Regenerate_pwr");
+                //MagicPowerSkill ver = caster.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Regenerate.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Regenerate_ver");
                 //verVal = ver.level;
                 //pwrVal = pwr.level;
-                //arcaneDmg = caster.GetComp<CompAbilityUserMagic>().arcaneDmg;
+                //arcaneDmg = caster.GetCompAbilityUserMagic().arcaneDmg;
                 //if (this.caster != null && caster.story != null && caster.story.traits != null && caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                 //{
-                //    MightPowerSkill mpwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-                //    MightPowerSkill mver = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+                //    MightPowerSkill mpwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+                //    MightPowerSkill mver = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
                 //    pwrVal = mpwr.level;
                 //    verVal = mver.level;
                 //}

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Rend.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Rend.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -48,8 +49,8 @@ namespace TorannMagic
             this.TargetsAoE.Clear();
             //this.UpdateTargets();
             this.FindTargets();
-            MagicPowerSkill ver = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_Rend.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Rend_ver");
-            this.arcaneDmg = base.CasterPawn.GetComp<CompAbilityUserMagic>().arcaneDmg;
+            MagicPowerSkill ver = base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_Rend.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Rend_ver");
+            this.arcaneDmg = base.CasterPawn.GetCompAbilityUserMagic().arcaneDmg;
             verVal = ver.level;
             bool flag2 = this.UseAbilityProps.AbilityTargetCategory != AbilityTargetCategory.TargetAoE && this.TargetsAoE.Count > 1;
             if (flag2)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Reversal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Reversal.cs
@@ -3,6 +3,7 @@ using System;
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -13,7 +14,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             MightPowerSkill pwr = comp.MightData.MightPowerSkill_Reversal.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Reversal_pwr");
 
             bool flag = caster != null && !caster.Dead;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ReverseTime.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ReverseTime.cs
@@ -7,6 +7,7 @@ using Verse;
 using Verse.AI;
 using UnityEngine;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -48,17 +49,17 @@ namespace TorannMagic
         private void Initialize()
         {
             Pawn pawn = this.CasterPawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
-            //MagicPowerSkill pwr = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ReverseTime.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ReverseTime_pwr");
-            //MagicPowerSkill ver = pawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_ReverseTime.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ReverseTime_ver");
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
+            //MagicPowerSkill pwr = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ReverseTime.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ReverseTime_pwr");
+            //MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_ReverseTime.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ReverseTime_ver");
             //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             //pwrVal = pwr.level;
             //verVal = ver.level;
             //arcaneDmg = comp.arcaneDmg;
             //if (pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
-            //    MightPowerSkill mver = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
+            //    MightPowerSkill mpwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mver = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver");
             //    pwrVal = mpwr.level;
             //    verVal = mver.level;
             //}

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SeismicSlash.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SeismicSlash.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using RimWorld;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -82,7 +83,7 @@ namespace TorannMagic
 
         public static int GetWeaponDmg(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             verVal = TM_Calc.GetSkillVersatilityLevel(pawn, TorannMagicDefOf.TM_SeismicSlash, true);
             pwrVal = TM_Calc.GetSkillPowerLevel(pawn, TorannMagicDefOf.TM_SeismicSlash);
             //MightPowerSkill pwr = comp.MightData.MightPowerSkill_SeismicSlash.FirstOrDefault((MightPowerSkill x) => x.label == "TM_SeismicSlash_pwr");
@@ -108,7 +109,7 @@ namespace TorannMagic
 
         protected override bool TryCastShot()
         {
-            CompAbilityUserMight comp = this.CasterPawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = this.CasterPawn.GetCompAbilityUserMight();
             //MightPowerSkill ver = comp.MightData.MightPowerSkill_SeismicSlash.FirstOrDefault((MightPowerSkill x) => x.label == "TM_SeismicSlash_ver");
             pwrVal = TM_Calc.GetSkillPowerLevel(CasterPawn, this.Ability.Def as TMAbilityDef);
             CellRect cellRect = CellRect.CenteredOn(base.CasterPawn.Position, 1);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowCall.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowCall.cs
@@ -5,6 +5,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -16,7 +17,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool result = false;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             Pawn soulPawn = comp.soulBondPawn;
 
             if(soulPawn != null && !soulPawn.Dead && !soulPawn.Destroyed)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowSlayerCloak.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowSlayerCloak.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -21,7 +22,7 @@ namespace TorannMagic
             bool flag = caster != null && !caster.Dead;
             if (flag)
             {
-                CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                 //verVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_ShadowSlayer, "TM_ShadowSlayer", "_ver", true);
                 //pwrVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_ShadowSlayer, "TM_ShadowSlayer", "_pwr", true);
                 verVal = TM_Calc.GetSkillVersatilityLevel(caster, TorannMagicDefOf.TM_ShadowSlayer);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowStep.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowStep.cs
@@ -5,6 +5,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -14,7 +15,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool result = false;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             Pawn soulPawn = comp.soulBondPawn;
 
             if(soulPawn != null && !soulPawn.Dead && !soulPawn.Destroyed)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowWalk.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowWalk.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -55,7 +56,7 @@ namespace TorannMagic
                 Map map = this.CasterPawn.Map;
                 IntVec3 cell = this.CasterPawn.Position;
                 bool draftFlag = this.CasterPawn.Drafted;
-                CompAbilityUserMagic comp = p.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = p.GetCompAbilityUserMagic();
                 if (comp != null)
                 {
                     pwrVal = comp.MagicData.MagicPowerSkill_ShadowWalk.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_ShadowWalk_pwr").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Shapeshift.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Shapeshift.cs
@@ -5,6 +5,7 @@ using Verse.Sound;
 using AbilityUser;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -25,7 +26,7 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;
 
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             verVal = comp.MagicData.MagicPowerSkill_Shapeshift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Shapeshift_ver").level;
             pwrVal = comp.MagicData.MagicPowerSkill_Shapeshift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Shapeshift_pwr").level;
             effVal = comp.MagicData.MagicPowerSkill_Shapeshift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Shapeshift_eff").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShapeshiftDW.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShapeshiftDW.cs
@@ -5,6 +5,7 @@ using Verse.Sound;
 using AbilityUser;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -22,7 +23,7 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;
 
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             verVal = comp.MagicData.MagicPowerSkill_Shapeshift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Shapeshift_ver").level;
             pwrVal = comp.MagicData.MagicPowerSkill_Shapeshift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Shapeshift_pwr").level;
             effVal = comp.MagicData.MagicPowerSkill_Shapeshift.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Shapeshift_eff").level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShatterSentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShatterSentinel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if(comp.IsMagicUser)
             {
                 if(comp.summonedSentinels.Count > 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShieldOther.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShieldOther.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse;
 using Verse.Sound;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI.Group;
 
@@ -49,7 +50,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            comp = caster.GetComp<CompAbilityUserMagic>();
+            comp = caster.GetCompAbilityUserMagic();
 
 
             if (pawn != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SigilDrain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SigilDrain.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -13,7 +14,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool flag = false;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
 
             if (comp.IsMagicUser)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SigilSurge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SigilSurge.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 
 
@@ -13,7 +14,7 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool flag = false;
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
 
             if (comp.IsMagicUser)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SnapFreeze.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SnapFreeze.cs
@@ -4,6 +4,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 using Verse.Sound;
 
 namespace TorannMagic
@@ -44,7 +45,7 @@ namespace TorannMagic
             Map map = this.CasterPawn.Map;
             if (map != null)
             {
-                CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
                 pawns.Clear();
                 plants.Clear();
                 GenClamor.DoClamor(p, this.UseAbilityProps.TargetAoEProperties.range, ClamorDefOf.Ability);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SniperFocus.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SniperFocus.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -14,8 +15,8 @@ namespace TorannMagic
         {
             Map map = base.CasterPawn.Map;
             Pawn pawn = base.CasterPawn;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
-            MightPowerSkill pwr = pawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_SniperFocus.FirstOrDefault((MightPowerSkill x) => x.label == "TM_SniperFocus_pwr");
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
+            MightPowerSkill pwr = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_SniperFocus.FirstOrDefault((MightPowerSkill x) => x.label == "TM_SniperFocus_pwr");
 
             List<Trait> traits = this.CasterPawn.story.traits.allTraits;
             for (int i = 0; i < traits.Count; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SoL_CreateLight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SoL_CreateLight.cs
@@ -4,6 +4,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -39,7 +40,7 @@ namespace TorannMagic
 
             if (pawn != null && !pawn.Downed)
             {
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp != null && comp.SoL != null)
                 {
                     if (!comp.SoL.IsGlowing)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SoL_Equalize.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SoL_Equalize.cs
@@ -4,6 +4,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -16,7 +17,7 @@ namespace TorannMagic
             Map map = this.CasterPawn.Map;
             if (pawn != null && !pawn.Downed)
             {
-                CompAbilityUserMagic comp = pawn.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 Hediff hd = pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_LightCapacitanceHD);
                 if(comp != null && comp.SoL != null && hd != null)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SootheAnimal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SootheAnimal.cs
@@ -43,11 +43,11 @@ namespace TorannMagic
             this.TargetsAoE.Clear();
             //this.UpdateTargets();
             this.FindTargets();
-            //MagicPowerSkill pwr = base.CasterPawn.GetComp<CompAbilityUserMagic>().MagicData.MagicPowerSkill_SootheAnimal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SootheAnimal_pwr");
+            //MagicPowerSkill pwr = base.CasterPawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_SootheAnimal.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SootheAnimal_pwr");
             //pwrVal = pwr.level;
             //if (base.CasterPawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    MightPowerSkill mpwr = base.CasterPawn.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
+            //    MightPowerSkill mpwr = base.CasterPawn.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr");
             //    pwrVal = mpwr.level;
             //}
             pwrVal = TM_Calc.GetSkillPowerLevel(CasterPawn, this.Ability.Def as TMAbilityDef);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SoothingBalm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SoothingBalm.cs
@@ -5,6 +5,7 @@ using RimWorld;
 using AbilityUser;
 using Verse;
 using HarmonyLib;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic
@@ -40,7 +41,7 @@ namespace TorannMagic
 
             Pawn pawn = this.currentTarget.Thing as Pawn;
             Pawn caster = this.CasterPawn;
-            CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
 
             int verVal = TM_Calc.GetSkillVersatilityLevel(caster, TorannMagicDefOf.TM_SoothingBalm, false);
             int pwrVal = TM_Calc.GetSkillPowerLevel(caster, TorannMagicDefOf.TM_SoothingBalm, false);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SoulBond.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SoulBond.cs
@@ -3,6 +3,7 @@ using System;
 using Verse;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -48,7 +49,7 @@ namespace TorannMagic
             caster = base.CasterPawn;
             pawn = this.currentTarget.Thing as Pawn;
 
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             //MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_SoulBond.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SoulBond_pwr");
             //MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_SoulBond.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_SoulBond_ver");
             //verVal = ver.level;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SpellMending.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SpellMending.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 
 
@@ -44,7 +45,7 @@ namespace TorannMagic
 
             if (hitPawn != null & !hitPawn.Dead && !hitPawn.RaceProps.Animal)
             {
-                CompAbilityUserMagic compCaster = caster.TryGetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic compCaster = caster.GetCompAbilityUserMagic();
                 if (compCaster != null && compCaster.MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level >= 8)
                 {
                     HealthUtility.AdjustSeverity(hitPawn, HediffDef.Named("SpellMendingHD"), 1.95f);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Sprint.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Sprint.cs
@@ -19,11 +19,11 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            //MightPowerSkill pwr = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Sprint.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Sprint_pwr");
+            //MightPowerSkill pwr = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Sprint.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Sprint_pwr");
             //pwrVal = pwr.level;
             //if(pwrVal == 0)
             //{
-            //    pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_pwr").level;
+            //    pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_pwr").level;
             //}
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             bool flag = pawn != null && !pawn.Dead;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Stoneskin.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Stoneskin.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse;
 using Verse.Sound;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI.Group;
 
@@ -49,7 +50,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            comp = caster.GetComp<CompAbilityUserMagic>();
+            comp = caster.GetCompAbilityUserMagic();
             //MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_Stoneskin.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Stoneskin_pwr");
             //MagicPowerSkill ver = comp.MagicData.MagicPowerSkill_Stoneskin.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Stoneskin_ver");
             //pwrVal = pwr.level;
@@ -57,8 +58,8 @@ namespace TorannMagic
             //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             //if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
-            //    verVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
+            //    pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
+            //    verVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
             //}
             //if (settingsRef.AIHardMode && !caster.IsColonist)
             //{
@@ -76,7 +77,7 @@ namespace TorannMagic
                 List<Pawn> geomancers = enumerable.ToList();
                 for (int i = 0; i < geomancers.Count(); i++)
                 {
-                    CompAbilityUserMagic compGeo = geomancers[i].GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic compGeo = geomancers[i].GetCompAbilityUserMagic();
                     if(compGeo != null && compGeo.stoneskinPawns.Contains(pawn))
                     {
                         compGeo.stoneskinPawns.Remove(pawn);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_StrongBack.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_StrongBack.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -36,11 +37,11 @@ namespace TorannMagic
                 else
                 {
                     float val = .5f;
-                    if (caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 3)
+                    if (caster.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 3)
                     {
                         val = 1.5f;
                     }
-                    if (caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 8)
+                    if (caster.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 8)
                     {
                         val = 2.5f;
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonDemon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonDemon.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI;
 
@@ -14,7 +15,7 @@ namespace TorannMagic
             bool flag = false;
             Map map = base.CasterPawn.Map;
 
-            CompAbilityUserMagic comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             Pawn sacrificialPawn = comp.soulBondPawn;
 
             if (!sacrificialPawn.DestroyedOrNull() && sacrificialPawn.Spawned && !sacrificialPawn.Dead)
@@ -36,7 +37,7 @@ namespace TorannMagic
                             {
                                 if (allPawns[i].CurJobDef == TorannMagicDefOf.JobDriver_SummonDemon)
                                 {
-                                    CompAbilityUserMagic supportComp = allPawns[i].GetComp<CompAbilityUserMagic>();
+                                    CompAbilityUserMagic supportComp = allPawns[i].GetCompAbilityUserMagic();
                                     if (supportComp.soulBondPawn == sacrificialPawn)
                                     {
                                         this.TryLaunchProjectile(ThingDef.Named("Projectile_SummonDemon"), this.CasterPawn);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonGuardianSpirit.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonGuardianSpirit.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse.AI;
 using Verse;
 using UnityEngine;
@@ -49,7 +50,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Map map = caster.Map;
             IntVec3 cell = currentTarget.Cell;
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             //pwrVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_GuardianSpirit, "TM_GuardianSpirit", "_pwr", true);
             //verVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_GuardianSpirit, "TM_GuardianSpirit", "_ver", true);
             //effVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_GuardianSpirit, "TM_GuardianSpirit", "_eff", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonSpiritWolves.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonSpiritWolves.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse.AI;
 using Verse;
 using UnityEngine;
@@ -50,7 +51,7 @@ namespace TorannMagic
             Map map = caster.Map;
             cellList.Clear();
             List<IntVec3> tmpList = GenRadial.RadialCellsAround(currentTarget.Cell, this.Projectile.projectile.explosionRadius, true).ToList();
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             //pwrVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_SpiritWolves, "TM_SpiritWolves", "_pwr", true);
             //verVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_SpiritWolves, "TM_SpiritWolves", "_ver", true);
             //effVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_SpiritWolves, "TM_SpiritWolves", "_eff", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonTotemEarth.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonTotemEarth.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse.AI;
 using Verse;
 using UnityEngine;
@@ -49,7 +50,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Map map = caster.Map;
             IntVec3 cell = currentTarget.Cell;
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             //pwrVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_Totems, "TM_Totems", "_pwr", true);
             //verVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_Totems, "TM_Totems", "_ver", true);
             //effVal = TM_Calc.GetMagicSkillLevel(caster, comp.MagicData.MagicPowerSkill_Totems, "TM_Totems", "_eff", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonTotemHealing.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonTotemHealing.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse.AI;
 using Verse;
 using UnityEngine;
@@ -49,7 +50,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Map map = caster.Map;
             IntVec3 cell = currentTarget.Cell;
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, TorannMagicDefOf.TM_Totems);
             verVal = TM_Calc.GetSkillVersatilityLevel(caster, TorannMagicDefOf.TM_Totems);
             effVal = TM_Calc.GetSkillEfficiencyLevel(caster, TorannMagicDefOf.TM_Totems);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonTotemLightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SummonTotemLightning.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse.AI;
 using Verse;
 using UnityEngine;
@@ -49,7 +50,7 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Map map = caster.Map;
             IntVec3 cell = currentTarget.Cell;
-            CompAbilityUserMagic comp = caster.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, TorannMagicDefOf.TM_Totems);
             verVal = TM_Calc.GetSkillVersatilityLevel(caster, TorannMagicDefOf.TM_Totems);
             effVal = TM_Calc.GetSkillEfficiencyLevel(caster, TorannMagicDefOf.TM_Totems);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SuppressingFire.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SuppressingFire.cs
@@ -3,6 +3,7 @@ using AbilityUser;
 using UnityEngine;
 using System.Linq;
 using RimWorld;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -50,7 +51,7 @@ namespace TorannMagic
             float weaponDamage = pawn.equipment.Primary.def.Verbs.FirstOrDefault().defaultProjectile.projectile.GetDamageAmount(pawn.equipment.Primary, null);
             float burstShots = pawn.equipment.Primary.def.Verbs.FirstOrDefault().burstShotCount;
             int effVal = TM_Calc.GetSkillEfficiencyLevel(pawn, TorannMagicDefOf.TM_RifleSpec);
-            shots = Mathf.RoundToInt(((50f / weaponDamage) + (2 * burstShots)) * (1.2f + .15f * effVal) * pawn.GetComp<CompAbilityUserMight>().mightPwr);
+            shots = Mathf.RoundToInt(((50f / weaponDamage) + (2 * burstShots)) * (1.2f + .15f * effVal) * pawn.GetCompAbilityUserMight().mightPwr);
             return shots;
         }
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Symbiosis.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Symbiosis.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using Verse.AI;
 
@@ -42,7 +43,7 @@ namespace TorannMagic
             bool flag = false;
             Pawn caster = this.CasterPawn;
             Pawn hitPawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = caster.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
             if (comp != null && comp.MagicData != null)
             {
                 pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);                

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Taunt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Taunt.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 using Verse.Sound;
@@ -26,7 +27,7 @@ namespace TorannMagic
             if (flag)
             {
 
-                CompAbilityUserMight comp = caster.GetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                 //int verVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_Custom, "TM_Taunt", "_ver", true);
                 //int pwrVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_Custom, "TM_Taunt", "_pwr", true);
                 int verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_TechnoShield.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_TechnoShield.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Verse;
 using Verse.Sound;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 using Verse.AI.Group;
 
@@ -49,14 +50,14 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            comp = caster.GetComp<CompAbilityUserMagic>();
+            comp = caster.GetCompAbilityUserMagic();
             //pwrVal = comp.MagicData.MagicPowerSkill_TechnoShield.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoShield_pwr").level;
             //verVal = comp.MagicData.MagicPowerSkill_TechnoShield.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoShield_ver").level;
             //ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
             //if (caster.story.traits.HasTrait(TorannMagicDefOf.Faceless))
             //{
-            //    pwrVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
-            //    verVal = caster.GetComp<CompAbilityUserMight>().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
+            //    pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_pwr").level;
+            //    verVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_Mimic.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Mimic_ver").level;
             //}
             //if (settingsRef.AIHardMode && !caster.IsColonist)
             //{

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_TempestStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_TempestStrike.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System.Linq;
 using System;
 using RimWorld;
+using TorannMagic.Extensions;
 using Verse.Sound;
 
 namespace TorannMagic
@@ -43,7 +44,7 @@ namespace TorannMagic
             bool result = false;
             Pawn pawn = this.CasterPawn;
             Map map = this.CasterPawn.Map;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             if (comp != null && comp.Stamina != null)
             {
                 for (int i = 0; i < 8; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_TigerStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_TigerStrike.cs
@@ -5,6 +5,7 @@ using Verse;
 using UnityEngine;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -31,35 +32,40 @@ namespace TorannMagic
                     {
                         TM_Action.DamageEntities(target, null, 4, DamageDefOf.Stun, this.CasterPawn);
                     }
-                    if(verVal > 1 && Rand.Chance(.4f) && target is Pawn)
-                    {
-                        if(TM_Calc.IsMagicUser(target as Pawn))
-                        {
-                            CompAbilityUserMagic compMagic = target.TryGetComp<CompAbilityUserMagic>();
-                            float manaDrain = Mathf.Clamp(compMagic.Mana.CurLevel, 0, .25f);
-                            this.CasterPawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD).Severity += (manaDrain * 100);
-                            compMagic.Mana.CurLevel -= manaDrain;
 
-                        }
-                        else if(TM_Calc.IsMightUser(target as Pawn))
+                    Pawn targetPawn = target as Pawn;
+                    if (targetPawn != null)
+                    {
+                        if(verVal > 1 && Rand.Chance(.4f))
                         {
-                            CompAbilityUserMight compMight = target.TryGetComp<CompAbilityUserMight>();
-                            float staminaDrain = Mathf.Clamp(compMight.Stamina.CurLevel, 0, .25f);
-                            this.CasterPawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD).Severity += (staminaDrain * 100);
-                            compMight.Stamina.CurLevel -= staminaDrain;
+                            if(TM_Calc.IsMagicUser(targetPawn))
+                            {
+                                CompAbilityUserMagic compMagic = targetPawn.GetCompAbilityUserMagic();
+                                float manaDrain = Mathf.Clamp(compMagic.Mana.CurLevel, 0, .25f);
+                                this.CasterPawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD).Severity += (manaDrain * 100);
+                                compMagic.Mana.CurLevel -= manaDrain;
+
+                            }
+                            else if(TM_Calc.IsMightUser(targetPawn))
+                            {
+                                CompAbilityUserMight compMight = targetPawn.GetCompAbilityUserMight();
+                                float staminaDrain = Mathf.Clamp(compMight.Stamina.CurLevel, 0, .25f);
+                                this.CasterPawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_ChiHD).Severity += (staminaDrain * 100);
+                                compMight.Stamina.CurLevel -= staminaDrain;
+                            }
+                        }
+                        if(verVal > 2 && Rand.Chance(.1f))
+                        {
+                            IEnumerable<BodyPartRecord> rangeOfParts = (targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BloodPumpingSource).Concat(
+                                targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BloodFiltrationSource).Concat(
+                                    targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BreathingPathway).Concat(
+                                        targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.SightSource)))));
+
+                            hitPart = rangeOfParts.RandomElement();
+                            dmgNum = Mathf.RoundToInt(dmgNum * 1.4f);
                         }
                     }
-                    if(verVal > 2 && Rand.Chance(.1f) && target is Pawn)
-                    {
-                        Pawn targetPawn = target as Pawn;
-                        IEnumerable<BodyPartRecord> rangeOfParts = (targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BloodPumpingSource).Concat(
-                            targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BloodFiltrationSource).Concat(
-                                targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.BreathingPathway).Concat(
-                                    targetPawn.RaceProps.body.GetPartsWithTag(BodyPartTagDefOf.SightSource)))));
 
-                        hitPart = rangeOfParts.RandomElement();
-                        dmgNum = Mathf.RoundToInt(dmgNum * 1.4f);
-                    }
                     //DamageInfo dinfo2 = new DamageInfo(TMDamageDefOf.DamageDefOf.TM_TigerStrike, dmgNum, 0, (float)-1, this.CasterPawn, null, null, DamageInfo.SourceCategory.ThingOrUnknown);
                     TM_Action.DamageEntities(target, hitPart, dmgNum, dmgType, this.CasterPawn);
                     Vector3 strikeEndVec = this.currentTarget.CenterVector3;
@@ -70,9 +76,8 @@ namespace TorannMagic
                     strikeStartVec.x += Rand.Range(-.2f, .2f);
                     Vector3 angle = TM_Calc.GetVector(strikeStartVec, strikeEndVec);
                     TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_TigerStrike, strikeStartVec, this.CasterPawn.Map, .4f, .08f, .03f, .05f, 0, 8f, (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat(), (Quaternion.AngleAxis(90, Vector3.up) * angle).ToAngleFlat());
-                    if(!target.DestroyedOrNull() && target is Pawn)
+                    if(!target.DestroyedOrNull() && targetPawn != null)
                     {
-                        Pawn targetPawn = target as Pawn;
                         if(targetPawn.Downed || targetPawn.Dead)
                         {
                             continueAttack = false;
@@ -100,7 +105,7 @@ namespace TorannMagic
 
         public int GetAttackDmg(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
             //MightPowerSkill pwr = comp.MightData.MightPowerSkill_TigerStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_TigerStrike_pwr");
             //MightPowerSkill ver = comp.MightData.MightPowerSkill_TigerStrike.FirstOrDefault((MightPowerSkill x) => x.label == "TM_TigerStrike_ver");
             //verVal = TM_Calc.GetMightSkillLevel(pawn, comp.MightData.MightPowerSkill_TigerStrike, "TM_TigerStrike", "_ver", true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_TimeMark.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_TimeMark.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using System.Linq;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -20,7 +21,7 @@ namespace TorannMagic
         {
             bool result = false;
             map = this.CasterPawn.Map;
-            comp = this.CasterPawn.GetComp<CompAbilityUserMagic>();
+            comp = this.CasterPawn.GetCompAbilityUserMagic();
             MagicPowerSkill pwr = comp.MagicData.MagicPowerSkill_Recall.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Recall_pwr");
             pwrVal = pwr.level;
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ToggleHediff.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ToggleHediff.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -38,7 +39,7 @@ namespace TorannMagic
                         }
                     }
 
-                    CompAbilityUserMagic magicComp = caster.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic magicComp = caster.GetCompAbilityUserMagic();
                     if(magicComp != null && magicComp.MagicData != null)
                     {
                         MagicPower mp = magicComp.MagicData.ReturnMatchingMagicPower(ability);
@@ -47,7 +48,7 @@ namespace TorannMagic
                             mp.autocast = caster.health.hediffSet.HasHediff(hdDef);
                         }
                     }
-                    CompAbilityUserMight mightComp = caster.TryGetComp<CompAbilityUserMight>();
+                    CompAbilityUserMight mightComp = caster.GetCompAbilityUserMight();
                     if (mightComp != null && mightComp.MightData != null)
                     {
                         MightPower mp = mightComp.MightData.ReturnMatchingMightPower(ability);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Transpose.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Transpose.cs
@@ -4,6 +4,7 @@ using Verse;
 using AbilityUser;
 using UnityEngine;
 using System.Linq;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -91,7 +92,7 @@ namespace TorannMagic
                             {
                                 CameraJumper.TryJumpAndSelect(p);
                             }
-                            CompAbilityUserMight comp = this.CasterPawn.GetComp<CompAbilityUserMight>();
+                            CompAbilityUserMight comp = this.CasterPawn.GetCompAbilityUserMight();
                             MightPowerSkill ver = comp.MightData.MightPowerSkill_Transpose.FirstOrDefault((MightPowerSkill x) => x.label == "TM_Transpose_ver");
                             if (ver.level < 1)
                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_VeilOfShadows.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_VeilOfShadows.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -21,7 +22,7 @@ namespace TorannMagic
             bool flag = caster != null && !caster.Dead;
             if (flag)
             {
-                CompAbilityUserMight comp = caster.TryGetComp<CompAbilityUserMight>();
+                CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
                 //verVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_VeilOfShadows, "TM_VeilOfShadows", "_ver", true);
                 //pwrVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_VeilOfShadows, "TM_VeilOfShadows", "_pwr", true);
                 verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef);

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/CompBPReflector.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/CompBPReflector.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using TorannMagic.Extensions;
 using Verse;
 using UnityEngine;
 
@@ -8,7 +9,7 @@ namespace TorannMagic.Weapon
     {
         public override Verb ReflectionHandler(Verb newVerb)
         {
-            CompAbilityUserMagic holder = GetPawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic holder = GetPawn.GetCompAbilityUserMagic();
             bool canReflect = this.Props.canReflect && holder.IsMagicUser;
             Verb result;
             if (canReflect)
@@ -87,7 +88,7 @@ namespace TorannMagic.Weapon
                     }
                     float deflectionChance = this.DeflectionChance;
                     float meleeSkill = GetPawn.skills.GetSkill(this.Props.deflectSkill).Level;
-                    CompAbilityUserMagic holder = GetPawn.GetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic holder = GetPawn.GetCompAbilityUserMagic();
                     deflectionChance += (meleeSkill * this.Props.deflectRatePerSkillPoint);
                     if (holder != null && !holder.IsMagicUser && (this.parent.def.defName == "TM_DefenderStaff" || this.parent.def.defName == "TM_BlazingPowerStaff"))
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_BlazingPower.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_BlazingPower.cs
@@ -4,6 +4,7 @@ using Verse;
 using RimWorld;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic.Weapon
@@ -20,7 +21,7 @@ namespace TorannMagic.Weapon
             ThingDef def = this.def;
             if (pawn != null)
             {
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp != null && comp.IsMagicUser)
                 {
                     this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_FireWand.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_FireWand.cs
@@ -3,6 +3,7 @@ using Verse;
 using RimWorld;
 using AbilityUser;
 using System.Linq;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic.Weapon
@@ -16,7 +17,7 @@ namespace TorannMagic.Weapon
             Pawn pawn = this.launcher as Pawn;
             if (pawn != null)
             {
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp.IsMagicUser)
                 {
                     this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_IceWand.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_IceWand.cs
@@ -2,6 +2,7 @@
 using RimWorld;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 using UnityEngine;
 
 namespace TorannMagic.Weapon
@@ -18,7 +19,7 @@ namespace TorannMagic.Weapon
             Pawn pawn = this.launcher as Pawn;
             if (pawn != null)
             {
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp.IsMagicUser)
                 {
                     this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_LightningWand.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_LightningWand.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using RimWorld;
 using Verse;
 using AbilityUser;
+using TorannMagic.Extensions;
 using Verse.Sound;
 using UnityEngine;
 
@@ -20,7 +21,7 @@ namespace TorannMagic.Weapon
             Pawn pawn = this.launcher as Pawn;
             if (pawn != null)
             {
-                CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+                CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
                 if (comp.IsMagicUser)
                 {
                     this.arcaneDmg = comp.arcaneDmg;

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Verb_BlazingPower.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Verb_BlazingPower.cs
@@ -1,5 +1,6 @@
 ﻿using Verse;
 using RimWorld;
+using TorannMagic.Extensions;
 using TorannMagic.Golems;
 
 namespace TorannMagic.Weapon
@@ -8,7 +9,7 @@ namespace TorannMagic.Weapon
     {
         protected override bool TryCastShot()
         {
-            CompAbilityUserMagic comp = this.CasterPawn.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             if (comp != null && comp.IsMagicUser)
             {
                 return base.TryCastShot();

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Verb_FreezingWinds.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Verb_FreezingWinds.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
 using System;
+using TorannMagic.Extensions;
 
 namespace TorannMagic.Weapon
 {
@@ -41,7 +42,7 @@ namespace TorannMagic.Weapon
 
         protected override bool TryCastShot()
         {
-            CompAbilityUserMagic comp = this.CasterPawn.TryGetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = this.CasterPawn.GetCompAbilityUserMagic();
             if(comp != null && comp.IsMagicUser)
             {
                 LocalTargetInfo t = this.CurrentTarget;

--- a/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_ChargeArcaneObject.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_ChargeArcaneObject.cs
@@ -4,6 +4,7 @@ using Verse.AI;
 using RimWorld;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -36,7 +37,7 @@ namespace TorannMagic
             Building_TMPortal portal = t as Building_TMPortal;
             Building_TMArcaneCapacitor arcaneCapacitor = t as Building_TMArcaneCapacitor;
             Building_TM_DMP dmp = t as Building_TM_DMP;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if (comp != null && portal != null && comp.IsMagicUser && comp.Mana.CurLevelPercentage >= .7f && portal.IsPaired && portal.ArcaneEnergyCur < .7f)
             {
                 if (pawn != null && pawn.RaceProps.Humanlike && pawn.workSettings.WorkIsActive(TorannMagicDefOf.TM_Magic) && pawn.health.capacities.GetLevel(TorannMagicDefOf.MagicManipulation) > 0 && pawn.IsColonist && pawn.Awake() && !pawn.Drafted && !pawn.Downed && pawn.CanReserveAndReach(portal, PathEndMode.InteractionCell, Danger.Some))

--- a/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoCommanderMotivate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoCommanderMotivate.cs
@@ -3,6 +3,7 @@ using Verse;
 using Verse.AI;
 using RimWorld;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -33,7 +34,7 @@ namespace TorannMagic
         public override bool HasJobOnThing(Pawn pawn, Thing t, bool forced = false)
         {
             Pawn pawn2 = t as Pawn;
-            CompAbilityUserMight comp = pawn.GetComp<CompAbilityUserMight>();           
+            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();           
             if (pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_CommanderAuraHD, false))
             {
                 HediffComp_CommanderAura hdComp = pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_CommanderAuraHD).TryGetComp<HediffComp_CommanderAura>();
@@ -60,7 +61,7 @@ namespace TorannMagic
         public override Job JobOnThing(Pawn pawn, Thing t, bool forced = false)
         {
             //Pawn pawn2 = t as Pawn;
-            //CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            //CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             //if(comp.nextEntertainTick >= Find.TickManager.TicksGame)
             //{
             //    return null;

--- a/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoEntertain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoEntertain.cs
@@ -3,6 +3,7 @@ using Verse;
 using Verse.AI;
 using RimWorld;
 using System.Collections.Generic;
+using TorannMagic.Extensions;
 
 
 namespace TorannMagic
@@ -33,7 +34,7 @@ namespace TorannMagic
         public override bool HasJobOnThing(Pawn pawn, Thing t, bool forced = false)
         {
             Pawn pawn2 = t as Pawn;
-            CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if (pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_EntertainingHD"), false) && comp.nextEntertainTick < Find.TickManager.TicksGame)
             {
                 if (pawn2 != null && pawn2 != pawn && pawn2.RaceProps.Humanlike && pawn2.IsColonist && pawn2.Awake() && !pawn2.Drafted && !pawn.Drafted && !pawn2.Downed && pawn2.CanCasuallyInteractNow())
@@ -114,7 +115,7 @@ namespace TorannMagic
         public override Job JobOnThing(Pawn pawn, Thing t, bool forced = false)
         {
             //Pawn pawn2 = t as Pawn;
-            //CompAbilityUserMagic comp = pawn.GetComp<CompAbilityUserMagic>();
+            //CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             //if(comp.nextEntertainTick >= Find.TickManager.TicksGame)
             //{
             //    return null;

--- a/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoMagicBill.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoMagicBill.cs
@@ -7,6 +7,7 @@ using Verse.AI;
 using RimWorld;
 using UnityEngine;
 using HarmonyLib;
+using TorannMagic.Extensions;
 
 namespace TorannMagic
 {
@@ -154,7 +155,7 @@ namespace TorannMagic
                         }
                         return RefuelWorkGiverUtility.RefuelJob(pawn, thing, forced);
                     }
-                    CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>();
+                    CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic();
                     if (compMagic != null && compMagic.Mana != null)
                     {
                         if (thing is Building_TMMagicCircle)
@@ -250,7 +251,7 @@ namespace TorannMagic
                         if (bill.recipe is MagicRecipeDef)
                         {
                             MagicRecipeDef magicRecipe = bill.recipe as MagicRecipeDef;
-                            CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>(); 
+                            CompAbilityUserMagic compMagic = pawn.GetCompAbilityUserMagic(); 
                             if(magicCircle.IsActive)
                             {
                                 issueBill = false;


### PR DESCRIPTION
…also provides faster GetComp<CompAbilityUserMagic> and GetComp<CompAbilityUserMight> since those are used so much. Has new function for death knights which returns hediff instead of bool for hate.

Note that there is a lot of removal of fault null checking (foo?.bar is still a null exception if foo is null. foo.FirstOrDefault().bar is also still a null exception if foo.FirstOrDefault() is default aka null.)
