### PR TITLE
Clean rendering code specifically around DrawMark

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -17,12 +17,9 @@ namespace TorannMagic
     [CompilerGenerated]
     [Serializable]
     [StaticConstructorOnStartup]
-    public class CompAbilityUserMagic : CompAbilityUser
+    public class CompAbilityUserMagic : CompAbilityUserMagicMightBase
     {
         public string LabelKey = "TM_Magic";
-
-        public int customIndex = -2;
-        public TMDefs.TM_CustomClass customClass = null;
 
         public bool firstTick = false;
         public bool magicPowersInitialized = false;
@@ -33,13 +30,8 @@ namespace TorannMagic
         private int damageMitigationDelayMS = 0;
         public int magicXPRate = 1000;
         public int lastXPGain = 0;
-        private int age = -1;
         private bool doOnce = true;
-        private int autocastTick = 0;
-        private int nextAICastAttemptTick = 0;
-        public bool canDeathRetaliate = false;
-        private bool deathRetaliating = false;
-        private int ticksTillRetaliation = 600;
+
         private List<IntVec3> deathRing = new List<IntVec3>();
         public float weaponDamage = 1;
         public float weaponCritChance = 0f;
@@ -198,12 +190,8 @@ namespace TorannMagic
 
         public float maxMP = 1;
         public float mpRegenRate = 1;
-        public float coolDown = 1;
         public float mpCost = 1;
-        public float xpGain = 1;
         public float arcaneDmg = 1;
-        public float arcaneRes = 1;
-        public float arcalleumCooldown = 0f;
 
         public List<TM_ChaosPowers> chaosPowers = new List<TM_ChaosPowers>();
         public TMAbilityDef mimicAbility = null;
@@ -533,14 +521,14 @@ namespace TorannMagic
                 {
                     if (!this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                     {
-                        DrawMageMark();
+                        DrawMark();
                     }
                 }
                 if (settingsRef.AIMarking && !base.Pawn.IsColonist && this.IsMagicUser)
                 {
                     if (!this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless))
                     {
-                        DrawMageMark();
+                        DrawMark();
                     }
                 }
 
@@ -612,14 +600,13 @@ namespace TorannMagic
         {
             if (!mageLightSet)
             {
-                float num = Mathf.Lerp(1.2f, 1.55f, 1f);
                 Vector3 lightPos = Vector3.zero;
 
                 lightPos = this.Pawn.Drawer.DrawPos;
                 lightPos.x -= .5f;
                 lightPos.z += .6f;
 
-                lightPos.y = Altitudes.AltitudeFor(AltitudeLayer.MoteOverhead);
+                lightPos.y = AltitudeLayer.MoteOverhead.AltitudeFor();
                 float angle = Rand.Range(0, 360);
                 Vector3 s = new Vector3(.27f, .5f, .27f);
                 Matrix4x4 matrix = default(Matrix4x4);
@@ -629,129 +616,9 @@ namespace TorannMagic
 
         }
 
-        public void DrawMageMark()
-        {
-            float num = Mathf.Lerp(1.2f, 1.55f, 1f);
-            Vector3 vector = this.Pawn.Drawer.DrawPos;
-            vector.x = vector.x + .45f;
-            vector.z = vector.z + .45f;
-            vector.y = Altitudes.AltitudeFor(AltitudeLayer.MoteOverhead);
-            float angle = 0f;
-            Vector3 s = new Vector3(.28f, 1f, .28f);
-            Matrix4x4 matrix = default(Matrix4x4);
-            matrix.SetTRS(vector, Quaternion.AngleAxis(angle, Vector3.up), s);
-            if (this.customClass != null)
-            {
-                Material mat = TM_RenderQueue.mageMarkMat;
-                if (this.customClass.classIconPath != "")
-                {
-                    mat = MaterialPool.MatFrom("Other/" + this.customClass.classIconPath.ToString());
-                }
-                else if(this.customClass.classTexturePath != "")
-                {
-                    mat = MaterialPool.MatFrom("Other/ClassTextures/" + this.customClass.classTexturePath, true);
-                }
-                if (this.customClass.classIconColor != null)
-                {
-                    mat.color = this.customClass.classIconColor;
-                }
-                Graphics.DrawMesh(MeshPool.plane10, matrix, mat, 0);
-            }
-            else
-            {
-                if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.InnerFire))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.fireMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.HeartOfFrost))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.iceMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.StormBorn))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.lightningMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Arcanist))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.arcanistMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Paladin))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.paladinMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Summoner))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.summonerMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Druid))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.druidMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Necromancer) || this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Lich))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.necroMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Priest))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.priestMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Bard))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.bardMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Succubus) || this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Warlock))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.demonkinMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Geomancer))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.earthMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Technomancer))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.technoMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.BloodMage))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.bloodmageMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Enchanter))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.enchanterMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Chronomancer))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.chronomancerMarkMat, 0);
-                }
-                else if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.ChaosMage))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.chaosMarkMat, 0);
-                }
-                else if (TM_Calc.IsWanderer(this.Pawn))
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.wandererMarkMat, 0);
-                }
-                else
-                {
-                    Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.mageMarkMat, 0);
-                }
-            }
-
-        }
-
         public void DrawEnchantMark()
         {
-            float num = Mathf.Lerp(1.2f, 1.55f, 1f);
-            Vector3 vector = this.Pawn.Drawer.DrawPos;
-            vector.x = vector.x + .45f;
-            vector.z = vector.z + .45f;
-            vector.y = Altitudes.AltitudeFor(AltitudeLayer.MoteOverhead);
-            float angle = 0f;
-            Vector3 s = new Vector3(.5f, 1f, .5f);
-            Matrix4x4 matrix = default(Matrix4x4);
-            matrix.SetTRS(vector, Quaternion.AngleAxis(angle, Vector3.up), s);
-            Graphics.DrawMesh(MeshPool.plane10, matrix, TM_RenderQueue.enchantMark, 0);
-
+            DrawMark(TM_RenderQueue.enchantMark, new Vector3(.5f, 1f, .5f));
         }
 
         public void DrawScornWings()
@@ -761,10 +628,10 @@ namespace TorannMagic
             {
                 float num = Mathf.Lerp(1.2f, 1.55f, 1f);
                 Vector3 vector = this.Pawn.Drawer.DrawPos;
-                vector.y = Altitudes.AltitudeFor(AltitudeLayer.Pawn);
+                vector.y = AltitudeLayer.Pawn.AltitudeFor();
                 if (this.Pawn.Rotation == Rot4.North)
                 {
-                    vector.y = Altitudes.AltitudeFor(AltitudeLayer.PawnState);
+                    vector.y = AltitudeLayer.PawnState.AltitudeFor();
                 }
                 float angle = (float)Rand.Range(0, 360);
                 Vector3 s = new Vector3(3f, 3f, 3f);
@@ -789,1082 +656,500 @@ namespace TorannMagic
 
         public int LevelUpSkill_global_regen(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_global_regen.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_global_regen.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_global_eff(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_global_eff.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_global_eff.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_global_spirit(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_global_spirit.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = MagicData.MagicPowerSkill_global_spirit.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_RayofHope(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_RayofHope.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_RayofHope.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Firebolt(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Firebolt.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Firebolt.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Fireball(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Fireball.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Fireball.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Fireclaw(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Fireclaw.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Fireclaw.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Firestorm(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Firestorm.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Firestorm.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_Soothe(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Soothe.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Soothe.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Icebolt(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Icebolt.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Icebolt.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_FrostRay(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_FrostRay.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_FrostRay.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Snowball(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Snowball.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Snowball.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Rainmaker(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Rainmaker.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Rainmaker.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Blizzard(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Blizzard.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Blizzard.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_AMP(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_AMP.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_AMP.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_LightningBolt(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_LightningBolt.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_LightningBolt.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_LightningCloud(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_LightningCloud.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_LightningCloud.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_LightningStorm(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_LightningStorm.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_LightningStorm.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_EyeOfTheStorm(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EyeOfTheStorm.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_Shadow(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Shadow.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Shadow.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_MagicMissile(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_MagicMissile.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_MagicMissile.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Blink(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Blink.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Blink.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Summon(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Summon.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Summon.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Teleport(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Teleport.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Teleport.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_FoldReality(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_FoldReality.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_FoldReality.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_Heal(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Heal.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Heal.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Shield(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Shield.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Shield.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_ValiantCharge(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ValiantCharge.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Overwhelm(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Overwhelm.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Overwhelm.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_HolyWrath(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_HolyWrath.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_HolyWrath.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_SummonMinion(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonMinion.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonMinion.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_SummonPylon(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonPylon.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonPylon.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_SummonExplosive(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonExplosive.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonExplosive.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_SummonElemental(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonElemental.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonElemental.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_SummonPoppi(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonPoppi.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SummonPoppi.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_Poison(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Poison.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Poison.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_SootheAnimal(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SootheAnimal.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SootheAnimal.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Regenerate(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Regenerate.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Regenerate.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_CureDisease(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_CureDisease.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_CureDisease.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_RegrowLimb(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_RegrowLimb.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_RegrowLimb.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_RaiseUndead(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_RaiseUndead.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_RaiseUndead.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_DeathMark(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_DeathMark.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_DeathMark.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_FogOfTorment(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_FogOfTorment.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_FogOfTorment.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_ConsumeCorpse(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ConsumeCorpse.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ConsumeCorpse.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_CorpseExplosion(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_CorpseExplosion.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_CorpseExplosion.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_DeathBolt(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_DeathBolt.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_DeathBolt.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_AdvancedHeal(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_AdvancedHeal.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Purify(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Purify.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Purify.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_HealingCircle(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_HealingCircle.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_HealingCircle.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_BestowMight(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BestowMight.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BestowMight.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Resurrection(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Resurrection.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Resurrection.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_BardTraining(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BardTraining.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BardTraining.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Entertain(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Entertain.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Entertain.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Inspire(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Inspire.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Inspire.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Lullaby(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Lullaby.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Lullaby.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_BattleHymn(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BattleHymn.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BattleHymn.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_SoulBond(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SoulBond.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_SoulBond.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_ShadowBolt(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ShadowBolt.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ShadowBolt.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Dominate(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Dominate.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Dominate.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Attraction(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Attraction.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Attraction.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Repulsion(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Repulsion.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Repulsion.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Scorn(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Scorn.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Scorn.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_PsychicShock(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_PsychicShock.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_PsychicShock.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         public int LevelUpSkill_Stoneskin(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Stoneskin.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Stoneskin.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Encase(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Encase.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Encase.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_EarthSprites(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EarthSprites.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EarthSprites.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_EarthernHammer(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EarthernHammer.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EarthernHammer.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Meteor(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Meteor.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Meteor.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Sentinel(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Sentinel.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Sentinel.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_TechnoBit(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_TechnoBit.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_TechnoBit.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_TechnoTurret(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_TechnoTurret.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_TechnoWeapon(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_TechnoWeapon.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_TechnoWeapon.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_TechnoShield(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_TechnoShield.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_TechnoShield.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Sabotage(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Sabotage.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Sabotage.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Overdrive(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Overdrive.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Overdrive.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_OrbitalStrike(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_OrbitalStrike.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_OrbitalStrike.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_BloodGift(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BloodGift.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BloodGift.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_IgniteBlood(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_IgniteBlood.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_IgniteBlood.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_BloodForBlood(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BloodForBlood.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BloodForBlood.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_BloodShield(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BloodShield.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BloodShield.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Rend(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Rend.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Rend.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_BloodMoon(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BloodMoon.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_BloodMoon.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_EnchantedBody(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EnchantedBody.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EnchantedBody.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Transmutate(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Transmutate.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Transmutate.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_EnchanterStone(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EnchanterStone.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EnchanterStone.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_EnchantWeapon(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EnchantWeapon.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_EnchantWeapon.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Polymorph(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Polymorph.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Polymorph.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Shapeshift(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Shapeshift.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Shapeshift.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Prediction(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Prediction.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Prediction.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_AlterFate(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_AlterFate.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_AlterFate.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_AccelerateTime(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_AccelerateTime.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_AccelerateTime.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_ReverseTime(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ReverseTime.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ReverseTime.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_ChronostaticField(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ChronostaticField.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ChronostaticField.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Recall(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Recall.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Recall.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_ChaosTradition(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ChaosTradition.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_ChaosTradition.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_WandererCraft(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_WandererCraft.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_WandererCraft.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
         public int LevelUpSkill_Cantrips(string skillName)
         {
-            int result = 0;
-            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == skillName);
-            bool flag = magicPowerSkill != null;
-            if (flag)
-            {
-                result = magicPowerSkill.level;
-            }
-            return result;
+            MagicPowerSkill magicPowerSkill = this.MagicData.MagicPowerSkill_Cantrips.FirstOrDefault(skill => skill.label == skillName);
+            return magicPowerSkill?.level ?? 0;
         }
 
         private void SingleEvent()
@@ -2205,50 +1490,41 @@ namespace TorannMagic
         {
             get
             {
-                bool flag = base.Pawn != null;
-                bool result;
-                if (flag)
+                if (Pawn?.story == null) return false;
+                if (this.customClass != null) return true;
+
+                if (this.customClass == null && this.customIndex == -2)
                 {
-                    bool flag3 = base.Pawn.story != null;
-                    if (flag3)
+                    this.customIndex = TM_ClassUtility.IsCustomClassIndex(this.Pawn.story.traits.allTraits);
+                    if (this.customIndex >= 0)
                     {
-                        if (this.customClass != null)
+                        if (!TM_ClassUtility.CustomClasses()[this.customIndex].isMage)
                         {
-                            return true;
+                            this.customIndex = -1;
+                            return false;
                         }
-                        if (this.customClass == null && this.customIndex == -2)
+                        else
                         {
-                            this.customIndex = TM_ClassUtility.IsCustomClassIndex(this.Pawn.story.traits.allTraits);
-                            if (this.customIndex >= 0)
-                            {
-                                if (!TM_ClassUtility.CustomClasses()[this.customIndex].isMage)
-                                {
-                                    this.customIndex = -1;
-                                    return false;
-                                }
-                                else
-                                {
-                                    this.customClass = TM_ClassUtility.CustomClasses()[this.customIndex];
-                                    return true;
-                                }
-                            }
-                        }
-                        bool flag4 = base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Enchanter) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.BloodMage) ||
-                            base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Technomancer) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Geomancer) ||
-                            base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Warlock) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Succubus) ||
-                            base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.InnerFire) ||
-                            base.Pawn.story.traits.HasTrait(TorannMagicDefOf.HeartOfFrost) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.StormBorn) ||
-                            base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Arcanist) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Paladin) ||
-                            base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Summoner) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Druid) ||
-                            (base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Necromancer) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Lich)) ||
-                            base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Priest) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Bard) ||
-                            base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Chronomancer) || TM_Calc.IsWanderer(base.Pawn) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.ChaosMage);
-                        if (flag4)
-                        {
+                            this.customClass = TM_ClassUtility.CustomClasses()[this.customIndex];
                             return true;
                         }
                     }
                 }
+                bool flag4 = base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Enchanter) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.BloodMage) ||
+                    base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Technomancer) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Geomancer) ||
+                    base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Warlock) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Succubus) ||
+                    base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.InnerFire) ||
+                    base.Pawn.story.traits.HasTrait(TorannMagicDefOf.HeartOfFrost) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.StormBorn) ||
+                    base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Arcanist) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Paladin) ||
+                    base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Summoner) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Druid) ||
+                    (base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Necromancer) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Lich)) ||
+                    base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Priest) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Bard) ||
+                    base.Pawn.story.traits.HasTrait(TorannMagicDefOf.Chronomancer) || TM_Calc.IsWanderer(base.Pawn) || base.Pawn.story.traits.HasTrait(TorannMagicDefOf.ChaosMage);
+                if (flag4)
+                {
+                    return true;
+                }
+
                 return false;
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagicMightBase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagicMightBase.cs
@@ -27,7 +27,7 @@ namespace TorannMagic
         public float coolDown = 1;
         public float xpGain = 1;
 
-        private static readonly SimpleCache<int, Material> traitCache = new SimpleCache<int, Material>(5);
+        private static readonly SimpleCache<string, Material> traitCache = new SimpleCache<string, Material>(5);
 
         protected void DrawMark(Material material, Vector3 scale)
         {
@@ -46,7 +46,7 @@ namespace TorannMagic
         // Scan for a trait and draw mark if there is one that applies. If you know the trait, use the specific DrawMark above
         protected void DrawMark()
         {
-            Material material = traitCache.GetOrCreate(Pawn.thingIDNumber, () =>
+            Material material = traitCache.GetOrCreate(Pawn.ThingID, () =>
             {
                 Trait markTrait =
                     Pawn.story.traits.allTraits.FirstOrDefault(trait => TraitIconMap.ContainsKey(trait.def));

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagicMightBase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagicMightBase.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using AbilityUser;
+using RimWorld;
+using TorannMagic.Utils;
+using UnityEngine;
+using Verse;
+
+namespace TorannMagic
+{
+    public abstract class CompAbilityUserMagicMightBase : CompAbilityUser
+    {
+        public int customIndex = -2;
+
+        public TMDefs.TM_CustomClass customClass = null;
+
+        protected int age = -1;
+
+        protected int autocastTick = 0;
+        protected int nextAICastAttemptTick = 0;
+
+        public bool canDeathRetaliate = false;
+        protected bool deathRetaliating = false;
+        protected int ticksTillRetaliation = 600;
+
+        public float arcalleumCooldown = 0f;
+        public float arcaneRes = 1;
+        public float coolDown = 1;
+        public float xpGain = 1;
+
+        private static readonly SimpleCache<int, Material> traitCache = new SimpleCache<int, Material>(5);
+
+        protected void DrawMark(Material material, Vector3 scale)
+        {
+            Vector3 vector = Pawn.Drawer.DrawPos;
+            vector.x += .45f;
+            vector.z += .45f;
+            vector.y = AltitudeLayer.MoteOverhead.AltitudeFor();
+            const float angle = 0f;
+
+            Matrix4x4 matrix = default(Matrix4x4);
+            matrix.SetTRS(vector, Quaternion.AngleAxis(angle, Vector3.up), scale);
+
+            Graphics.DrawMesh(MeshPool.plane10, matrix, material, 0);
+        }
+
+        // Scan for a trait and draw mark if there is one that applies. If you know the trait, use the specific DrawMark above
+        protected void DrawMark()
+        {
+            Material material = traitCache.GetOrCreate(Pawn.thingIDNumber, () =>
+            {
+                Trait markTrait =
+                    Pawn.story.traits.allTraits.FirstOrDefault(trait => TraitIconMap.ContainsKey(trait.def));
+                return markTrait != null ? TraitIconMap.Get(markTrait.def).IconMaterial : null;
+            }, 5);
+
+            if(material != null)
+                DrawMark(material, new Vector3(.28f, 1f, .28f));
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagicMightBase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagicMightBase.cs
@@ -27,7 +27,7 @@ namespace TorannMagic
         public float coolDown = 1;
         public float xpGain = 1;
 
-        private static readonly SimpleCache<string, Material> traitCache = new SimpleCache<string, Material>(5);
+        private static readonly SimpleCache<int, Material> traitCache = new SimpleCache<int, Material>(5);
 
         protected void DrawMark(Material material, Vector3 scale)
         {
@@ -46,7 +46,7 @@ namespace TorannMagic
         // Scan for a trait and draw mark if there is one that applies. If you know the trait, use the specific DrawMark above
         protected void DrawMark()
         {
-            Material material = traitCache.GetOrCreate(Pawn.ThingID, () =>
+            Material material = traitCache.GetOrCreate(Pawn.thingIDNumber, () =>
             {
                 Trait markTrait =
                     Pawn.story.traits.allTraits.FirstOrDefault(trait => TraitIconMap.ContainsKey(trait.def));

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6413,29 +6413,6 @@ namespace TorannMagic
                         // Early exit condition
                         if (!settingsRef.showClassIconOnColonistBar || colonist.story == null) return null;
                         
-                        // Check custom classes
-                        CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
-                        if (compMagic != null && compMagic.customClass != null)
-                        {
-                            Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
-                            if (compMagic.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMagic.customClass.classTexturePath, true);
-                            }
-
-                            return new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom");
-                        }
-                        CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
-                        if (compMight != null && compMight.customClass != null)
-                        {
-                            Texture2D customIcon = TM_MatPool.DefaultCustomFighterIcon;
-                            if (compMight.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMight.customClass.classTexturePath, true);
-                            }
-                            
-                            return new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom");
-                        }
                         for (int i = 0; i < colonist.story.traits.allTraits.Count; i++)
                         {
                             TraitDef trait = colonist.story.traits.allTraits[i].def;

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6398,7 +6398,7 @@ namespace TorannMagic
                 if (colonist.Dead) return;
 
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                if (colonist.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
+                if (colonist.health.hediffSet.HasHediff(TorannMagicDefOf.TM_UndeadHD))
                 {
                     float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
                     Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6391,8 +6391,8 @@ namespace TorannMagic
             }
         }
 
-        private static readonly SimpleCache<int, TraitIconMap.TraitIconValue> ColonistBarColonistDrawerCache = 
-            new SimpleCache<int, TraitIconMap.TraitIconValue>(5);
+        private static readonly SimpleCache<string, TraitIconMap.TraitIconValue> ColonistBarColonistDrawerCache =
+            new SimpleCache<string, TraitIconMap.TraitIconValue>(5);
 
         [HarmonyPatch(typeof(ColonistBarColonistDrawer), "DrawIcons", null)]
         public class ColonistBarColonistDrawer_Patch
@@ -6403,7 +6403,7 @@ namespace TorannMagic
 
                 ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
                 var traitIconValue = ColonistBarColonistDrawerCache.GetOrCreate(
-                    colonist.thingIDNumber,
+                    colonist.ThingID,
                     () =>
                     {
                         if (colonist.health.hediffSet.HasHediff(TorannMagicDefOf.TM_UndeadHD))

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6395,231 +6395,65 @@ namespace TorannMagic
         {
             public static void Postfix(ColonistBarColonistDrawer __instance, ref Rect rect, Pawn colonist)
             {
-                if (!colonist.Dead)
+                if (colonist.Dead) return;
+
+                ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
+                if (colonist.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
                 {
-                    ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                    if (colonist.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")))
+                    float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
+                    Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
+                    rect = new Rect(vector.x, vector.y, num, num);
+                    GUI.DrawTexture(rect, TM_MatPool.Icon_Undead);
+                    TooltipHandler.TipRegion(rect, "TM_Icon_Undead".Translate());
+                    vector.x += num;
+                }
+                else if (settingsRef.showClassIconOnColonistBar && colonist.story != null)
+                {
+                    // Create the shapes for the icon
+                    float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
+                    Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
+                    rect = new Rect(vector.x, vector.y, num, num);
+                    // Check for custom classes
+                    CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
+                    if (compMagic != null && compMagic.customClass != null)
                     {
-                        float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
-                        Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
-                        rect = new Rect(vector.x, vector.y, num, num);
-                        GUI.DrawTexture(rect, TM_MatPool.Icon_Undead);
-                        TooltipHandler.TipRegion(rect, "TM_Icon_Undead".Translate());
+                        Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
+                        if (compMagic.customClass.classTexturePath != "")
+                        {
+                            customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMagic.customClass.classTexturePath, true);
+                        }
+                        GUI.DrawTexture(rect, customIcon);
+                        TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
                         vector.x += num;
-                        //rect = new Rect(vector.x, vector.y, num, num);
+                        return;
                     }
-                    else if (settingsRef.showClassIconOnColonistBar && colonist.story != null)
+                    CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
+                    if (compMight != null && compMight.customClass != null)
                     {
-                        float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
-                        Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
-                        rect = new Rect(vector.x, vector.y, num, num);
-                        CompAbilityUserMight compMight = colonist.TryGetComp<CompAbilityUserMight>();
-                        CompAbilityUserMagic compMagic = colonist.TryGetComp<CompAbilityUserMagic>();
-                        if (compMagic != null && compMagic.customClass != null)
+                        Texture2D customIcon = TM_MatPool.DefaultCustomFighterIcon;
+                        if (compMight.customClass.classTexturePath != "")
                         {
-                            Texture2D customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomMageMark", true);
-                            if (compMagic.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMagic.customClass.classTexturePath, true);
-                            }
-                            GUI.DrawTexture(rect, customIcon);
-                            TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
-                            vector.x += num;
+                            customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMight.customClass.classTexturePath, true);
                         }
-                        else if (compMight != null && compMight.customClass != null)
+                        GUI.DrawTexture(rect, customIcon);
+                        TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
+                        vector.x += num;
+                    }
+                    // Otherwise use dictionary TraitIconMapping to apply the material and shape
+                    else
+                    {
+                        for (int i = 0; i < colonist.story.traits.allTraits.Count; i++)
                         {
-                            Texture2D customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomFighterMark", true);
-                            if (compMight.customClass.classTexturePath != "")
-                            {
-                                customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + compMight.customClass.classTexturePath, true);
-                            }
-                            GUI.DrawTexture(rect, customIcon);
-                            TooltipHandler.TipRegion(rect, "TM_Icon_Custom".Translate());
-                            vector.x += num;
+                            TraitDef trait = colonist.story.traits.allTraits[i].def;
+                            if (!TraitIconMap.ContainsKey(trait)) continue;
 
+                            GUI.DrawTexture(rect, TraitIconMap.Get(trait).IconMaterial);
+                            TooltipHandler.TipRegion(rect, TraitIconMap.Get(trait).IconType.Translate());
+                            vector.x += num;
+                            return;
                         }
-                        else
-                        {
-
-                            if (colonist.story.traits.HasTrait(TorannMagicDefOf.InnerFire))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.fireIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.HeartOfFrost))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.iceIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.StormBorn))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.lightningIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Arcanist))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.arcanistIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Paladin))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.paladinIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Summoner))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.summonerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Druid))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.druidIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Necromancer) || colonist.story.traits.HasTrait(TorannMagicDefOf.Lich))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.necroIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Priest))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.priestIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Bard))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.bardIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Succubus) || colonist.story.traits.HasTrait(TorannMagicDefOf.Warlock))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.demonkinIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Geomancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.earthIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Technomancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.technoIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.BloodMage))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.bloodmageIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Enchanter))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.enchanterIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Chronomancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.chronoIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Gladiator))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.gladiatorIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Sniper))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.sniperIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Bladedancer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.bladedancerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Ranger))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.rangerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.Faceless))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.facelessIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Psionic))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.psiIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.DeathKnight))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.deathknightIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Monk))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.monkIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.wandererIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.wayfarerIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.ChaosMage))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.chaosIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Mage".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_Commander))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.commanderIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                            else if (colonist.story.traits.HasTrait(TorannMagicDefOf.TM_SuperSoldier))
-                            {
-                                GUI.DrawTexture(rect, TM_MatPool.SSIcon);
-                                TooltipHandler.TipRegion(rect, "TM_Icon_Fighter".Translate());
-                                vector.x += num;
-                            }
-                        }
-                        //rect = new Rect(vector.x, vector.y, num, num);
                     }
                 }
-                //return true;
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -18,6 +18,7 @@ using TorannMagic.TMDefs;
 using TorannMagic.Golems;
 using RimWorld.QuestGen;
 using System.Diagnostics;
+using TorannMagic.Utils;
 
 namespace TorannMagic
 {

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -6408,7 +6408,7 @@ namespace TorannMagic
                     {
                         if (colonist.health.hediffSet.HasHediff(TorannMagicDefOf.TM_UndeadHD))
                         {
-                            return new TraitIconMap.TraitIconValue(TM_MatPool.Icon_Undead, "TM_Icon_Undead");
+                            return new TraitIconMap.TraitIconValue(TM_RenderQueue.necroMarkMat, TM_MatPool.Icon_Undead, "TM_Icon_Undead");
                         }
 
                         // Early exit condition
@@ -6418,12 +6418,7 @@ namespace TorannMagic
                         {
                             TraitDef trait = colonist.story.traits.allTraits[i].def;
                             if (TraitIconMap.ContainsKey(trait))
-                            {
-                                return new TraitIconMap.TraitIconValue(
-                                    TraitIconMap.Get(trait).IconMaterial,
-                                    TraitIconMap.Get(trait).IconType
-                                );
-                            }
+                                return TraitIconMap.Get(trait);
                         }
 
                         return null;
@@ -6438,7 +6433,7 @@ namespace TorannMagic
                 float num = 20f * Find.ColonistBar.Scale * settingsRef.classIconSize;
                 Vector2 vector = new Vector2(rect.x + 1f, rect.yMin + 1f);
                 rect = new Rect(vector.x, vector.y, num, num);
-                GUI.DrawTexture(rect, traitIconValue.IconMaterial);
+                GUI.DrawTexture(rect, traitIconValue.IconTexture);
                 TooltipHandler.TipRegion(rect, traitIconValue.IconType.Translate());
                 vector.x += num;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
@@ -57,12 +57,22 @@ namespace TorannMagic.ModOptions
                 else
                 {
                     // Map the trait to the texture to avoid having to TryGetComp
-                    Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
+                    // Get material
+                    Material mat = TM_RenderQueue.fighterMarkMat;
+                    if (customClass.classIconPath != "")
+                        mat = MaterialPool.MatFrom("Other/" + customClass.classIconPath);
+                    else if (customClass.classTexturePath != "")
+                        mat = MaterialPool.MatFrom("Other/ClassTextures/" + customClass.classTexturePath, true);
+                    mat.color = customClass.classIconColor;
+
+                    // Get texture
+                    Texture2D customTexture = TM_MatPool.DefaultCustomMageIcon;
                     if (customClass.classTexturePath != "")
                     {
-                        customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + customClass.classTexturePath, true);
+                        customTexture = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + customClass.classTexturePath, true);
                     }
-                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, customIconType));
+
+                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(mat, customTexture, customIconType));
                     
                     // Add custom trait to list for processing
                     customTraits.Add(customClass.classTrait);

--- a/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
@@ -49,7 +49,23 @@ namespace TorannMagic.ModOptions
             for (int i = 0; i < TM_ClassUtility.CustomClasses().Count; i++)
             {
                 TMDefs.TM_CustomClass customClass = TM_ClassUtility.CustomClasses()[i];
-                customTraits.AddDistinct(customClass.classTrait);
+                if (customTraits.Contains(customClass.classTrait))
+                {
+                    Log.Warning($"RimWorld of Magic trait {customClass.classTrait} already added. This is likely a naming conflict between mods.");
+                }
+                else
+                {
+                    // Map the trait to the texture to avoid having to TryGetComp
+                    Texture2D customIcon = TM_MatPool.DefaultCustomMageIcon;
+                    if (customClass.classTexturePath != "")
+                    {
+                        customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + customClass.classTexturePath, true);
+                    }
+                    
+                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom"));
+                    // Add custom trait to list for processing
+                    customTraits.Add(customClass.classTrait);
+                }
                 customClass.classTrait.conflictingTraits.AddRange(TM_Data.AllClassTraits);
             }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ModOptions/ModClassOptions.cs
@@ -46,6 +46,7 @@ namespace TorannMagic.ModOptions
             //Conflicting trait levelset
             List<TraitDef> customTraits = new List<TraitDef>();
             customTraits.Clear();
+            const string customIconType = "TM_Icon_Custom";
             for (int i = 0; i < TM_ClassUtility.CustomClasses().Count; i++)
             {
                 TMDefs.TM_CustomClass customClass = TM_ClassUtility.CustomClasses()[i];
@@ -61,8 +62,8 @@ namespace TorannMagic.ModOptions
                     {
                         customIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/" + customClass.classTexturePath, true);
                     }
+                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, customIconType));
                     
-                    TraitIconMap.Set(customClass.classTrait, new TraitIconMap.TraitIconValue(customIcon, "TM_Icon_Custom"));
                     // Add custom trait to list for processing
                     customTraits.Add(customClass.classTrait);
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,8 +134,8 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
-    <Compile Include="SimpleCache.cs" />
     <Compile Include="TraitIconMap.cs" />
+    <Compile Include="Utils\SimpleCache.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />
     <Compile Include="TMDefs\TM_Branding.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Building_TMTotem_Healing.cs" />
     <Compile Include="Building_TMTotem_Lightning.cs" />
     <Compile Include="Building_TM_DMP.cs" />
+    <Compile Include="CompAbilityUserMagicMightBase.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
     <Compile Include="TraitIconMap.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
+    <Compile Include="TraitIconMap.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />
     <Compile Include="TMDefs\TM_Branding.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Building_TM_DMP.cs" />
     <Compile Include="Enchantment\HediffComp_WinterChill.cs" />
     <Compile Include="Enchantment\Verb_WeaponWintersFury.cs" />
+    <Compile Include="SimpleCache.cs" />
     <Compile Include="TraitIconMap.cs" />
     <Compile Include="Weapon\FlyingObject_FreezingWinds.cs" />
     <Compile Include="Skyfaller_Hail.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/SimpleCache.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/SimpleCache.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace TorannMagic
+{
+    public class SimpleCache<TKey, TValue>
+    {
+        private class CacheValue<T>
+        {
+            public readonly T Value;
+            public readonly DateTime Timeout;
+            public CacheValue(T value, double secondsToTimeout)
+            {
+                Value = value;
+                Timeout = DateTime.UtcNow.AddSeconds(secondsToTimeout);
+            }
+        }
+
+        private readonly Dictionary<TKey, CacheValue<TValue>> cache;
+        private DateTime nextFlush;
+        private readonly double minutesUntilFlush;
+
+        public SimpleCache(double minutesUntilFlush)
+        {
+            cache = new Dictionary<TKey, CacheValue<TValue>>();
+            nextFlush = DateTime.UtcNow.AddMinutes(minutesUntilFlush);
+            this.minutesUntilFlush = minutesUntilFlush;
+        }
+
+        public TValue GetOrCreate(TKey key, Func<TValue> valueGetter, double secondsToTimeout)
+        {
+            if (cache.ContainsKey(key) && cache[key].Timeout > DateTime.UtcNow)
+            {
+                return cache[key].Value;
+            }
+
+            if (DateTime.UtcNow > nextFlush)
+            {
+                DateTime now = DateTime.UtcNow;
+                var itemsToRemove = cache.Where(kv => now > kv.Value.Timeout).ToList();
+                foreach (var item in itemsToRemove)
+                {
+                    cache.Remove(item.Key);
+                }
+                
+                nextFlush = DateTime.UtcNow.AddMinutes(minutesUntilFlush);
+            }
+            cache[key] = new CacheValue<TValue>(valueGetter(), secondsToTimeout);
+            return cache[key].Value;
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -75,78 +75,59 @@ namespace TorannMagic
 
         public static bool IsUndead(Pawn pawn)
         {
-            if (pawn != null)
+            if (pawn == null) return false;
+
+            if (pawn.health?.hediffSet != null && pawn.health.hediffSet.hediffs.Any(hediff =>
+                hediff.def == TorannMagicDefOf.TM_UndeadHD
+                || hediff.def == TorannMagicDefOf.TM_UndeadAnimalHD
+                || hediff.def == TorannMagicDefOf.TM_LichHD
+                || hediff.def == TorannMagicDefOf.TM_UndeadStageHD
+                || hediff.def.defName.StartsWith("ROM_Vamp")
+            ))
+                return true;
+
+            if (
+                pawn.def.defName == "SL_Runner"
+                || pawn.def.defName == "SL_Peon"
+                || pawn.def.defName == "SL_Archer"
+                || pawn.def.defName == "SL_Hero"
+                || pawn.def == TorannMagicDefOf.TM_GiantSkeletonR
+                || pawn.def == TorannMagicDefOf.TM_SkeletonR
+                || pawn.def == TorannMagicDefOf.TM_SkeletonLichR
+            )
+                return true;
+
+            if (pawn.story?.traits != null && pawn.story.traits.HasTrait(TorannMagicDefOf.Undead))
+                return true;
+
+            for (int i = 0; i < pawn.AllComps.Count; i++)
             {
-                bool flag_Hediff = false;
-                if (pawn.health != null && pawn.health.hediffSet != null)
+                if (pawn.AllComps[i] is CompAbilityUserMagicMightBase comp)
                 {
-                    if (pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD"), false) || pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadAnimalHD"), false) || pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_LichHD"), false) || pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadStageHD"), false))
-                    {
-                        flag_Hediff = true;
-                    }
-                    Hediff hediff = null;
-                    for (int i = 0; i < pawn.health.hediffSet.hediffs.Count; i++)
-                    {
-                        hediff = pawn.health.hediffSet.hediffs[i];
-                        if (hediff.def.defName.Contains("ROM_Vamp"))
-                        {
-                            flag_Hediff = true;
-                        }
-                    }
+                    if (comp.customClass != null && comp.customClass.isUndead)
+                        return true;
                 }
-                bool flag_DefName = false;
-                if (pawn.def.defName == "SL_Runner" || pawn.def.defName == "SL_Peon" || pawn.def.defName == "SL_Archer" || pawn.def.defName == "SL_Hero")
-                {
-                    flag_DefName = true;
-                }
-                if(pawn.def == TorannMagicDefOf.TM_GiantSkeletonR || pawn.def == TorannMagicDefOf.TM_SkeletonR || pawn.def == TorannMagicDefOf.TM_SkeletonLichR)
-                {
-                    flag_DefName = true;
-                }
-                bool flag_Trait = false;
-                if (pawn.story != null && pawn.story.traits != null)
-                {
-                    if (pawn.story.traits.HasTrait(TorannMagicDefOf.Undead))
-                    {
-                        flag_Trait = true;
-                    }
-                }
-                bool flag_UndeadClass = false;
-                CompAbilityUserMight compMight = pawn.TryGetComp<CompAbilityUserMight>();
-                if(compMight != null && compMight.customClass != null && compMight.customClass.isUndead)
-                {
-                    flag_UndeadClass = true;
-                }
-                CompAbilityUserMagic compMagic = pawn.TryGetComp<CompAbilityUserMagic>();
-                if (compMagic != null && compMagic.customClass != null && compMagic.customClass.isUndead)
-                {
-                    flag_UndeadClass = true;
-                }
-                bool isUndead = flag_Hediff || flag_DefName || flag_Trait || flag_UndeadClass;
-                return isUndead;
             }
+
             return false;
         }
 
         public static bool IsElemental(Pawn pawn)
         {
-            if (pawn != null)
-            {
-                bool flag_Def = false;
-                if (pawn.def != null)
-                {
-                    if (pawn.def == TorannMagicDefOf.TM_LesserEarth_ElementalR || pawn.def == TorannMagicDefOf.TM_LesserFire_ElementalR || pawn.def == TorannMagicDefOf.TM_LesserWater_ElementalR || pawn.def == TorannMagicDefOf.TM_LesserWind_ElementalR ||
-                        pawn.def == TorannMagicDefOf.TM_Earth_ElementalR || pawn.def == TorannMagicDefOf.TM_Fire_ElementalR || pawn.def == TorannMagicDefOf.TM_Water_ElementalR || pawn.def == TorannMagicDefOf.TM_Wind_ElementalR ||
-                        pawn.def == TorannMagicDefOf.TM_GreaterEarth_ElementalR || pawn.def == TorannMagicDefOf.TM_GreaterFire_ElementalR || pawn.def == TorannMagicDefOf.TM_GreaterWater_ElementalR || pawn.def == TorannMagicDefOf.TM_GreaterWind_ElementalR)
-                    {
-                        flag_Def = true;
-                    }
-                }
-
-                bool isElemental = flag_Def;
-                return isElemental;
-            }
-            return false;
+            return pawn?.def != null && (
+                pawn.def == TorannMagicDefOf.TM_LesserEarth_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_LesserFire_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_LesserWater_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_LesserWind_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_Earth_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_Fire_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_Water_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_Wind_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_GreaterEarth_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_GreaterFire_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_GreaterWater_ElementalR
+                || pawn.def == TorannMagicDefOf.TM_GreaterWind_ElementalR
+            );
         }
 
         public static bool IsUndeadNotVamp(Pawn pawn)

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_MatPool.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_MatPool.cs
@@ -79,6 +79,9 @@ namespace TorannMagic
         public static readonly Texture2D wandererIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/wandererFlame", true);
         public static readonly Texture2D wayfarerIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/wayfarerFlame", true);
 
+        public static readonly Texture2D DefaultCustomMageIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomMageMark", true);
+        public static readonly Texture2D DefaultCustomFighterIcon = ContentFinder<Texture2D>.Get("Other/ClassTextures/CustomFighterMark", true);
+
 
         //skeleton chain
         public static readonly Material circleChain = MaterialPool.MatFrom("PawnKind/skeleton_chain_circle", ShaderDatabase.MoteGlow);

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -12,12 +12,14 @@ namespace TorannMagic
         // Class to hold Values for below dictionary
         public class TraitIconValue
         {
-            public readonly Texture2D IconMaterial;
+            public readonly Material IconMaterial;
+            public readonly Texture2D IconTexture;
             public readonly string IconType;
 
-            public TraitIconValue(Texture2D iconMaterial, string iconType)
+            public TraitIconValue(Material iconMaterial, Texture2D iconTexture, string iconType)
             {
                 IconMaterial = iconMaterial;
+                IconTexture = iconTexture;
                 IconType = iconType;
             }
         }
@@ -25,36 +27,37 @@ namespace TorannMagic
         // via ModOptions.ModClassOptions.InitializeCustomClassActions
         private static readonly Dictionary<ushort, TraitIconValue> TraitIconMapping = new Dictionary<ushort, TraitIconValue>()
         {
-            { TorannMagicDefOf.InnerFire.index, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
-            { TorannMagicDefOf.HeartOfFrost.index, new TraitIconValue(TM_MatPool.iceIcon, MageIcon) },
-            { TorannMagicDefOf.StormBorn.index, new TraitIconValue(TM_MatPool.lightningIcon, MageIcon) },
-            { TorannMagicDefOf.Arcanist.index, new TraitIconValue(TM_MatPool.arcanistIcon, MageIcon) },
-            { TorannMagicDefOf.Paladin.index, new TraitIconValue(TM_MatPool.paladinIcon, MageIcon) },
-            { TorannMagicDefOf.Summoner.index, new TraitIconValue(TM_MatPool.summonerIcon, MageIcon) },
-            { TorannMagicDefOf.Druid.index, new TraitIconValue(TM_MatPool.druidIcon, MageIcon) },
-            { TorannMagicDefOf.Necromancer.index, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
-            { TorannMagicDefOf.Lich.index, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
-            { TorannMagicDefOf.TM_Bard.index, new TraitIconValue(TM_MatPool.bardIcon, MageIcon) },
-            { TorannMagicDefOf.Succubus.index, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
-            { TorannMagicDefOf.Warlock.index, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
-            { TorannMagicDefOf.Geomancer.index, new TraitIconValue(TM_MatPool.earthIcon, MageIcon) },
-            { TorannMagicDefOf.Technomancer.index, new TraitIconValue(TM_MatPool.technoIcon, MageIcon) },
-            { TorannMagicDefOf.BloodMage.index, new TraitIconValue(TM_MatPool.bloodmageIcon, MageIcon) },
-            { TorannMagicDefOf.Enchanter.index, new TraitIconValue(TM_MatPool.enchanterIcon, MageIcon) },
-            { TorannMagicDefOf.Chronomancer.index, new TraitIconValue(TM_MatPool.chronoIcon, MageIcon) },
-            { TorannMagicDefOf.Gladiator.index, new TraitIconValue(TM_MatPool.gladiatorIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Sniper.index, new TraitIconValue(TM_MatPool.sniperIcon, FighterIcon) },
-            { TorannMagicDefOf.Bladedancer.index, new TraitIconValue(TM_MatPool.bladedancerIcon, FighterIcon) },
-            { TorannMagicDefOf.Ranger.index, new TraitIconValue(TM_MatPool.rangerIcon, FighterIcon) },
-            { TorannMagicDefOf.Faceless.index, new TraitIconValue(TM_MatPool.facelessIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Psionic.index, new TraitIconValue(TM_MatPool.psiIcon, FighterIcon) },
-            { TorannMagicDefOf.DeathKnight.index, new TraitIconValue(TM_MatPool.deathknightIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Monk.index, new TraitIconValue(TM_MatPool.monkIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Wanderer.index, new TraitIconValue(TM_MatPool.wandererIcon, MageIcon) },
-            { TorannMagicDefOf.TM_Wayfarer.index, new TraitIconValue(TM_MatPool.wayfarerIcon, FighterIcon) },
-            { TorannMagicDefOf.ChaosMage.index, new TraitIconValue(TM_MatPool.chaosIcon, MageIcon) },
-            { TorannMagicDefOf.TM_Commander.index, new TraitIconValue(TM_MatPool.commanderIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_SuperSoldier.index, new TraitIconValue(TM_MatPool.SSIcon, FighterIcon) }
+            { TorannMagicDefOf.InnerFire.index, new TraitIconValue(TM_RenderQueue.fireMarkMat, TM_MatPool.fireIcon, MageIcon) },
+            { TorannMagicDefOf.HeartOfFrost.index, new TraitIconValue(TM_RenderQueue.iceMarkMat, TM_MatPool.iceIcon, MageIcon) },
+            { TorannMagicDefOf.StormBorn.index, new TraitIconValue(TM_RenderQueue.lightningMarkMat, TM_MatPool.lightningIcon, MageIcon) },
+            { TorannMagicDefOf.Arcanist.index, new TraitIconValue(TM_RenderQueue.arcanistMarkMat, TM_MatPool.arcanistIcon, MageIcon) },
+            { TorannMagicDefOf.Paladin.index, new TraitIconValue(TM_RenderQueue.paladinMarkMat, TM_MatPool.paladinIcon, MageIcon) },
+            { TorannMagicDefOf.Priest.index, new TraitIconValue(TM_RenderQueue.priestMarkMat, TM_MatPool.priestIcon, MageIcon) },
+            { TorannMagicDefOf.Summoner.index, new TraitIconValue(TM_RenderQueue.summonerMarkMat, TM_MatPool.summonerIcon, MageIcon) },
+            { TorannMagicDefOf.Druid.index, new TraitIconValue(TM_RenderQueue.druidMarkMat, TM_MatPool.druidIcon, MageIcon) },
+            { TorannMagicDefOf.Necromancer.index, new TraitIconValue(TM_RenderQueue.necroMarkMat, TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.Lich.index, new TraitIconValue(TM_RenderQueue.necroMarkMat, TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Bard.index, new TraitIconValue(TM_RenderQueue.bardMarkMat, TM_MatPool.bardIcon, MageIcon) },
+            { TorannMagicDefOf.Succubus.index, new TraitIconValue(TM_RenderQueue.demonkinMarkMat, TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Warlock.index, new TraitIconValue(TM_RenderQueue.warlockMarkMat, TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Geomancer.index, new TraitIconValue(TM_RenderQueue.earthMarkMat, TM_MatPool.earthIcon, MageIcon) },
+            { TorannMagicDefOf.Technomancer.index, new TraitIconValue(TM_RenderQueue.technoMarkMat, TM_MatPool.technoIcon, MageIcon) },
+            { TorannMagicDefOf.BloodMage.index, new TraitIconValue(TM_RenderQueue.bloodmageMarkMat, TM_MatPool.bloodmageIcon, MageIcon) },
+            { TorannMagicDefOf.Enchanter.index, new TraitIconValue(TM_RenderQueue.enchanterMarkMat, TM_MatPool.enchanterIcon, MageIcon) },
+            { TorannMagicDefOf.Chronomancer.index, new TraitIconValue(TM_RenderQueue.chronomancerMarkMat, TM_MatPool.chronoIcon, MageIcon) },
+            { TorannMagicDefOf.Gladiator.index, new TraitIconValue(TM_RenderQueue.gladiatorMarkMat, TM_MatPool.gladiatorIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Sniper.index, new TraitIconValue(TM_RenderQueue.sniperMarkMat, TM_MatPool.sniperIcon, FighterIcon) },
+            { TorannMagicDefOf.Bladedancer.index, new TraitIconValue(TM_RenderQueue.bladedancerMarkMat, TM_MatPool.bladedancerIcon, FighterIcon) },
+            { TorannMagicDefOf.Ranger.index, new TraitIconValue(TM_RenderQueue.rangerMarkMat, TM_MatPool.rangerIcon, FighterIcon) },
+            { TorannMagicDefOf.Faceless.index, new TraitIconValue(TM_RenderQueue.facelessMarkMat, TM_MatPool.facelessIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Psionic.index, new TraitIconValue(TM_RenderQueue.psionicMarkMat, TM_MatPool.psiIcon, FighterIcon) },
+            { TorannMagicDefOf.DeathKnight.index, new TraitIconValue(TM_RenderQueue.deathknightMarkMat, TM_MatPool.deathknightIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Monk.index, new TraitIconValue(TM_RenderQueue.monkMarkMat, TM_MatPool.monkIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Wanderer.index, new TraitIconValue(TM_RenderQueue.wandererMarkMat, TM_MatPool.wandererIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Wayfarer.index, new TraitIconValue(TM_RenderQueue.wayfarerMarkMat, TM_MatPool.wayfarerIcon, FighterIcon) },
+            { TorannMagicDefOf.ChaosMage.index, new TraitIconValue(TM_RenderQueue.chaosMarkMat, TM_MatPool.chaosIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Commander.index, new TraitIconValue(TM_RenderQueue.commanderMarkMat, TM_MatPool.commanderIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_SuperSoldier.index, new TraitIconValue(TM_RenderQueue.supersoldierMarkMat, TM_MatPool.SSIcon, FighterIcon) }
         };
 
         public static TraitIconValue Get(TraitDef traitDef)

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -23,53 +23,53 @@ namespace TorannMagic
         }
         // Dictionary that maps TraitDef to their appropriate Icon material and Icon type. Custom Classes are loaded
         // via ModOptions.ModClassOptions.InitializeCustomClassActions
-        private static readonly Dictionary<TraitDef, TraitIconValue> TraitIconMapping = new Dictionary<TraitDef, TraitIconValue>()
+        private static readonly Dictionary<ushort, TraitIconValue> TraitIconMapping = new Dictionary<ushort, TraitIconValue>()
         {
-            { TorannMagicDefOf.InnerFire, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
-            { TorannMagicDefOf.HeartOfFrost, new TraitIconValue(TM_MatPool.iceIcon, MageIcon) },
-            { TorannMagicDefOf.StormBorn, new TraitIconValue(TM_MatPool.lightningIcon, MageIcon) },
-            { TorannMagicDefOf.Arcanist, new TraitIconValue(TM_MatPool.arcanistIcon, MageIcon) },
-            { TorannMagicDefOf.Paladin, new TraitIconValue(TM_MatPool.paladinIcon, MageIcon) },
-            { TorannMagicDefOf.Summoner, new TraitIconValue(TM_MatPool.summonerIcon, MageIcon) },
-            { TorannMagicDefOf.Druid, new TraitIconValue(TM_MatPool.druidIcon, MageIcon) },
-            { TorannMagicDefOf.Necromancer, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
-            { TorannMagicDefOf.Lich, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
-            { TorannMagicDefOf.TM_Bard, new TraitIconValue(TM_MatPool.bardIcon, MageIcon) },
-            { TorannMagicDefOf.Succubus, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
-            { TorannMagicDefOf.Warlock, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
-            { TorannMagicDefOf.Geomancer, new TraitIconValue(TM_MatPool.earthIcon, MageIcon) },
-            { TorannMagicDefOf.Technomancer, new TraitIconValue(TM_MatPool.technoIcon, MageIcon) },
-            { TorannMagicDefOf.BloodMage, new TraitIconValue(TM_MatPool.bloodmageIcon, MageIcon) },
-            { TorannMagicDefOf.Enchanter, new TraitIconValue(TM_MatPool.enchanterIcon, MageIcon) },
-            { TorannMagicDefOf.Chronomancer, new TraitIconValue(TM_MatPool.chronoIcon, MageIcon) },
-            { TorannMagicDefOf.Gladiator, new TraitIconValue(TM_MatPool.gladiatorIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Sniper, new TraitIconValue(TM_MatPool.sniperIcon, FighterIcon) },
-            { TorannMagicDefOf.Bladedancer, new TraitIconValue(TM_MatPool.bladedancerIcon, FighterIcon) },
-            { TorannMagicDefOf.Ranger, new TraitIconValue(TM_MatPool.rangerIcon, FighterIcon) },
-            { TorannMagicDefOf.Faceless, new TraitIconValue(TM_MatPool.facelessIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Psionic, new TraitIconValue(TM_MatPool.psiIcon, FighterIcon) },
-            { TorannMagicDefOf.DeathKnight, new TraitIconValue(TM_MatPool.deathknightIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Monk, new TraitIconValue(TM_MatPool.monkIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_Wanderer, new TraitIconValue(TM_MatPool.wandererIcon, MageIcon) },
-            { TorannMagicDefOf.TM_Wayfarer, new TraitIconValue(TM_MatPool.wayfarerIcon, FighterIcon) },
-            { TorannMagicDefOf.ChaosMage, new TraitIconValue(TM_MatPool.chaosIcon, MageIcon) },
-            { TorannMagicDefOf.TM_Commander, new TraitIconValue(TM_MatPool.commanderIcon, FighterIcon) },
-            { TorannMagicDefOf.TM_SuperSoldier, new TraitIconValue(TM_MatPool.SSIcon, FighterIcon) }
+            { TorannMagicDefOf.InnerFire.index, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
+            { TorannMagicDefOf.HeartOfFrost.index, new TraitIconValue(TM_MatPool.iceIcon, MageIcon) },
+            { TorannMagicDefOf.StormBorn.index, new TraitIconValue(TM_MatPool.lightningIcon, MageIcon) },
+            { TorannMagicDefOf.Arcanist.index, new TraitIconValue(TM_MatPool.arcanistIcon, MageIcon) },
+            { TorannMagicDefOf.Paladin.index, new TraitIconValue(TM_MatPool.paladinIcon, MageIcon) },
+            { TorannMagicDefOf.Summoner.index, new TraitIconValue(TM_MatPool.summonerIcon, MageIcon) },
+            { TorannMagicDefOf.Druid.index, new TraitIconValue(TM_MatPool.druidIcon, MageIcon) },
+            { TorannMagicDefOf.Necromancer.index, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.Lich.index, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Bard.index, new TraitIconValue(TM_MatPool.bardIcon, MageIcon) },
+            { TorannMagicDefOf.Succubus.index, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Warlock.index, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Geomancer.index, new TraitIconValue(TM_MatPool.earthIcon, MageIcon) },
+            { TorannMagicDefOf.Technomancer.index, new TraitIconValue(TM_MatPool.technoIcon, MageIcon) },
+            { TorannMagicDefOf.BloodMage.index, new TraitIconValue(TM_MatPool.bloodmageIcon, MageIcon) },
+            { TorannMagicDefOf.Enchanter.index, new TraitIconValue(TM_MatPool.enchanterIcon, MageIcon) },
+            { TorannMagicDefOf.Chronomancer.index, new TraitIconValue(TM_MatPool.chronoIcon, MageIcon) },
+            { TorannMagicDefOf.Gladiator.index, new TraitIconValue(TM_MatPool.gladiatorIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Sniper.index, new TraitIconValue(TM_MatPool.sniperIcon, FighterIcon) },
+            { TorannMagicDefOf.Bladedancer.index, new TraitIconValue(TM_MatPool.bladedancerIcon, FighterIcon) },
+            { TorannMagicDefOf.Ranger.index, new TraitIconValue(TM_MatPool.rangerIcon, FighterIcon) },
+            { TorannMagicDefOf.Faceless.index, new TraitIconValue(TM_MatPool.facelessIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Psionic.index, new TraitIconValue(TM_MatPool.psiIcon, FighterIcon) },
+            { TorannMagicDefOf.DeathKnight.index, new TraitIconValue(TM_MatPool.deathknightIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Monk.index, new TraitIconValue(TM_MatPool.monkIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Wanderer.index, new TraitIconValue(TM_MatPool.wandererIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Wayfarer.index, new TraitIconValue(TM_MatPool.wayfarerIcon, FighterIcon) },
+            { TorannMagicDefOf.ChaosMage.index, new TraitIconValue(TM_MatPool.chaosIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Commander.index, new TraitIconValue(TM_MatPool.commanderIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_SuperSoldier.index, new TraitIconValue(TM_MatPool.SSIcon, FighterIcon) }
         };
 
         public static TraitIconValue Get(TraitDef traitDef)
         {
-            return TraitIconMapping[traitDef];
+            return TraitIconMapping[traitDef.index];
         }
 
         public static void Set(TraitDef traitDef, TraitIconValue traitIconValue)
         {
-            TraitIconMapping[traitDef] = traitIconValue;
+            TraitIconMapping[traitDef.index] = traitIconValue;
         }
 
         public static bool ContainsKey(TraitDef traitDef)
         {
-            return TraitIconMapping.ContainsKey(traitDef);
+            return TraitIconMapping.ContainsKey(traitDef.index);
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using RimWorld;
+using UnityEngine;
+
+namespace TorannMagic
+{
+    public static class TraitIconMap
+    {
+        // Data for ColonistBarColonistDrawer_Patch
+        private const string MageIcon = "TM_Icon_Mage";  // Use same strings in tuples for less memory usage
+        private const string FighterIcon = "TM_Icon_Fighter";
+        // Class to hold Values for below dictionary
+        public class TraitIconValue
+        {
+            public readonly Texture2D IconMaterial;
+            public readonly string IconType;
+
+            public TraitIconValue(Texture2D iconMaterial, string iconType)
+            {
+                IconMaterial = iconMaterial;
+                IconType = iconType;
+            }
+        }
+        // Dictionary that maps TraitDef to their appropriate Icon material and Icon type
+        // TODO: dynamically add custom classes on load to allow for easier checks
+        private static readonly Dictionary<TraitDef, TraitIconValue> TraitIconMapping = new Dictionary<TraitDef, TraitIconValue>()
+        {
+            { TorannMagicDefOf.InnerFire, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
+            { TorannMagicDefOf.HeartOfFrost, new TraitIconValue(TM_MatPool.iceIcon, MageIcon) },
+            { TorannMagicDefOf.StormBorn, new TraitIconValue(TM_MatPool.lightningIcon, MageIcon) },
+            { TorannMagicDefOf.Arcanist, new TraitIconValue(TM_MatPool.arcanistIcon, MageIcon) },
+            { TorannMagicDefOf.Paladin, new TraitIconValue(TM_MatPool.paladinIcon, MageIcon) },
+            { TorannMagicDefOf.Summoner, new TraitIconValue(TM_MatPool.summonerIcon, MageIcon) },
+            { TorannMagicDefOf.Druid, new TraitIconValue(TM_MatPool.druidIcon, MageIcon) },
+            { TorannMagicDefOf.Necromancer, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.Lich, new TraitIconValue(TM_MatPool.necroIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Bard, new TraitIconValue(TM_MatPool.bardIcon, MageIcon) },
+            { TorannMagicDefOf.Succubus, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Warlock, new TraitIconValue(TM_MatPool.demonkinIcon, MageIcon) },
+            { TorannMagicDefOf.Geomancer, new TraitIconValue(TM_MatPool.earthIcon, MageIcon) },
+            { TorannMagicDefOf.Technomancer, new TraitIconValue(TM_MatPool.technoIcon, MageIcon) },
+            { TorannMagicDefOf.BloodMage, new TraitIconValue(TM_MatPool.bloodmageIcon, MageIcon) },
+            { TorannMagicDefOf.Enchanter, new TraitIconValue(TM_MatPool.enchanterIcon, MageIcon) },
+            { TorannMagicDefOf.Chronomancer, new TraitIconValue(TM_MatPool.chronoIcon, MageIcon) },
+            { TorannMagicDefOf.Gladiator, new TraitIconValue(TM_MatPool.gladiatorIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Sniper, new TraitIconValue(TM_MatPool.sniperIcon, FighterIcon) },
+            { TorannMagicDefOf.Bladedancer, new TraitIconValue(TM_MatPool.bladedancerIcon, FighterIcon) },
+            { TorannMagicDefOf.Ranger, new TraitIconValue(TM_MatPool.rangerIcon, FighterIcon) },
+            { TorannMagicDefOf.Faceless, new TraitIconValue(TM_MatPool.facelessIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Psionic, new TraitIconValue(TM_MatPool.psiIcon, FighterIcon) },
+            { TorannMagicDefOf.DeathKnight, new TraitIconValue(TM_MatPool.deathknightIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Monk, new TraitIconValue(TM_MatPool.monkIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_Wanderer, new TraitIconValue(TM_MatPool.wandererIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Wayfarer, new TraitIconValue(TM_MatPool.wayfarerIcon, FighterIcon) },
+            { TorannMagicDefOf.ChaosMage, new TraitIconValue(TM_MatPool.chaosIcon, MageIcon) },
+            { TorannMagicDefOf.TM_Commander, new TraitIconValue(TM_MatPool.commanderIcon, FighterIcon) },
+            { TorannMagicDefOf.TM_SuperSoldier, new TraitIconValue(TM_MatPool.SSIcon, FighterIcon) }
+        };
+
+        public static TraitIconValue Get(TraitDef traitDef)
+        {
+            return TraitIconMapping[traitDef];
+        }
+
+        public static bool ContainsKey(TraitDef traitDef)
+        {
+            return TraitIconMapping.ContainsKey(traitDef);
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -7,7 +7,7 @@ namespace TorannMagic
     public static class TraitIconMap
     {
         // Data for ColonistBarColonistDrawer_Patch
-        private const string MageIcon = "TM_Icon_Mage";  // Use same strings in tuples for less memory usage
+        private const string MageIcon = "TM_Icon_Mage";
         private const string FighterIcon = "TM_Icon_Fighter";
         // Class to hold Values for below dictionary
         public class TraitIconValue

--- a/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TraitIconMap.cs
@@ -21,8 +21,8 @@ namespace TorannMagic
                 IconType = iconType;
             }
         }
-        // Dictionary that maps TraitDef to their appropriate Icon material and Icon type
-        // TODO: dynamically add custom classes on load to allow for easier checks
+        // Dictionary that maps TraitDef to their appropriate Icon material and Icon type. Custom Classes are loaded
+        // via ModOptions.ModClassOptions.InitializeCustomClassActions
         private static readonly Dictionary<TraitDef, TraitIconValue> TraitIconMapping = new Dictionary<TraitDef, TraitIconValue>()
         {
             { TorannMagicDefOf.InnerFire, new TraitIconValue(TM_MatPool.fireIcon, MageIcon) },
@@ -60,6 +60,11 @@ namespace TorannMagic
         public static TraitIconValue Get(TraitDef traitDef)
         {
             return TraitIconMapping[traitDef];
+        }
+
+        public static void Set(TraitDef traitDef, TraitIconValue traitIconValue)
+        {
+            TraitIconMapping[traitDef] = traitIconValue;
         }
 
         public static bool ContainsKey(TraitDef traitDef)

--- a/RimWorldOfMagic/RimWorldOfMagic/Utils/SimpleCache.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Utils/SimpleCache.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Verse;
 
-namespace TorannMagic
+namespace TorannMagic.Utils
 {
     public class SimpleCache<TKey, TValue>
     {


### PR DESCRIPTION
This one is heavily dependent on the work on ColonistDrawer patch (#15) i did earlier. It is based off of that branch as well so either review that one first or skip it

Essentially this branch started as cleaning functions (making them more readable and exit as early as possible instead of checking everything then exiting), but then quickly evolved into applying the same changes ColonistDrawer patch has but for the marks. I do cache the trait check so pawns only scan their traits every 5 seconds rather than every time. While I don't see any particularly large tps gains, I do notice that I am getting a couple frames back it feels like. I did not do benchmarking though. My strategy this time was just to make the code more readable at a glance.