### PR TITLE
Fix bug in TM_Inspiration_ArcanePathway.LetterText.get when dealing with custom classes with only one degree

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/TM_Inspiration_ArcanePathway.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/TM_Inspiration_ArcanePathway.cs
@@ -22,10 +22,11 @@ namespace TorannMagic.Thoughts
         {
             get
             {
-                TaggedString taggedString = def.beginLetter.Formatted(pawn.LabelShortCap, TM_Data.EnabledMagicTraits[mageIndex].degreeDatas[TM_Data.EnabledMagicTraits[mageIndex].degreeDatas.FirstOrDefault().degree].label).AdjustedFor(pawn);
+                TraitDef traitDef = TM_Data.EnabledMagicTraits[mageIndex];
+                TaggedString taggedString = def.beginLetter.Formatted(pawn.LabelShortCap, traitDef.degreeDatas[0].label).AdjustedFor(pawn);
                 if (!string.IsNullOrWhiteSpace(reason))
                 {
-                    taggedString = reason.Formatted(pawn.LabelCap, TM_Data.EnabledMagicTraits[mageIndex].degreeDatas[0].LabelCap, pawn.Named("PAWN")).AdjustedFor(pawn) + "\n\n" + taggedString;
+                    taggedString = reason.Formatted(pawn.LabelCap, traitDef.degreeDatas[0].LabelCap, pawn.Named("PAWN")).AdjustedFor(pawn) + "\n\n" + taggedString;
                 }
                 return taggedString;
             }


### PR DESCRIPTION
Use first degreeDatas entry for both labels. Also put traitDef into a variable since EnabledMagicTraits can technically change between lines.