### PR TITLE
Use Building_ExplosiveProximityTrap as a base class for Lighting and Poison Trap

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/Building_ExplosiveProximityTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_ExplosiveProximityTrap.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using RimWorld;
+﻿using RimWorld;
 using Verse;
 using Verse.Sound;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
-using Verse.AI;
-using Verse.AI.Group;
 
 namespace TorannMagic
 {
@@ -20,7 +16,7 @@ namespace TorannMagic
         private const float AnimalSpringChanceFactor = 0.1f;
 
         private int trapSpringDelay = 30;
-        private bool trapSprung = false;
+        private bool trapSprung;
 
         private Pawn trapPawn = new Pawn();
 
@@ -59,13 +55,7 @@ namespace TorannMagic
             }
         }
 
-        public bool Armed
-        {
-            get
-            {
-                return !trapSprung;
-            }
-        }
+        public bool Armed => !trapSprung;
 
         public override void Tick()
         {
@@ -109,13 +99,13 @@ namespace TorannMagic
                     p.LabelShort
                 ), "LetterFriendlyTrapSprung".Translate(
                     p.LabelShort
-                ), LetterDefOf.NegativeEvent, new TargetInfo(Position, Map, false), null);
+                ), LetterDefOf.NegativeEvent, new TargetInfo(Position, Map));
             }
         }
 
         public new virtual void Spring(Pawn p)
         {
-            SoundDefOf.EnergyShield_Broken.PlayOneShot(new TargetInfo(Position, Map, false));
+            SoundDefOf.EnergyShield_Broken.PlayOneShot(new TargetInfo(Position, Map));
             trapPawn = p;
             trapSprung = true;
         }
@@ -123,7 +113,7 @@ namespace TorannMagic
         // Helper function to allow overriding SpringChance BEFORE Mathf.Clamp01 is called on it.
         protected virtual float UnclampedSpringChance(Pawn p)
         {
-            float num = KnowsOfTrap(p) ? 0.8f : this.GetStatValue(StatDefOf.TrapSpringChance, true);
+            float num = KnowsOfTrap(p) ? 0.8f : this.GetStatValue(StatDefOf.TrapSpringChance);
             num *= GenMath.LerpDouble(0.4f, 0.8f, 0f, 1f, p.BodySize);
             return num;
         }
@@ -177,7 +167,7 @@ namespace TorannMagic
             InstallBlueprintUtility.CancelBlueprintsFor(this);
             if (mode == DestroyMode.Deconstruct)
             {
-                SoundDef.Named("Building_Deconstructed").PlayOneShot(new TargetInfo(Position, Map, false));
+                SoundDef.Named("Building_Deconstructed").PlayOneShot(new TargetInfo(Position, Map));
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_ExplosiveProximityTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_ExplosiveProximityTrap.cs
@@ -120,44 +120,31 @@ namespace TorannMagic
             trapSprung = true;
         }
 
+        // Helper function to allow overriding SpringChance BEFORE Mathf.Clamp01 is called on it.
+        protected virtual float UnclampedSpringChance(Pawn p)
+        {
+            float num = KnowsOfTrap(p) ? 0.8f : this.GetStatValue(StatDefOf.TrapSpringChance, true);
+            num *= GenMath.LerpDouble(0.4f, 0.8f, 0f, 1f, p.BodySize);
+            return num;
+        }
+
         protected override float SpringChance(Pawn p)
         {
-            float num;
-            if (KnowsOfTrap(p))
-            {
-                num = 0.8f;
-            }
-            else
-            {
-                num = this.GetStatValue(StatDefOf.TrapSpringChance, true);
-            }
-            num *= GenMath.LerpDouble(0.4f, 0.8f, 0f, 1f, p.BodySize);
+            float num = UnclampedSpringChance(p);
             return Mathf.Clamp01(num);
         }
 
         public override ushort PathFindCostFor(Pawn p)
         {
-            if (!Armed)
-            {
-                return 0;
-            }
-            if (KnowsOfTrap(p))
-            {
+            if (Armed && KnowsOfTrap(p))
                 return 800;
-            }
             return 0;
         }
 
         public override ushort PathWalkCostFor(Pawn p)
         {
-            if (!Armed)
-            {
-                return 0;
-            }
-            if (KnowsOfTrap(p))
-            {
+            if (Armed && KnowsOfTrap(p))
                 return 50;
-            }
             return 0;
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
@@ -10,27 +10,10 @@ using Verse.AI.Group;
 
 namespace TorannMagic
 {
-    public class Building_LightningTrap : Building_Trap
+    public class Building_LightningTrap : Building_ExplosiveProximityTrap
     {
-        public List<Pawn> touchingPawns = new List<Pawn>();
-
-        private const float KnowerSpringChance = 0.004f;
-        private const ushort KnowerPathFindCost = 800;
-        private const ushort KnowerPathWalkCost = 30;
-        private const float AnimalSpringChanceFactor = 0.1f;
-
-        private int trapSpringDelay = 30;
-        private bool trapSprung = false;
-
         public bool extendedTrap = false;
         public bool iceTrap = false;
-
-        Pawn trapPawn = new Pawn();
-
-        protected override void SpringSub(Pawn p)
-        {
-            base.GetComp<CompExplosive>().StartWick(null);
-        }
 
         public override void ExposeData()
         {
@@ -39,84 +22,13 @@ namespace TorannMagic
             Scribe_Values.Look<bool>(ref this.iceTrap, "iceTrap", false, false);
         }
 
-        private void CheckPawn(IntVec3 position)
+        public new void Spring(Pawn p)
         {
-            List<Thing> thingList = position.GetThingList(base.Map);
-            for (int i = 0; i < thingList.Count; i++)
-            {
-                Pawn pawn = thingList[i] as Pawn;
-                if (pawn != null && pawn.Faction != this.Faction && pawn.HostileTo(this.Faction) && !this.touchingPawns.Contains(pawn))
-                {
-                    this.touchingPawns.Add(pawn);
-                    this.CheckSpring(pawn);
-                }
-            }
-        }
-
-        public bool Armed
-        {
-            get
-            {
-                return !this.trapSprung;
-            }
-        }
-
-        public override void Tick()
-        {
-            if (this.Armed)
-            {
-                CheckPawn(base.Position);
-                for (int j = 0; j < 8; j++)
-                {
-                    IntVec3 intVec = this.Position + GenAdj.AdjacentCells[j];
-                    CheckPawn(intVec);
-                }
-                for (int j = 0; j < this.touchingPawns.Count; j++)
-                {
-                    Pawn pawn2 = this.touchingPawns[j];
-                    if (!pawn2.Spawned || pawn2.Position != base.Position)
-                    {
-                        this.touchingPawns.Remove(pawn2);
-                    }
-                }
-            }
-            else
-            {
-                this.trapSpringDelay--;
-                if (this.trapSpringDelay <= 0)
-                {
-                    this.SpringSub(this.trapPawn);
-                }
-            }
-
-            base.Tick();
-        }
-
-        private void CheckSpring(Pawn p)
-        {
-            if (Rand.Value < this.SpringChance(p))
-            {
-                this.Spring(p);
-                if (p.Faction == Faction.OfPlayer || p.HostFaction == Faction.OfPlayer)
-                {
-                    Find.LetterStack.ReceiveLetter("LetterFriendlyTrapSprungLabel".Translate(
-                        p.LabelShort
-                    ), "LetterFriendlyTrapSprung".Translate(
-                        p.LabelShort
-                    ), LetterDefOf.NegativeEvent, new TargetInfo(base.Position, base.Map, false), null);
-                }
-            }
-        }
-
-        new public void Spring(Pawn p)
-        {
-            SoundDefOf.EnergyShield_Broken.PlayOneShot(new TargetInfo(base.Position, base.Map, false));
-            this.trapPawn = p;
-            this.trapSprung = true;
-            IntVec3 targetPos = this.Position;
+            base.Spring(p);
+            IntVec3 targetPos = Position;
             targetPos.z += 2;
             LocalTargetInfo t = targetPos;
-            bool flag = t.Cell != default(IntVec3);
+            bool flag = t.Cell != default;
             float speed = .8f;
             if(extendedTrap)
             {
@@ -124,9 +36,11 @@ namespace TorannMagic
             }
             if (flag)
             {
-                Thing eyeThing = new Thing();
-                eyeThing.def = TorannMagicDefOf.FlyingObject_LightningTrap;
-                FlyingObject_LightningTrap flyingObject = (FlyingObject_LightningTrap)GenSpawn.Spawn(TorannMagicDefOf.FlyingObject_LightningTrap, this.Position, this.Map);
+                Thing eyeThing = new Thing
+                {
+                    def = TorannMagicDefOf.FlyingObject_LightningTrap
+                };
+                FlyingObject_LightningTrap flyingObject = (FlyingObject_LightningTrap)GenSpawn.Spawn(TorannMagicDefOf.FlyingObject_LightningTrap, Position, Map);
                 flyingObject.Launch(p, this.Position.ToVector3Shifted(), t.Cell, eyeThing, this.Faction, null, speed);
             }
             if(iceTrap)
@@ -149,70 +63,6 @@ namespace TorannMagic
 
                 }
             }
-        }
-
-        protected override float SpringChance(Pawn p)
-        {
-            float num;
-            if (this.KnowsOfTrap(p))
-            {
-                num = 0.8f;
-            }
-            else
-            {
-                num = this.GetStatValue(StatDefOf.TrapSpringChance, true);
-            }
-            num *= GenMath.LerpDouble(0.4f, 0.8f, 0f, 1f, p.BodySize);
-            return Mathf.Clamp01(num);
-        }
-
-        public override ushort PathFindCostFor(Pawn p)
-        {
-            if (!this.Armed)
-            {
-                return 0;
-            }
-            if (this.KnowsOfTrap(p))
-            {
-                return 800;
-            }
-            return 0;
-        }
-
-        public override ushort PathWalkCostFor(Pawn p)
-        {
-            if (!this.Armed)
-            {
-                return 0;
-            }
-            if (this.KnowsOfTrap(p))
-            {
-                return 50;
-            }
-            return 0;
-        }
-
-        public override bool IsDangerousFor(Pawn p)
-        {
-            return this.Armed && this.KnowsOfTrap(p) && p.Faction != this.Faction;
-        }
-
-        public override string GetInspectString()
-        {
-            string text = base.GetInspectString();
-            if (!text.NullOrEmpty())
-            {
-                text += "\n";
-            }
-            if (this.Armed)
-            {
-                text += "Proximity Trap Armed";
-            }
-            else
-            {
-                text += "Trap Not Armed";
-            }
-            return text;
         }
 
         public override void Destroy(DestroyMode mode = DestroyMode.Vanish)

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
@@ -16,24 +16,19 @@ namespace TorannMagic
             Scribe_Values.Look<bool>(ref this.iceTrap, "iceTrap", false, false);
         }
 
-        public new void Spring(Pawn p)
+        public override void Spring(Pawn p)
         {
-            base.Spring(p);
             IntVec3 targetPos = Position;
             targetPos.z += 2;
             LocalTargetInfo t = targetPos;
-            bool flag = t.Cell != default;
             float speed = .8f;
             if(extendedTrap)
             {
                 speed = .6f;
             }
-            if (flag)
+            if (t.Cell != default)
             {
-                Thing eyeThing = new Thing
-                {
-                    def = TorannMagicDefOf.FlyingObject_LightningTrap
-                };
+                Thing eyeThing = new Thing {def = TorannMagicDefOf.FlyingObject_LightningTrap};
                 FlyingObject_LightningTrap flyingObject = (FlyingObject_LightningTrap)GenSpawn.Spawn(TorannMagicDefOf.FlyingObject_LightningTrap, Position, Map);
                 flyingObject.Launch(p, Position.ToVector3Shifted(), t.Cell, eyeThing, Faction, null, speed);
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
@@ -1,19 +1,13 @@
-﻿using System;
-using RimWorld;
+﻿using RimWorld;
 using Verse;
 using Verse.Sound;
-using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
-using Verse.AI;
-using Verse.AI.Group;
 
 namespace TorannMagic
 {
     public class Building_LightningTrap : Building_ExplosiveProximityTrap
     {
-        public bool extendedTrap = false;
-        public bool iceTrap = false;
+        public bool extendedTrap;
+        public bool iceTrap;
 
         public override void ExposeData()
         {
@@ -41,11 +35,11 @@ namespace TorannMagic
                     def = TorannMagicDefOf.FlyingObject_LightningTrap
                 };
                 FlyingObject_LightningTrap flyingObject = (FlyingObject_LightningTrap)GenSpawn.Spawn(TorannMagicDefOf.FlyingObject_LightningTrap, Position, Map);
-                flyingObject.Launch(p, this.Position.ToVector3Shifted(), t.Cell, eyeThing, this.Faction, null, speed);
+                flyingObject.Launch(p, Position.ToVector3Shifted(), t.Cell, eyeThing, Faction, null, speed);
             }
             if(iceTrap)
             {
-                AddSnowRadial(this.Position, this.Map, 6, 1.1f);
+                AddSnowRadial(Position, Map, 6, 1.1f);
             }
         }
 
@@ -55,24 +49,22 @@ namespace TorannMagic
             for (int i = 0; i < num; i++)
             {
                 IntVec3 intVec = center + GenRadial.RadialPattern[i];
-                if (intVec.InBounds(map))
-                {
-                    float lengthHorizontal = (center - intVec).LengthHorizontal;
-                    float num2 = 1f - lengthHorizontal / radius;
-                    map.snowGrid.AddDepth(intVec, num2 * depth);
+                if (!intVec.InBounds(map)) continue;
 
-                }
+                float lengthHorizontal = (center - intVec).LengthHorizontal;
+                float num2 = 1f - lengthHorizontal / radius;
+                map.snowGrid.AddDepth(intVec, num2 * depth);
             }
         }
 
         public override void Destroy(DestroyMode mode = DestroyMode.Vanish)
         {
-            Map map = base.Map;
+            Map map = Map;
             base.Destroy(mode);
             InstallBlueprintUtility.CancelBlueprintsFor(this);
             if (mode == DestroyMode.Deconstruct)
             {
-                SoundDef.Named("Building_Deconstructed").PlayOneShot(new TargetInfo(base.Position, map, false));
+                SoundDef.Named("Building_Deconstructed").PlayOneShot(new TargetInfo(Position, map));
             }
         }
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_LightningTrap.cs
@@ -1,19 +1,13 @@
-﻿using System;
-using RimWorld;
+﻿using RimWorld;
 using Verse;
 using Verse.Sound;
-using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
-using Verse.AI;
-using Verse.AI.Group;
 
 namespace TorannMagic
 {
     public class Building_LightningTrap : Building_ExplosiveProximityTrap
     {
-        public bool extendedTrap = false;
-        public bool iceTrap = false;
+        public bool extendedTrap;
+        public bool iceTrap;
 
         public override void ExposeData()
         {
@@ -41,11 +35,11 @@ namespace TorannMagic
                     def = TorannMagicDefOf.FlyingObject_LightningTrap
                 };
                 FlyingObject_LightningTrap flyingObject = (FlyingObject_LightningTrap)GenSpawn.Spawn(TorannMagicDefOf.FlyingObject_LightningTrap, Position, Map);
-                flyingObject.Launch(p, this.Position.ToVector3Shifted(), t.Cell, eyeThing, this.Faction, null, speed);
+                flyingObject.Launch(p, Position.ToVector3Shifted(), t.Cell, eyeThing, Faction, null, speed);
             }
             if(iceTrap)
             {
-                AddSnowRadial(this.Position, this.Map, 6, 1.1f);
+                AddSnowRadial(Position, Map, 6, 1.1f);
             }
         }
 
@@ -55,24 +49,22 @@ namespace TorannMagic
             for (int i = 0; i < num; i++)
             {
                 IntVec3 intVec = center + GenRadial.RadialPattern[i];
-                if (intVec.InBoundsWithNullCheck(map))
-                {
-                    float lengthHorizontal = (center - intVec).LengthHorizontal;
-                    float num2 = 1f - lengthHorizontal / radius;
-                    map.snowGrid.AddDepth(intVec, num2 * depth);
+                if (!intVec.InBoundsWithNullCheck(map)) continue;
 
-                }
+                float lengthHorizontal = (center - intVec).LengthHorizontal;
+                float num2 = 1f - lengthHorizontal / radius;
+                map.snowGrid.AddDepth(intVec, num2 * depth);
             }
         }
 
         public override void Destroy(DestroyMode mode = DestroyMode.Vanish)
         {
-            Map map = base.Map;
+            Map map = Map;
             base.Destroy(mode);
             InstallBlueprintUtility.CancelBlueprintsFor(this);
             if (mode == DestroyMode.Deconstruct)
             {
-                SoundDef.Named("Building_Deconstructed").PlayOneShot(new TargetInfo(base.Position, map, false));
+                SoundDef.Named("Building_Deconstructed").PlayOneShot(new TargetInfo(Position, map));
             }
         }
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
@@ -35,7 +35,6 @@ namespace TorannMagic
             Scribe_Values.Look<bool>(ref this.destroyAfterUse, "destroyAfterUse", false, false);
             Scribe_Values.Look<int>(ref this.age, "age", -1, false);
             Scribe_Values.Look<int>(ref this.duration, "duration", 600, false);
-            Scribe_Values.Look<int>(ref this.strikeDelay, "strikeDelay", 0, false);
             Scribe_Values.Look<int>(ref this.lastStrike, "lastStrike", 0, false);
             Scribe_Defs.Look<ThingDef>(ref this.fog, "fog");        
         }
@@ -151,7 +150,12 @@ namespace TorannMagic
                     Destroy();
                 }
             }
-            base.Tick();
+
+            // Explicitly doing something not great here since overall this little section being wrong is easier
+            // to maintain than the whole class having to repeat Building_Trap code. This is the code for ThingWithComps.Tick
+            // and we are skipping Building_ExplosiveProximityTrap.Tick and Building_Trap.Tick to avoid friendly trap trigger message.
+            for (int i = 0; i < AllComps.Count; i++)
+                AllComps[i].CompTick();
         }
 
         private void CheckForAgent()

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
@@ -197,39 +197,23 @@ namespace TorannMagic
             triggered = true;
         }
 
-        protected override float SpringChance(Pawn p)
+        protected override float UnclampedSpringChance(Pawn p)
         {
-            float num;
-            if (KnowsOfTrap(p))
-            {
-                num = 0.8f;
-            }
-            else
-            {
-                num = this.GetStatValue(StatDefOf.TrapSpringChance, true);
-            }
-            num *= GenMath.LerpDouble(0.4f, 0.8f, 0f, 1f, p.BodySize);
+            float num = base.UnclampedSpringChance(p);
             if (p.RaceProps.Animal)
-            {
                 num *= 0.1f;
-            }
-            return Mathf.Clamp01(num);
+            return num;
         }
 
         public new bool KnowsOfTrap(Pawn p)
         {
-            if (p.Faction != null && !p.Faction.HostileTo(Faction))
-            {
+            if (
+                p.Faction != null && !p.Faction.HostileTo(Faction)
+                || p.Faction == null && p.RaceProps.Animal && !p.InAggroMentalState
+                || p.guest != null && p.guest.Released
+            )
                 return true;
-            }
-            if (p.Faction == null && p.RaceProps.Animal && !p.InAggroMentalState)
-            {
-                return true;
-            }
-            if (p.guest != null && p.guest.Released)
-            {
-                return true;
-            }
+
             Lord lord = p.GetLord();
             return p.RaceProps.Humanlike && lord?.LordJob is LordJob_FormAndSendCaravan;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using RimWorld;
+﻿using RimWorld;
 using Verse;
 using Verse.Sound;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using Verse.AI;
 using Verse.AI.Group;
 
 namespace TorannMagic
@@ -13,17 +11,17 @@ namespace TorannMagic
     [StaticConstructorOnStartup]
     public class Building_PoisonTrap : Building_ExplosiveProximityTrap
     {
-        int age = -1;
-        int duration = 480;
-        int strikeDelay = 40;
-        int lastStrike = 0;
-        bool triggered = false;
-        float radius = 3f;
-        int ticksTillReArm = 15000;
-        bool rearming = false;
-        ThingDef fog;
+        private int age = -1;
+        private int duration = 480;
+        private int strikeDelay = 40;
+        private int lastStrike;
+        private bool triggered;
+        private const float radius = 3f;
+        private const int ticksTillReArm = 15000;
+        private bool rearming;
+        private ThingDef fog;
 
-        public bool destroyAfterUse = false;
+        public bool destroyAfterUse;
 
         private static readonly Material trap_rearming = MaterialPool.MatFrom("Other/PoisonTrap_rearming");
         private static readonly MaterialPropertyBlock MatPropertyBlock = new MaterialPropertyBlock();
@@ -48,7 +46,7 @@ namespace TorannMagic
             {
                 Matrix4x4 matrix = default(Matrix4x4);
                 matrix.SetTRS(DrawPos, Quaternion.identity, new Vector3(1f, 1f, 1f));   //drawer for beam
-                Graphics.DrawMesh(MeshPool.plane10, matrix, Building_PoisonTrap.trap_rearming, 0, null, 0, Building_PoisonTrap.MatPropertyBlock);
+                Graphics.DrawMesh(MeshPool.plane10, matrix, trap_rearming, 0, null, 0, MatPropertyBlock);
             }
             else
             {
@@ -182,11 +180,11 @@ namespace TorannMagic
 
         public override void Spring(Pawn p)
         {
-            SoundDef.Named("DeadfallSpring").PlayOneShot(new TargetInfo(base.Position, base.Map, false));
+            SoundDef.Named("DeadfallSpring").PlayOneShot(new TargetInfo(Position, Map));
             fog = TorannMagicDefOf.Fog_Poison;
             fog.gas.expireSeconds.min = duration / 60;
             fog.gas.expireSeconds.max = duration / 60;
-            GenExplosion.DoExplosion(Position, Map, radius, TMDamageDefOf.DamageDefOf.TM_Poison, this, 0, 0, SoundDef.Named("TinyBell"), def, null, null, fog, 1f, 1, false, null, 0f, 0, 0.0f, false);
+            GenExplosion.DoExplosion(Position, Map, radius, TMDamageDefOf.DamageDefOf.TM_Poison, this, 0, 0, SoundDef.Named("TinyBell"), def, null, null, fog, 1f, 1, false, null, 0f, 0);
             triggered = true;
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
@@ -64,22 +64,17 @@ namespace TorannMagic
                 {
                     try
                     {
-                        IntVec3 curCell;
                         IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(Position, radius, true);
-                        for (int i = 0; i < targets.Count(); i++)
+                        foreach (IntVec3 curCell in targets)
                         {
-                            curCell = targets.ToArray()[i];
+                            if (!curCell.InBounds(Map) || !curCell.IsValid) continue;
 
-                            if (curCell.InBounds(Map) && curCell.IsValid)
-                            {
-                                Pawn victim = curCell.GetFirstPawn(Map);
-                                if (victim != null && !victim.Dead && victim.RaceProps.IsFlesh)
-                                {
-                                    BodyPartRecord bpr = null;
-                                    bpr = victim.def.race.body.AllParts.InRandomOrder().FirstOrDefault(x => x.def.tags.Contains(BodyPartTagDefOf.BreathingSource));
-                                    TM_Action.DamageEntities(victim, bpr, Rand.Range(1f, 2f), 2f, TMDamageDefOf.DamageDefOf.TM_Poison, this);
-                                }
-                            }
+                            Pawn victim = curCell.GetFirstPawn(Map);
+                            if (victim == null || victim.Dead || !victim.RaceProps.IsFlesh) continue;
+
+                            BodyPartRecord bpr = victim.def.race.body.AllParts.InRandomOrder().FirstOrDefault(
+                                x => x.def.tags.Contains(BodyPartTagDefOf.BreathingSource));
+                            TM_Action.DamageEntities(victim, bpr, Rand.Range(1f, 2f), 2f, TMDamageDefOf.DamageDefOf.TM_Poison, this);
                         }
                     }
                     catch
@@ -122,30 +117,31 @@ namespace TorannMagic
                 { 
                     if (Armed)
                     {
-                        IntVec3 curCell;
-                        IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(base.Position, 2, true);
-                        for (int i = 0; i < targets.Count(); i++)
+                        IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(Position, 2, true);
+                        foreach (IntVec3 curCell in targets)
                         {
-                            curCell = targets.ToArray()[i];
-                            List<Thing> thingList = curCell.GetThingList(base.Map);
+                            List<Thing> thingList = curCell.GetThingList(Map);
                             for (int j = 0; j < thingList.Count; j++)
                             {
                                 Pawn pawn = thingList[j] as Pawn;
-                                if (pawn != null && !touchingPawns.Contains(pawn))
-                                {
-                                    if (!pawn.RaceProps.Animal && pawn.Faction != null && pawn.Faction != Faction && pawn.HostileTo(Faction))
-                                    {
-                                        touchingPawns.Add(pawn);
-                                        CheckSpring(pawn);
-                                    }
-                                }
+                                if (
+                                    pawn == null
+                                    || pawn.RaceProps.Animal
+                                    || pawn.Faction == null
+                                    || pawn.Faction == Faction
+                                    || !pawn.HostileTo(Faction)
+                                    || touchingPawns.Contains(pawn)
+                                )
+                                    continue;
+                                touchingPawns.Add(pawn);
+                                CheckSpring(pawn);
                             }
                         }
                     }
                     for (int j = 0; j < touchingPawns.Count; j++)
                     {
                         Pawn pawn2 = touchingPawns[j];
-                        if (!pawn2.Spawned || pawn2.Position != base.Position)
+                        if (!pawn2.Spawned || pawn2.Position != Position)
                         {
                             touchingPawns.Remove(pawn2);
                         }
@@ -164,19 +160,16 @@ namespace TorannMagic
         {
             destroyAfterUse = true;
             List<Pawn> pList = Map.mapPawns.AllPawnsSpawned;
-            if (pList != null && pList.Count > 0)
+            if (pList == null || pList.Count <= 0) return;
+            for (int i = 0; i < pList.Count; i++)
             {
-                for (int i = 0; i < pList.Count; i++)
+                Pawn p = pList[i];
+                CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
+                if (comp?.combatItems == null || comp.combatItems.Count <= 0) continue;
+
+                if(comp.combatItems.Contains(this))
                 {
-                    Pawn p = pList[i];
-                    CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
-                    if(comp?.combatItems != null && comp.combatItems.Count > 0)
-                    {
-                        if(comp.combatItems.Contains(this))
-                        {
-                            destroyAfterUse = false;
-                        }
-                    }
+                    destroyAfterUse = false;
                 }
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
@@ -11,15 +11,8 @@ using Verse.AI.Group;
 namespace TorannMagic
 {
     [StaticConstructorOnStartup]
-    public class Building_PoisonTrap : Building
+    public class Building_PoisonTrap : Building_ExplosiveProximityTrap
     {
-        private List<Pawn> touchingPawns = new List<Pawn>();
-
-        private const float KnowerSpringChance = 0.004f;
-        private const ushort KnowerPathFindCost = 800;
-        private const ushort KnowerPathWalkCost = 30;
-        private const float AnimalSpringChanceFactor = 0.1f;
-
         int age = -1;
         int duration = 480;
         int strikeDelay = 40;
@@ -34,14 +27,6 @@ namespace TorannMagic
 
         private static readonly Material trap_rearming = MaterialPool.MatFrom("Other/PoisonTrap_rearming");
         private static readonly MaterialPropertyBlock MatPropertyBlock = new MaterialPropertyBlock();
-
-        public virtual bool Armed
-        {
-            get
-            {
-                return true;
-            }
-        }
 
         public override void ExposeData()
         {
@@ -62,7 +47,7 @@ namespace TorannMagic
             if (rearming)
             {
                 Matrix4x4 matrix = default(Matrix4x4);
-                matrix.SetTRS(this.DrawPos, Quaternion.identity, new Vector3(1f, 1f, 1f));   //drawer for beam
+                matrix.SetTRS(DrawPos, Quaternion.identity, new Vector3(1f, 1f, 1f));   //drawer for beam
                 Graphics.DrawMesh(MeshPool.plane10, matrix, Building_PoisonTrap.trap_rearming, 0, null, 0, Building_PoisonTrap.MatPropertyBlock);
             }
             else
@@ -73,25 +58,25 @@ namespace TorannMagic
 
         public override void Tick()
         {
-            if (this.triggered)
+            if (triggered)
             {
-                if(this.age >= this.lastStrike + this.strikeDelay)
+                if(age >= lastStrike + strikeDelay)
                 {
                     try
                     {
                         IntVec3 curCell;
-                        IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(base.Position, this.radius, true);
+                        IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(Position, radius, true);
                         for (int i = 0; i < targets.Count(); i++)
                         {
-                            curCell = targets.ToArray<IntVec3>()[i];
+                            curCell = targets.ToArray()[i];
 
-                            if (curCell.InBounds(base.Map) && curCell.IsValid)
+                            if (curCell.InBounds(Map) && curCell.IsValid)
                             {
-                                Pawn victim = curCell.GetFirstPawn(base.Map);
+                                Pawn victim = curCell.GetFirstPawn(Map);
                                 if (victim != null && !victim.Dead && victim.RaceProps.IsFlesh)
                                 {
                                     BodyPartRecord bpr = null;
-                                    bpr = victim.def.race.body.AllParts.InRandomOrder().FirstOrDefault<BodyPartRecord>((BodyPartRecord x) => x.def.tags.Contains(BodyPartTagDefOf.BreathingSource));
+                                    bpr = victim.def.race.body.AllParts.InRandomOrder().FirstOrDefault(x => x.def.tags.Contains(BodyPartTagDefOf.BreathingSource));
                                     TM_Action.DamageEntities(victim, bpr, Rand.Range(1f, 2f), 2f, TMDamageDefOf.DamageDefOf.TM_Poison, this);
                                 }
                             }
@@ -100,12 +85,12 @@ namespace TorannMagic
                     catch
                     {
                         Log.Message("Debug: poison trap failed to process triggered event - terminating poison trap");
-                        this.Destroy(DestroyMode.Vanish);
+                        Destroy();
                     }
-                    this.lastStrike = this.age;
+                    lastStrike = age;
                 }
-                this.age++;
-                if(this.age > this.duration)
+                age++;
+                if(age > duration)
                 {
                     CheckForAgent();
                     if(destroyAfterUse)
@@ -114,19 +99,19 @@ namespace TorannMagic
                     }
                     else
                     {
-                        this.age = 0;
+                        age = 0;
                         triggered = false;
                         rearming = true;
-                        this.lastStrike = 0;
+                        lastStrike = 0;
                     }
                 }
             }
             else if(rearming)
             {
-                this.age++;
-                if(this.age > this.ticksTillReArm)
+                age++;
+                if(age > ticksTillReArm)
                 {
-                    this.age = 0;
+                    age = 0;
                     rearming = false;
                     triggered = false;
                 }
@@ -135,41 +120,41 @@ namespace TorannMagic
             {
                 try
                 { 
-                    if (this.Armed)
+                    if (Armed)
                     {
                         IntVec3 curCell;
                         IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(base.Position, 2, true);
                         for (int i = 0; i < targets.Count(); i++)
                         {
-                            curCell = targets.ToArray<IntVec3>()[i];
+                            curCell = targets.ToArray()[i];
                             List<Thing> thingList = curCell.GetThingList(base.Map);
                             for (int j = 0; j < thingList.Count; j++)
                             {
                                 Pawn pawn = thingList[j] as Pawn;
-                                if (pawn != null && !this.touchingPawns.Contains(pawn))
+                                if (pawn != null && !touchingPawns.Contains(pawn))
                                 {
-                                    if (!pawn.RaceProps.Animal && pawn.Faction != null && pawn.Faction != this.Faction && pawn.HostileTo(this.Faction))
+                                    if (!pawn.RaceProps.Animal && pawn.Faction != null && pawn.Faction != Faction && pawn.HostileTo(Faction))
                                     {
-                                        this.touchingPawns.Add(pawn);
-                                        this.CheckSpring(pawn);
+                                        touchingPawns.Add(pawn);
+                                        CheckSpring(pawn);
                                     }
                                 }
                             }
                         }
                     }
-                    for (int j = 0; j < this.touchingPawns.Count; j++)
+                    for (int j = 0; j < touchingPawns.Count; j++)
                     {
-                        Pawn pawn2 = this.touchingPawns[j];
+                        Pawn pawn2 = touchingPawns[j];
                         if (!pawn2.Spawned || pawn2.Position != base.Position)
                         {
-                            this.touchingPawns.Remove(pawn2);
+                            touchingPawns.Remove(pawn2);
                         }
                     }
                 }
                 catch
                 {
                     Log.Message("Debug: poison trap failed to process armed event - terminating poison trap");
-                    this.Destroy(DestroyMode.Vanish);
+                    Destroy();
                 }
             }
             base.Tick();
@@ -177,55 +162,45 @@ namespace TorannMagic
 
         private void CheckForAgent()
         {
-            this.destroyAfterUse = true;
-            List<Pawn> pList = this.Map.mapPawns.AllPawnsSpawned;
+            destroyAfterUse = true;
+            List<Pawn> pList = Map.mapPawns.AllPawnsSpawned;
             if (pList != null && pList.Count > 0)
             {
                 for (int i = 0; i < pList.Count; i++)
                 {
                     Pawn p = pList[i];
                     CompAbilityUserMight comp = p.TryGetComp<CompAbilityUserMight>();
-                    if(comp != null && comp.combatItems != null && comp.combatItems.Count > 0)
+                    if(comp?.combatItems != null && comp.combatItems.Count > 0)
                     {
                         if(comp.combatItems.Contains(this))
                         {
-                            this.destroyAfterUse = false;
+                            destroyAfterUse = false;
                         }
                     }
                 }
             }
         }
 
-        private void CheckSpring(Pawn p)
+        protected override void CheckSpring(Pawn p)
         {
-            if (Rand.Value < this.SpringChance(p))
-            {
-                this.Spring(p);
-                //if (p.Faction == Faction.OfPlayer || p.HostFaction == Faction.OfPlayer)
-                //{
-                //    Find.LetterStack.ReceiveLetter("LetterFriendlyTrapSprungLabel".Translate(
-                //        p.LabelShort
-                //    ), "LetterFriendlyTrapSprung".Translate(
-                //        p.LabelShort
-                //    ), LetterDefOf.NegativeEvent, new TargetInfo(base.Position, base.Map, false), null);
-                //}
-            }
+            if (Rand.Value < SpringChance(p))
+                Spring(p);
         }
 
-        public void Spring(Pawn p)
+        public override void Spring(Pawn p)
         {
             SoundDef.Named("DeadfallSpring").PlayOneShot(new TargetInfo(base.Position, base.Map, false));
             fog = TorannMagicDefOf.Fog_Poison;
-            fog.gas.expireSeconds.min = this.duration / 60;
-            fog.gas.expireSeconds.max = this.duration / 60;
-            GenExplosion.DoExplosion(base.Position, base.Map, this.radius, TMDamageDefOf.DamageDefOf.TM_Poison, this, 0, 0, SoundDef.Named("TinyBell"), def, null, null, fog, 1f, 1, false, null, 0f, 0, 0.0f, false);
-            this.triggered = true;
+            fog.gas.expireSeconds.min = duration / 60;
+            fog.gas.expireSeconds.max = duration / 60;
+            GenExplosion.DoExplosion(Position, Map, radius, TMDamageDefOf.DamageDefOf.TM_Poison, this, 0, 0, SoundDef.Named("TinyBell"), def, null, null, fog, 1f, 1, false, null, 0f, 0, 0.0f, false);
+            triggered = true;
         }
 
-        protected virtual float SpringChance(Pawn p)
+        protected override float SpringChance(Pawn p)
         {
             float num;
-            if (this.KnowsOfTrap(p))
+            if (KnowsOfTrap(p))
             {
                 num = 0.8f;
             }
@@ -241,9 +216,9 @@ namespace TorannMagic
             return Mathf.Clamp01(num);
         }
 
-        public bool KnowsOfTrap(Pawn p)
+        public new bool KnowsOfTrap(Pawn p)
         {
-            if (p.Faction != null && !p.Faction.HostileTo(base.Faction))
+            if (p.Faction != null && !p.Faction.HostileTo(Faction))
             {
                 return true;
             }
@@ -256,67 +231,12 @@ namespace TorannMagic
                 return true;
             }
             Lord lord = p.GetLord();
-            return p.RaceProps.Humanlike && lord != null && lord.LordJob is LordJob_FormAndSendCaravan;
-        }
-
-        public override ushort PathFindCostFor(Pawn p)
-        {
-            if (!this.Armed)
-            {
-                return 0;
-            }
-            if (this.KnowsOfTrap(p))
-            {
-                return 800;
-            }
-            return 0;
-        }
-
-        public override ushort PathWalkCostFor(Pawn p)
-        {
-            if (!this.Armed)
-            {
-                return 0;
-            }
-            if (this.KnowsOfTrap(p))
-            {
-                return 30;
-            }
-            return 0;
+            return p.RaceProps.Humanlike && lord?.LordJob is LordJob_FormAndSendCaravan;
         }
 
         public override bool IsDangerousFor(Pawn p)
         {
-            return this.Armed && this.KnowsOfTrap(p);
-        }
-
-        public override string GetInspectString()
-        {
-            string text = base.GetInspectString();
-            if (!text.NullOrEmpty())
-            {
-                text += "\n";
-            }
-            if (this.Armed)
-            {
-                text += "Trap Armed";
-            }
-            else
-            {
-                text += "Trap Not Armed";
-            }
-            return text;
-        }        
-
-        public override void Destroy(DestroyMode mode = DestroyMode.Vanish)
-        {
-            Map map = base.Map;
-            base.Destroy(mode);
-            InstallBlueprintUtility.CancelBlueprintsFor(this);
-            if (mode == DestroyMode.Deconstruct)
-            {
-                SoundDef.Named("Building_Deconstructed").PlayOneShot(new TargetInfo(base.Position, map, false));
-            }
+            return Armed && KnowsOfTrap(p);
         }
     }
 }


### PR DESCRIPTION
This one is a bit weird as it's more of a design edit than anything else trying to make it easier to find any bugs and easier to make changes if you decide to do so. Since there was a lot of repeated code shared between the traps, I wanted to make an abstract base class. Turns out that ended up being identical to Building_ExplosiveProximityTrap, so I just made that the base class for the others. 

Now I will say technically your code is more correct that PoisonTrap is NOT a child of ExplosiveProximityTrap because its Tick requires skipping of some its base invocations to ThingWithComps Tick call. However the workaround is such little code that is unlikely to change, I figured this would be the easier to maintain option (it's literally two lines that I commented noticeably in the code).

Essentially this is following the general recommendation: less lines of code = less opportunities for bugs (as long as readability is maintained)