### PR TITLE
Fix key error

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/TM_ClassUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_ClassUtility.cs
@@ -33,68 +33,71 @@ namespace TorannMagic
 
         public static void LoadCustomClasses()
         {
-            if (TM_CustomClassDef.Named("TM_CustomClasses") != null)
-            {
-                CustomClasses = TM_CustomClassDef.Named("TM_CustomClasses").customClasses;
-                //CustomAdvancedClassTraitIndexMap.Clear();
-                //var CustomBaseClassesList = new List<TM_CustomClass>();
-                //var CustomMageClassesList = new List<TM_CustomClass>();
-                //var CustomFighterClassesList = new List<TM_CustomClass>();
-                //var CustomAdvancedClassesList = new List<TM_CustomClass>();
-                CustomBaseClasses.Clear();
-                CustomMageClasses.Clear();
-                CustomFighterClasses.Clear();
-                CustomAdvancedClasses.Clear();
+            TM_CustomClassDef named = TM_CustomClassDef.Named("TM_CustomClasses");
+            if (named == null) return;
 
-                foreach (TM_CustomClass cc in CustomClasses.Where(cc => Settings.Instance.CustomClass[cc.classTrait.ToString()]))
+            CustomClasses = named.customClasses;
+            //CustomAdvancedClassTraitIndexMap.Clear();
+            //var CustomBaseClassesList = new List<TM_CustomClass>();
+            //var CustomMageClassesList = new List<TM_CustomClass>();
+            //var CustomFighterClassesList = new List<TM_CustomClass>();
+            //var CustomAdvancedClassesList = new List<TM_CustomClass>();
+            CustomBaseClasses.Clear();
+            CustomMageClasses.Clear();
+            CustomFighterClasses.Clear();
+            CustomAdvancedClasses.Clear();
+
+            // Get all custom classes that are enabled, defaulting to enabled if we can't find the saved setting.
+            IEnumerable<TM_CustomClass> enabledCustomClasses = CustomClasses.Where(cc =>
+                Settings.Instance.CustomClass.TryGetValue(cc.classTrait.ToString(), true));
+
+            foreach (TM_CustomClass cc in enabledCustomClasses)
+            {
+                if (cc.isMage)
                 {
-                    if (cc.isMage)
+                    if (cc.isAdvancedClass)
                     {
-                        if (cc.isAdvancedClass)
-                        {
-                            if (cc.advancedClassOptions != null && cc.advancedClassOptions.canSpawnWithClass)
-                            {
-                                CustomMageClasses.Add(cc);
-                            }
-                        }
-                        else
+                        if (cc.advancedClassOptions != null && cc.advancedClassOptions.canSpawnWithClass)
                         {
                             CustomMageClasses.Add(cc);
                         }
                     }
-                    if (cc.isFighter)
+                    else
                     {
-                        if (cc.isAdvancedClass)
-                        {
-                            if (cc.advancedClassOptions != null && cc.advancedClassOptions.canSpawnWithClass)
-                            {
-                                CustomFighterClasses.Add(cc);
-                            }
-                        }
-                        else
+                        CustomMageClasses.Add(cc);
+                    }
+                }
+                if (cc.isFighter)
+                {
+                    if (cc.isAdvancedClass)
+                    {
+                        if (cc.advancedClassOptions != null && cc.advancedClassOptions.canSpawnWithClass)
                         {
                             CustomFighterClasses.Add(cc);
                         }
                     }
-                    if (!cc.isAdvancedClass) CustomBaseClasses.Add(cc); //base classes cannot also be advanced classes, but advanced classes can act like base classes
                     else
                     {
-                        CustomAdvancedClasses.Add(cc);
-                        //CustomAdvancedClassTraitIndexMap[cc.classTrait.index] = cc;
+                        CustomFighterClasses.Add(cc);
                     }
-                    //CustomBaseClasses = CustomBaseClassesList.ToArray();
-                    //CustomFighterClasses = CustomFighterClassesList.ToArray();
-                    //CustomMageClasses = CustomMageClassesList.ToArray();
-                    //CustomAdvancedClasses = CustomAdvancedClassesList.ToArray();
                 }
-                LoadClassIndexes();
+                if (!cc.isAdvancedClass) CustomBaseClasses.Add(cc); //base classes cannot also be advanced classes, but advanced classes can act like base classes
+                else
+                {
+                    CustomAdvancedClasses.Add(cc);
+                    //CustomAdvancedClassTraitIndexMap[cc.classTrait.index] = cc;
+                }
+                //CustomBaseClasses = CustomBaseClassesList.ToArray();
+                //CustomFighterClasses = CustomFighterClassesList.ToArray();
+                //CustomMageClasses = CustomMageClassesList.ToArray();
+                //CustomAdvancedClasses = CustomAdvancedClassesList.ToArray();
             }
+            LoadClassIndexes();
         }
 
         public static void LoadClassIndexes()
         {
             CustomClassTraitIndexes = new Dictionary<ushort, int>();
-            CustomClassTraitIndexes.Clear();
             for (int i = 0; i < CustomClasses.Count; i++)
             {
                 CustomClassTraitIndexes[CustomClasses[i].classTrait.index] = i;


### PR DESCRIPTION
* Main change is if we can't find a saved setting on whether the class is enabled or not, just make it enabled. The other place this could be wrong is in the Settings instance declaration Possessor is not anywhere to be found. Regardless, I like having the default.
* Invert the if statement for less nesting, and put the named into a variable since that's an expensive grab.
* Don't clear the new dictionary. It doesn't do anything since a new dictionary is ALWAYS empty unless a different initializer is used.