### PR TITLE
Clean up ability worker target corpse.cs

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
@@ -9,14 +9,12 @@ namespace TorannMagic
     {
         public override LocalTargetInfo TargetAbilityFor(AbilityAIDef abilityDef, Pawn pawn)
         {
-            Corpse corpse = PickClosestCorpse(abilityDef, pawn);
-            return corpse ?? base.TargetAbilityFor(abilityDef, pawn);
+            return PickClosestCorpse(abilityDef, pawn) ?? base.TargetAbilityFor(abilityDef, pawn);
         }
 
         public override bool CanPawnUseThisAbility(AbilityAIDef abilityDef, Pawn pawn, LocalTargetInfo target)
         {
-            Corpse corpse = PickClosestCorpse(abilityDef, pawn);
-            return corpse != null && base.CanPawnUseThisAbility(abilityDef, pawn, target);
+            return PickClosestCorpse(abilityDef, pawn) != null && base.CanPawnUseThisAbility(abilityDef, pawn, target);
         }
 
         public virtual Corpse PickClosestCorpse(AbilityAIDef abilityDef, Pawn pawn)

--- a/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
@@ -19,23 +19,10 @@ namespace TorannMagic
 
         public virtual Corpse PickClosestCorpse(AbilityAIDef abilityDef, Pawn pawn)
         {
-            foreach (IntVec3 curCell in GenRadial.RadialCellsAround(pawn.TargetCurrentlyAimingAt.Cell, 6f, true))
-            {
-                if (!curCell.InBoundsWithNullCheck(pawn.Map) || !curCell.IsValid) continue;
-
-                Corpse corpse = curCell.GetThingList(pawn.Map).OfType<Corpse>().FirstOrDefault();
-                if (corpse != null) return corpse;
-            }
-
-            foreach (IntVec3 curCell in GenRadial.RadialCellsAround(pawn.Position, 6f, true))
-            {
-                if (!curCell.InBoundsWithNullCheck(pawn.Map) || !curCell.IsValid) continue;
-
-                Corpse corpse = curCell.GetThingList(pawn.Map).OfType<Corpse>().FirstOrDefault();
-                if (corpse != null) return corpse;
-            }
-
-            return null;
+            return GenRadial.RadialCellsAround(pawn.Position, 6f, true)
+                .Where(cell => cell.InBoundsWithNullCheck(pawn.Map) && cell.IsValid)
+                .Select(cell => cell.GetThingList(pawn.Map).OfType<Corpse>().FirstOrDefault())
+                .FirstOrDefault(corpse => corpse != null);
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AbilityWorker_TargetCorpse.cs
@@ -9,82 +9,35 @@ namespace TorannMagic
     {
         public override LocalTargetInfo TargetAbilityFor(AbilityAIDef abilityDef, Pawn pawn)
         {
-            Corpse corpse = this.PickClosestCorpse(abilityDef, pawn);
-            bool flag = corpse == null;
-            LocalTargetInfo result;
-            if (flag)
-            {
-                result = base.TargetAbilityFor(abilityDef, pawn);
-            }
-            else
-            {
-                result = corpse;
-            }
-            return result;
+            Corpse corpse = PickClosestCorpse(abilityDef, pawn);
+            return corpse ?? base.TargetAbilityFor(abilityDef, pawn);
         }
 
         public override bool CanPawnUseThisAbility(AbilityAIDef abilityDef, Pawn pawn, LocalTargetInfo target)
         {
-            Corpse corpse = this.PickClosestCorpse(abilityDef, pawn);
-            bool flag = corpse == null;
-            return !flag && base.CanPawnUseThisAbility(abilityDef, pawn, target);
+            Corpse corpse = PickClosestCorpse(abilityDef, pawn);
+            return corpse != null && base.CanPawnUseThisAbility(abilityDef, pawn, target);
         }
 
         public virtual Corpse PickClosestCorpse(AbilityAIDef abilityDef, Pawn pawn)
         {
-            Corpse corpse = null;
-            Thing corpseThing = null;
-
-            IntVec3 curCell;
-            IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(pawn.Position, 6f, true);
-            for (int i = 0; i < targets.Count(); i++)
+            foreach (IntVec3 curCell in GenRadial.RadialCellsAround(pawn.TargetCurrentlyAimingAt.Cell, 6f, true))
             {
-                curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBoundsWithNullCheck(pawn.Map) && curCell.IsValid)
-                {
-                    List<Thing> thingList;
-                    thingList = curCell.GetThingList(pawn.Map);
-                    int z = 0;
-                    while (z < thingList.Count)
-                    {
-                        corpseThing = thingList[z];
-                        if (corpseThing != null)
-                        {
-                            bool validator = corpseThing is Corpse;
-                            if (validator)
-                            {
-                                corpse = corpseThing as Corpse;
-                            }                            
-                        }
-                    }
-                }
+                if (!curCell.InBoundsWithNullCheck(pawn.Map) || !curCell.IsValid) continue;
+
+                Corpse corpse = curCell.GetThingList(pawn.Map).OfType<Corpse>().FirstOrDefault();
+                if (corpse != null) return corpse;
             }
 
-            IEnumerable<IntVec3> targetsD = GenRadial.RadialCellsAround(pawn.TargetCurrentlyAimingAt.Cell, 6f, true);
-            for (int i = 0; i < targets.Count(); i++)
+            foreach (IntVec3 curCell in GenRadial.RadialCellsAround(pawn.Position, 6f, true))
             {
-                curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBoundsWithNullCheck(pawn.Map) && curCell.IsValid)
-                {
-                    List<Thing> thingList;
-                    thingList = curCell.GetThingList(pawn.Map);
-                    int z = 0;
-                    while (z < thingList.Count)
-                    {
-                        corpseThing = thingList[z];
-                        if (corpseThing != null)
-                        {
-                            bool validator = corpseThing is Corpse;
-                            if (validator)
-                            {
-                                corpse = corpseThing as Corpse;
-                            }
-                        }
-                    }
-                }
+                if (!curCell.InBoundsWithNullCheck(pawn.Map) || !curCell.IsValid) continue;
+
+                Corpse corpse = curCell.GetThingList(pawn.Map).OfType<Corpse>().FirstOrDefault();
+                if (corpse != null) return corpse;
             }
 
-            return corpse;
+            return null;
         }
     }
 }


### PR DESCRIPTION
Definitely double check PickClosestCorpse. I couldn't actually determine what it was supposed to be doing since it looks like it might land in an infinite loop (maybe ThingList is shrinking somehow?) and it definitely was not using the variable targetsD.  I believe I did end up with the same intended behavior though of grab the corpse from nearby the caster. 

If it is supposed to look at the aiming at location, copy the LINQ return statement here currently then put it above and change out the pawn.Position to be pawn.TargetCurrentlyAimingAt.Cell, put it into a variable, return it if it is not null, otherwise return whats here in the PR already.