### PR TITLE
Change DoExplosion to use named args rather than relying on Position (1.4 compatibility without affecting 1.3)

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_PoisonTrap.cs
@@ -190,7 +190,15 @@ namespace TorannMagic
             fog = TorannMagicDefOf.Fog_Poison;
             fog.gas.expireSeconds.min = this.duration / 60;
             fog.gas.expireSeconds.max = this.duration / 60;
-            GenExplosion.DoExplosion(base.Position, base.Map, this.radius, TMDamageDefOf.DamageDefOf.TM_Poison, this, 0, 0, SoundDef.Named("TinyBell"), def, null, null, fog, 1f, 1, false, null, 0f, 0, 0.0f, false);
+            GenExplosion.DoExplosion(
+                Position, Map, radius, TMDamageDefOf.DamageDefOf.TM_Poison, this,
+                damAmount: 0,
+                armorPenetration: 0,
+                explosionSound: SoundDef.Named("TinyBell"),
+                weapon: def,
+                postExplosionSpawnThingDef: fog,
+                postExplosionSpawnChance: 1f
+            );
             this.triggered = true;
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift.cs
@@ -200,7 +200,14 @@ namespace TorannMagic
             {                
                 FindGoodCenterLocation();
                 Map.weatherManager.eventHandler.AddEvent(new WeatherEvent_LightningStrike(this.Map, this.centerLocation.ToIntVec3));
-                GenExplosion.DoExplosion(this.centerLocation.ToIntVec3, this.Map, this.areaRadius, DamageDefOf.Bomb, null, Rand.Range(6, 16), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+                GenExplosion.DoExplosion(
+                    centerLocation.ToIntVec3, Map, areaRadius, DamageDefOf.Bomb, null,
+                    damAmount: Rand.Range(6, 16),
+                    armorPenetration: 0,
+                    explosionSound: SoundDefOf.Thunder_OffMap,
+                    chanceToStartFire: 0.1f,
+                    damageFalloff: true
+                );
 
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift_Defenders.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift_Defenders.cs
@@ -204,8 +204,14 @@ namespace TorannMagic
             {                
                 FindGoodCenterLocation();
                 Map.weatherManager.eventHandler.AddEvent(new WeatherEvent_LightningStrike(this.Map, this.centerLocation.ToIntVec3));
-                GenExplosion.DoExplosion(this.centerLocation.ToIntVec3, this.Map, this.areaRadius, DamageDefOf.Bomb, null, Rand.Range(6, 16), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
-
+                GenExplosion.DoExplosion(
+                    centerLocation.ToIntVec3, Map, areaRadius, DamageDefOf.Bomb, null,
+                    damAmount: Rand.Range(6, 16),
+                    armorPenetration: 0,
+                    explosionSound: SoundDefOf.Thunder_OffMap,
+                    chanceToStartFire: 0.1f,
+                    damageFalloff: true
+                );
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMPowerNode.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMPowerNode.cs
@@ -63,10 +63,18 @@ namespace TorannMagic
                     Pawn e = TM_Calc.FindNearbyEnemy(this.Position, this.Map, this.factionInt, 20, 0);
                     if (e != null && TM_Calc.HasLoSFromTo(this.Position, e, this, 0, 20))
                     {
-                        GenExplosion.DoExplosion(e.Position, this.Map, .4f, DamageDefOf.Stun, this, 4, 1f);
+                        GenExplosion.DoExplosion(
+                            e.Position, Map, .4f, DamageDefOf.Stun, this,
+                            damAmount: 4,
+                            armorPenetration: 1f
+                        );
                         if (e.RaceProps.IsMechanoid || TM_Calc.IsRobotPawn(e))
                         {
-                            GenExplosion.DoExplosion(e.Position, this.Map, .4f, TMDamageDefOf.DamageDefOf.TM_ElectricalBurn, this, 8, 1f);
+                            GenExplosion.DoExplosion(
+                                e.Position, Map, .4f, TMDamageDefOf.DamageDefOf.TM_ElectricalBurn, this,
+                                damAmount: 8,
+                                armorPenetration: 1f
+                            );
                         }
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TechnoTurret.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TechnoTurret.cs
@@ -226,7 +226,12 @@ namespace TorannMagic
                     rndPos.z += Rand.Range(-.5f, .5f);
                     TM_MoteMaker.ThrowGenericFleck(TorannMagicDefOf.ElectricalSpark, rndPos, this.Map, Rand.Range(.4f, .7f), .2f, .05f, .1f, 0, 0, 0, Rand.Range(0, 360));
                 }
-                GenExplosion.DoExplosion(this.Position, this.Map, 1f, DamageDefOf.EMP, this, 0, 0, SoundDefOf.Crunch, null, null, this, null, 0, 0, false, null, 0, 0, 0, false);
+                GenExplosion.DoExplosion(
+                    Position, Map, 1f, DamageDefOf.EMP, this,
+                    damAmount: 0,
+                    armorPenetration: 0,
+                    explosionSound: SoundDefOf.Crunch
+                );
                 this.Destroy(DestroyMode.Vanish);
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
@@ -102,7 +102,12 @@ namespace TorannMagic
                 {
                     if(isExplosion)
                     {
-                        GenExplosion.DoExplosion(curCell, this.Pawn.Map, .4f, damageType, this.Pawn, damageAmount, Rand.Range(0, damageAmount), TorannMagicDefOf.TM_SoftExplosion, null, null, null, null, 0f, 1, false, null, 0f, 0, 0.0f, false);
+                        GenExplosion.DoExplosion(
+                            curCell, Pawn.Map, .4f, damageType, Pawn,
+                            damAmount: damageAmount,
+                            armorPenetration: Rand.Range(0, damageAmount),
+                            explosionSound: TorannMagicDefOf.TM_SoftExplosion
+                        );
                     }
                     else
                     {
@@ -452,7 +457,13 @@ namespace TorannMagic
                         {
                             CellRect cellRect = CellRect.CenteredOn(this.Pawn.Position, 3);
                             cellRect.ClipInsideMap(this.Pawn.Map);
-                            GenExplosion.DoExplosion(cellRect.RandomCell, this.Pawn.Map, 2f, DamageDefOf.Burn, this.Pawn, Rand.Range(6, 12), -1, DamageDefOf.Bomb.soundExplosion, null, null, null, null, 0f, 1, false, null, 0f, 0, 0.2f, true);
+                            GenExplosion.DoExplosion(
+                                cellRect.RandomCell, Pawn.Map, 2f, DamageDefOf.Burn, Pawn,
+                                damAmount: Rand.Range(6, 12),
+                                explosionSound: DamageDefOf.Bomb.soundExplosion,
+                                chanceToStartFire: 0.2f,
+                                damageFalloff: true
+                            );
                             DamageEntities(this.Pawn, 10f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.Pawn);
                             deathOnce = true;
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/CompLeaper.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompLeaper.cs
@@ -150,7 +150,11 @@ namespace TorannMagic
                 {
                     if (this.Pawn.Downed && !this.Pawn.Dead)
                     {
-                        GenExplosion.DoExplosion(this.Pawn.Position, this.Pawn.Map, Rand.Range(this.explosionRadius * .5f, this.explosionRadius * 1.5f), DamageDefOf.Burn, this.Pawn, Rand.Range(6, 10), 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                        GenExplosion.DoExplosion(
+                            Pawn.Position, Pawn.Map, Rand.Range(explosionRadius * .5f, explosionRadius * 1.5f), DamageDefOf.Burn, Pawn,
+                            damAmount: Rand.Range(6, 10),
+                            armorPenetration: 0
+                        );
                         this.Pawn.Kill(null, null);
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
@@ -220,7 +220,12 @@ namespace TorannMagic
                     {
                         if (isExplosion)
                         {
-                            GenExplosion.DoExplosion(curCell, this.Pawn.Map, .4f, damageType, this.Pawn, damageAmount, Rand.Range(0, damageAmount), TorannMagicDefOf.TM_SoftExplosion, null, null, null, null, 0f, 1, false, null, 0f, 0, 0.0f, false);
+                            GenExplosion.DoExplosion(
+                                curCell, Pawn.Map, .4f, damageType, Pawn,
+                                damAmount: damageAmount,
+                                armorPenetration: Rand.Range(0, damageAmount),
+                                explosionSound: TorannMagicDefOf.TM_SoftExplosion
+                            );
                         }
                         else
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/DeathWorker_Poppi.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/DeathWorker_Poppi.cs
@@ -31,7 +31,10 @@ namespace TorannMagic
                     radius = radius * Rand.Range(1.5f, 2f);
                 }
             }
-            GenExplosion.DoExplosion(corpse.Position, corpse.Map, radius, DamageDefOf.Burn, corpse.InnerPawn, Rand.Range(12, 16));
+            GenExplosion.DoExplosion(
+                corpse.Position, corpse.Map, radius, DamageDefOf.Burn, corpse.InnerPawn,
+                damAmount: Rand.Range(12, 16)
+            );
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced.cs
@@ -420,7 +420,13 @@ namespace TorannMagic
                 {
                     if(this.isExplosive)
                     {
-                        GenExplosion.DoExplosion(this.ExactPosition.ToIntVec3(), this.Map, this.impactRadius, this.impactDamageType, this.launcher as Pawn, this.explosionDamage, -1, this.impactDamageType.soundExplosion, def, null, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+                        GenExplosion.DoExplosion(
+                            ExactPosition.ToIntVec3(), Map, impactRadius, impactDamageType, launcher as Pawn,
+                            damAmount: explosionDamage,
+                            explosionSound: impactDamageType.soundExplosion,
+                            weapon: def,
+                            damageFalloff: true
+                        );
                     }
                     else
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced_Icebolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Advanced_Icebolt.cs
@@ -15,7 +15,14 @@ namespace TorannMagic
         {
             Map map = base.Map;
             Pawn pawn = this.launcher as Pawn;
-            GenExplosion.DoExplosion(base.Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Iceshard, this.launcher, Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1, null)), 0, this.def.projectile.soundExplode, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+            GenExplosion.DoExplosion(
+                Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Iceshard, launcher,
+                damAmount: Mathf.RoundToInt(def.projectile.GetDamageAmount(1)),
+                armorPenetration: 0,
+                explosionSound: def.projectile.soundExplode,
+                weapon: def,
+                projectile: equipmentDef
+            );
             CellRect cellRect = CellRect.CenteredOn(base.Position, 2);
             cellRect.ClipInsideMap(map);
             for (int i = 0; i < 3; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DeathBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DeathBolt.cs
@@ -277,7 +277,14 @@ namespace TorannMagic
                         spreadingDarknessCell = cellRect.RandomCell;
                         if (spreadingDarknessCell.InBoundsWithNullCheck(base.Map) && spreadingDarknessCell.IsValid)
                         {
-                            GenExplosion.DoExplosion(spreadingDarknessCell, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_DeathBolt, this.pawn, Mathf.RoundToInt((Rand.Range(.4f * this.def.projectile.GetDamageAmount(1, null), .8f * this.def.projectile.GetDamageAmount(1, null)) + (3f * pwrVal)) * this.arcaneDmg), 2, this.def.projectile.soundExplode, def, null, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+                            GenExplosion.DoExplosion(
+                                spreadingDarknessCell, Map, .4f, TMDamageDefOf.DamageDefOf.TM_DeathBolt, pawn,
+                                damAmount: Mathf.RoundToInt((Rand.Range(.4f * def.projectile.GetDamageAmount(1), .8f * def.projectile.GetDamageAmount(1)) + 3f * pwrVal) * arcaneDmg),
+                                armorPenetration: 2,
+                                explosionSound: def.projectile.soundExplode,
+                                weapon: def,
+                                damageFalloff: true
+                            );
                             TM_MoteMaker.ThrowDiseaseMote(base.Position.ToVector3Shifted(), base.Map, .6f);
                             if (powered)
                             {
@@ -346,7 +353,14 @@ namespace TorannMagic
                 }
             }        
 
-            GenExplosion.DoExplosion(base.Position, base.Map, this.radius, TMDamageDefOf.DamageDefOf.TM_DeathBolt, this.pawn, Mathf.RoundToInt((Rand.Range(.6f*this.def.projectile.GetDamageAmount(1,null), 1.1f*this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), 4, this.def.projectile.soundExplode, def, null, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+            GenExplosion.DoExplosion(
+                Position, Map, radius, TMDamageDefOf.DamageDefOf.TM_DeathBolt, this.pawn,
+                damAmount: Mathf.RoundToInt((Rand.Range(.6f*def.projectile.GetDamageAmount(1), 1.1f*def.projectile.GetDamageAmount(1)) + 5f * pwrVal) * arcaneDmg),
+                armorPenetration: 4,
+                explosionSound: def.projectile.soundExplode,
+                weapon: def,
+                damageFalloff: true
+            );
 
             this.ticksFollowingImpact = this.verVal * 15;
             this.impacted = true;

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DemonFlight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DemonFlight.cs
@@ -32,8 +32,6 @@ namespace TorannMagic
 
         public bool damageLaunched = true;
 
-        public bool explosion = false;
-
         public int timesToDamage = 3;
 
         public int weaponDmg = 0;
@@ -115,7 +113,6 @@ namespace TorannMagic
             Scribe_Values.Look<int>(ref this.verVal, "verVal", 0, false);
             Scribe_Values.Look<int>(ref this.pwrVal, "pwrVal", 0, false);
             Scribe_Values.Look<bool>(ref this.damageLaunched, "damageLaunched", true, false);
-            Scribe_Values.Look<bool>(ref this.explosion, "explosion", false, false);
             Scribe_References.Look<Thing>(ref this.assignedTarget, "assignedTarget", false);
             Scribe_References.Look<Pawn>(ref this.pawn, "pawn", false);
             Scribe_Deep.Look<Thing>(ref this.flyingThing, "flyingThing", new object[0]);
@@ -336,11 +333,6 @@ namespace TorannMagic
                     {
                         hitThing.TakeDamage(this.impactDamage.Value);
                     }
-                }
-                bool flag4 = this.explosion;
-                if (flag4)
-                {
-                    GenExplosion.DoExplosion(base.Position, base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
                 }
             }
             try

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DirtDevil.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_DirtDevil.cs
@@ -30,8 +30,6 @@ namespace TorannMagic
 
         public bool damageLaunched = true;
 
-        public bool explosion = false;
-
         public int timesToDamage = 3;
 
         public int weaponDmg = 0;
@@ -96,7 +94,6 @@ namespace TorannMagic
             Scribe_Values.Look<int>(ref this.timesToDamage, "timesToDamage", 0, false);
             Scribe_Values.Look<int>(ref this.searchDelay, "searchDelay", 10, false);
             Scribe_Values.Look<bool>(ref this.damageLaunched, "damageLaunched", true, false);
-            Scribe_Values.Look<bool>(ref this.explosion, "explosion", false, false);
             Scribe_Values.Look<bool>(ref this.initialized, "initialized", false, false);
             Scribe_References.Look<Thing>(ref this.assignedTarget, "assignedTarget", false);
             //Scribe_References.Look<Thing>(ref this.launcher, "launcher", false);
@@ -336,11 +333,6 @@ namespace TorannMagic
                     {
                         hitThing.TakeDamage(this.impactDamage.Value);
                     }
-                }
-                bool flag4 = this.explosion;
-                if (flag4)
-                {
-                    GenExplosion.DoExplosion(base.Position, base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
                 }
             }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_EyeOfTheStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_EyeOfTheStorm.cs
@@ -47,8 +47,6 @@ namespace TorannMagic
 
         public bool damageLaunched = true;
 
-        public bool explosion = false;
-
         public int timesToDamage = 3;
 
         public int weaponDmg = 0;
@@ -113,7 +111,6 @@ namespace TorannMagic
             Scribe_Values.Look<int>(ref this.pwrVal, "pwrVal", 0, false);
             Scribe_Values.Look<int>(ref this.verVal, "verVal", 0, false);
             Scribe_Values.Look<bool>(ref this.damageLaunched, "damageLaunched", true, false);
-            Scribe_Values.Look<bool>(ref this.explosion, "explosion", false, false);
             Scribe_Values.Look<bool>(ref this.initialized, "initialized", false, false);
             Scribe_References.Look<Thing>(ref this.assignedTarget, "assignedTarget", false);
             //Scribe_References.Look<Thing>(ref this.launcher, "launcher", false);
@@ -261,9 +258,23 @@ namespace TorannMagic
                         for (int k = 0; k < Rand.Range(1, 8); k++)
                         {
                             IntVec3 randomCell = cellRect.RandomCell;
-                            GenExplosion.DoExplosion(randomCell, base.Map, Rand.Range(.4f, .8f), TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(5 + pwrVal, 9 + 3 * pwrVal) * this.arcaneDmg), 0, SoundDefOf.Thunder_OnMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+                            GenExplosion.DoExplosion(
+                                randomCell, Map, Rand.Range(.4f, .8f), TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                                damAmount: Mathf.RoundToInt(Rand.Range(5 + pwrVal, 9 + 3 * pwrVal) * arcaneDmg),
+                                armorPenetration: 0,
+                                explosionSound: SoundDefOf.Thunder_OnMap,
+                                chanceToStartFire: 0.1f,
+                                damageFalloff: true
+                            );
                         }
-                        GenExplosion.DoExplosion(curPawnTarg.Position, base.Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(5 + pwrVal, 9 + 3 * pwrVal) * this.arcaneDmg), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+                        GenExplosion.DoExplosion(
+                            curPawnTarg.Position, Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                            damAmount: Mathf.RoundToInt(Rand.Range(5 + pwrVal, 9 + 3 * pwrVal) * arcaneDmg),
+                            armorPenetration: 0,
+                            explosionSound: SoundDefOf.Thunder_OffMap,
+                            chanceToStartFire: 0.1f,
+                            damageFalloff: true
+                        );
                         this.lastStrike = this.age + (this.maxStrikeDelay - (int)Rand.Range(0 + (pwrVal * 20), 50 + (pwrVal * 10)));
                     }
                     else
@@ -293,10 +304,24 @@ namespace TorannMagic
                     for (int k = 0; k < Rand.Range(1, 8); k++)
                     {
                         IntVec3 randomCell = cellRect.RandomCell;
-                        GenExplosion.DoExplosion(randomCell, base.Map, Rand.Range(.2f, .6f), TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(3 + 3 * pwrVal, 7 + 5 * pwrVal) * this.arcaneDmg), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+                        GenExplosion.DoExplosion(
+                            randomCell, Map, Rand.Range(.2f, .6f), TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                            damAmount: Mathf.RoundToInt(Rand.Range(3 + 3 * pwrVal, 7 + 5 * pwrVal) * arcaneDmg),
+                            armorPenetration: 0,
+                            explosionSound: SoundDefOf.Thunder_OffMap,
+                            chanceToStartFire: 0.1f,
+                            damageFalloff: true
+                        );
 
                     }
-                    GenExplosion.DoExplosion(curBldgTarg.Position, base.Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(10 + 3 * pwrVal, 25 + 5 * pwrVal) * this.arcaneDmg), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+                    GenExplosion.DoExplosion(
+                        curBldgTarg.Position, Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                        damAmount: Mathf.RoundToInt(Rand.Range(10 + 3 * pwrVal, 25 + 5 * pwrVal) * arcaneDmg),
+                        armorPenetration: 0,
+                        explosionSound: SoundDefOf.Thunder_OffMap,
+                        chanceToStartFire: 0.1f,
+                        damageFalloff: true
+                    );
                     this.lastStrikeBldg = this.age + (this.maxStrikeDelayBldg - (int)Rand.Range(0 + (pwrVal * 10), (pwrVal * 15)));
                 }
                 else
@@ -393,11 +418,6 @@ namespace TorannMagic
                         hitThing.TakeDamage(this.impactDamage.Value);
                     }
                 }
-                bool flag4 = this.explosion;
-                if (flag4)
-                {
-                    GenExplosion.DoExplosion(base.Position, base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
-                }
             }
 
             List<IntVec3> dissipationList = GenRadial.RadialCellsAround(this.ExactPosition.ToIntVec3(), 12, false).ToList();
@@ -412,11 +432,25 @@ namespace TorannMagic
                         CellRect cellRect = CellRect.CenteredOn(strikeCell, 1);
                         cellRect.ClipInsideMap(base.Map);
                         IntVec3 randomCell = cellRect.RandomCell;
-                        GenExplosion.DoExplosion(randomCell, base.Map, Rand.Range(.2f, .6f), TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(3 + 3 * pwrVal, 7 + 5 * pwrVal) * this.arcaneDmg), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+                        GenExplosion.DoExplosion(
+                            randomCell, Map, Rand.Range(.2f, .6f), TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                            damAmount: Mathf.RoundToInt(Rand.Range(3 + 3 * pwrVal, 7 + 5 * pwrVal) * arcaneDmg),
+                            armorPenetration: 0,
+                            explosionSound: SoundDefOf.Thunder_OffMap,
+                            chanceToStartFire: 0.1f,
+                            damageFalloff: true
+                        );
                     }
                 }
             }
-            GenExplosion.DoExplosion(this.ExactPosition.ToIntVec3(), base.Map, 3f + verVal, TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(5 + 5 * pwrVal, 10 + 10 * pwrVal) * this.arcaneDmg), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+            GenExplosion.DoExplosion(
+                ExactPosition.ToIntVec3(), Map, 3f + verVal, TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                damAmount: Mathf.RoundToInt(Rand.Range(5 + 5 * pwrVal, 10 + 10 * pwrVal) * arcaneDmg),
+                armorPenetration: 0,
+                explosionSound: SoundDefOf.Thunder_OffMap,
+                chanceToStartFire: 0.1f,
+                damageFalloff: true
+            );
 
 
             this.Destroy(DestroyMode.Vanish);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightningTrap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_LightningTrap.cs
@@ -48,8 +48,6 @@ namespace TorannMagic
 
         public bool damageLaunched = true;
 
-        public bool explosion = false;
-
         public int timesToDamage = 3;
 
         public int weaponDmg = 0;
@@ -114,7 +112,6 @@ namespace TorannMagic
             //Scribe_Values.Look<int>(ref this.pwrVal, "pwrVal", 0, false);
             //Scribe_Values.Look<int>(ref this.verVal, "verVal", 0, false);
             Scribe_Values.Look<bool>(ref this.damageLaunched, "damageLaunched", true, false);
-            Scribe_Values.Look<bool>(ref this.explosion, "explosion", false, false);
             Scribe_Values.Look<bool>(ref this.initialized, "initialized", false, false);
             Scribe_References.Look<Thing>(ref this.assignedTarget, "assignedTarget", false);
             //Scribe_References.Look<Thing>(ref this.launcher, "launcher", false);
@@ -250,9 +247,23 @@ namespace TorannMagic
                 for (int k = 0; k < Rand.Range(1, 5); k++)
                 {
                     IntVec3 randomCell = cellRect.RandomCell;
-                    GenExplosion.DoExplosion(randomCell, base.Map, Rand.Range(.4f, .8f), TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(4, 6)), 0, SoundDefOf.Thunder_OnMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+                    GenExplosion.DoExplosion(
+                        randomCell, Map, Rand.Range(.4f, .8f), TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                        damAmount: Mathf.RoundToInt(Rand.Range(4, 6)),
+                        armorPenetration: 0,
+                        explosionSound: SoundDefOf.Thunder_OnMap,
+                        chanceToStartFire: 0.1f,
+                        damageFalloff: true
+                    );
                 }
-                GenExplosion.DoExplosion(target.Position, base.Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(5, 9) * this.arcaneDmg), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+                GenExplosion.DoExplosion(
+                    target.Position, Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                    damAmount: Mathf.RoundToInt(Rand.Range(5, 9) * arcaneDmg),
+                    armorPenetration: 0,
+                    explosionSound: SoundDefOf.Thunder_OffMap,
+                    chanceToStartFire: 0.1f,
+                    damageFalloff: true
+                );
                 this.lastStrike = this.age;
             }            
             DrawStrikeFading();
@@ -341,11 +352,6 @@ namespace TorannMagic
                         hitThing.TakeDamage(this.impactDamage.Value);
                     }
                 }
-                bool flag4 = this.explosion;
-                if (flag4)
-                {
-                    GenExplosion.DoExplosion(this.origin.ToIntVec3(), base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
-                }
             }
 
             List<IntVec3> dissipationList = GenRadial.RadialCellsAround(this.origin.ToIntVec3(), 5, false).ToList();
@@ -360,11 +366,25 @@ namespace TorannMagic
                         CellRect cellRect = CellRect.CenteredOn(strikeCell, 2);
                         cellRect.ClipInsideMap(base.Map);
                         IntVec3 randomCell = cellRect.RandomCell;
-                        GenExplosion.DoExplosion(randomCell, base.Map, Rand.Range(.2f, .6f), TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(2, 6)), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+                        GenExplosion.DoExplosion(
+                            randomCell, Map, Rand.Range(.2f, .6f), TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                            damAmount: Mathf.RoundToInt(Rand.Range(2, 6)),
+                            armorPenetration: 0,
+                            explosionSound: SoundDefOf.Thunder_OffMap,
+                            chanceToStartFire: 0.1f,
+                            damageFalloff: true
+                        );
                     }
                 }
             }
-            GenExplosion.DoExplosion(this.origin.ToIntVec3(), base.Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(4, 8)), 0, SoundDefOf.Thunder_OffMap, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+            GenExplosion.DoExplosion(
+                origin.ToIntVec3(), Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                damAmount: Mathf.RoundToInt(Rand.Range(4, 8)),
+                armorPenetration: 0,
+                explosionSound: SoundDefOf.Thunder_OffMap,
+                chanceToStartFire: 0.1f,
+                damageFalloff: true
+            );
 
 
             this.Destroy(DestroyMode.Vanish);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsiStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsiStorm.cs
@@ -389,7 +389,13 @@ namespace TorannMagic
         //    {
         //        cleaveVector = this.ExactPosition + (Quaternion.AngleAxis(-45, Vector3.up) * ((1.5f + (.5f * pwrVal)) * this.direction));
         //        intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
-        //        //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f * this.def.projectile.GetDamageAmount(1,null), 1.1f * this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+        //        /*GenExplosion.DoExplosion(
+        //              intVec, Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn,
+        //              damAmount: Mathf.RoundToInt((Rand.Range(.6f * def.projectile.GetDamageAmount(1), 1.1f * def.projectile.GetDamageAmount(1)) + 5f * pwrVal) * arcaneDmg),
+        //              explosionSound: this.def.projectile.soundExplode,
+        //              weapon: def,
+        //              damageFalloff: true
+        //          );*/
 
         //        if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
         //        {
@@ -405,7 +411,13 @@ namespace TorannMagic
         //        }
         //        cleaveVector = this.ExactPosition + (Quaternion.AngleAxis(45, Vector3.up) * ((1.5f + (.5f * pwrVal)) * this.direction));
         //        intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
-        //        //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f * this.def.projectile.GetDamageAmount(1,null), 1.1f * this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+        //        /*GenExplosion.DoExplosion(
+        //              intVec, Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn,
+        //              damAmount: Mathf.RoundToInt((Rand.Range(.6f * def.projectile.GetDamageAmount(1), 1.1f * def.projectile.GetDamageAmount(1)) + 5f * pwrVal) * arcaneDmg),
+        //              explosionSound: def.projectile.soundExplode,
+        //              weapon: def,
+        //              damageFalloff: true
+        //          );*/
 
         //        if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
         //        {
@@ -421,7 +433,13 @@ namespace TorannMagic
         //        }
         //        cleaveVector = this.ExactPosition + ((2 + (.3f * (float)pwrVal)) * this.direction);
         //        intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
-        //        //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f*this.def.projectile.GetDamageAmount(1,null), 1.1f*this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+        //        /*GenExplosion.DoExplosion(
+        //              intVec, Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn,
+        //              damAmount: Mathf.RoundToInt((Rand.Range(.6f*def.projectile.GetDamageAmount(1), 1.1f*def.projectile.GetDamageAmount(1)) + 5f * pwrVal) * arcaneDmg),
+        //              explosionSound: def.projectile.soundExplode,
+        //              weapon: def,
+        //              damageFalloff: true
+        //          */);
 
         //        if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
         //        {
@@ -437,7 +455,13 @@ namespace TorannMagic
         //        }
         //    }
         //    this.Destroy(DestroyMode.Vanish);
-        //    //GenExplosion.DoExplosion(base.Position, base.Map, this.radius, TMDamageDefOf.DamageDefOf.TM_DeathBolt, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f*this.def.projectile.GetDamageAmount(1,null), 1.1f*this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+        //    /*GenExplosion.DoExplosion(
+        //          Position, Map, radius, TMDamageDefOf.DamageDefOf.TM_DeathBolt, launcher as Pawn,
+        //          damAmount: Mathf.RoundToInt((Rand.Range(.6f*def.projectile.GetDamageAmount(1), 1.1f*def.projectile.GetDamageAmount(1)) + 5f * pwrVal) * arcaneDmg),
+        //          explosionSound: def.projectile.soundExplode,
+        //          weapon: def,
+        //          damageFalloff: true
+        //      );*/
         //}
 
         //public void DamageThingsAtPosition()

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicDash.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicDash.cs
@@ -367,7 +367,13 @@ namespace TorannMagic
             this.drawTicks = 120;
             this.speed = 40;
             TM_MoteMaker.MakePowerBeamMotePsionic(base.Position, this.Map, 10f, 2f, .7f, .1f, .6f);
-            GenExplosion.DoExplosion(base.Position, this.Map, 1.7f, TMDamageDefOf.DamageDefOf.TM_PsionicInjury, this.pawn, Mathf.RoundToInt(Rand.Range(8, 14) * (1+ .1f * pwrVal) * this.arcaneDmg), 0, this.def.projectile.soundExplode, def, null, null, null, 0f, 1, false, null, 0f, 1, 0.0f, false);
+            GenExplosion.DoExplosion(
+                Position, Map, 1.7f, TMDamageDefOf.DamageDefOf.TM_PsionicInjury, pawn,
+                damAmount: Mathf.RoundToInt(Rand.Range(8, 14) * (1+ .1f * pwrVal) * arcaneDmg),
+                armorPenetration: 0,
+                explosionSound: def.projectile.soundExplode,
+                weapon: def
+            );
             TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_PsiCurrent, this.ExactPosition, this.Map, Rand.Range(.3f, .5f), .1f, 0f, .1f, 0, 4f, this.trueAngle, this.trueAngle);
             TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_PsiCurrent, this.ExactPosition, this.Map, Rand.Range(.5f, .6f), .1f, .04f, .1f, 0, 7f, this.trueAngle, this.trueAngle);
             TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_PsiCurrent, this.ExactPosition, this.Map, Rand.Range(.7f, .8f), .1f, .08f, .1f, 0, 10f, this.trueAngle, this.trueAngle);
@@ -382,7 +388,13 @@ namespace TorannMagic
             this.drawTicks = 60;
             this.speed = 20;
             TM_MoteMaker.MakePowerBeamMotePsionic(base.Position, this.Map, 10f, 2f, .7f, .1f, .6f);
-            GenExplosion.DoExplosion(base.Position, this.Map, 1.7f, TMDamageDefOf.DamageDefOf.TM_PsionicInjury, this.pawn, Mathf.RoundToInt(Rand.Range(10, 16) * (1 + .1f * pwrVal) * this.arcaneDmg), 0, this.def.projectile.soundExplode, def, null, null, null, 0f, 1, false, null, 0f, 1, 0.0f, false);
+            GenExplosion.DoExplosion(
+                Position, Map, 1.7f, TMDamageDefOf.DamageDefOf.TM_PsionicInjury, pawn,
+                damAmount: Mathf.RoundToInt(Rand.Range(10, 16) * (1 + .1f * pwrVal) * arcaneDmg),
+                armorPenetration: 0,
+                explosionSound: def.projectile.soundExplode,
+                weapon: def
+            );
             this.origin = this.ExactPosition;
             this.destination = this.origin + (this.direction * forwardMagnitude);
             this.ticksToImpact = this.StartingTicksToImpact;
@@ -412,7 +424,10 @@ namespace TorannMagic
                 bool flag4 = this.explosion;
                 if (flag4)
                 {
-                    GenExplosion.DoExplosion(base.Position, base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                    GenExplosion.DoExplosion(
+                        Position, Map, 0.9f, DamageDefOf.Stun, this,
+                        armorPenetration: 0
+                    );
                 }
             }
             GenSpawn.Spawn(this.flyingThing, base.Position, base.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicLeap.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicLeap.cs
@@ -242,11 +242,20 @@ namespace TorannMagic
                 bool flag4 = this.explosion;
                 if (flag4)
                 {
-                    GenExplosion.DoExplosion(base.Position, base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                    GenExplosion.DoExplosion(
+                        Position, Map, 0.9f, DamageDefOf.Stun, this,
+                        armorPenetration: 0
+                    );
                 }
             }
             TM_MoteMaker.MakePowerBeamMotePsionic(this.ExactPosition.ToIntVec3(), this.Map, 10f, 2f, .7f, .1f, .6f);
-            //GenExplosion.DoExplosion(this.ExactPosition.ToIntVec3(), this.Map, 1.7f, TMDamageDefOf.DamageDefOf.TM_PsionicInjury, this.pawn, Rand.Range(8, 12) + 2*this.effVal, 0, this.def.projectile.soundExplode, def, null, null, null, 0f, 1, false, null, 0f, 1, 0.0f, false);
+            /*GenExplosion.DoExplosion(
+                ExactPosition.ToIntVec3(), Map, 1.7f, TMDamageDefOf.DamageDefOf.TM_PsionicInjury, pawn,
+                damAmount: Rand.Range(8, 12) + 2*this.effVal,
+                armorPenetration: 0,
+                explosionSound: def.projectile.soundExplode,
+                weapon: def
+            );*/
             SearchForTargets(base.Position, 1.7f, this.Map);
             GenSpawn.Spawn(this.flyingThing, base.Position, base.Map);
             ModOptions.Constants.SetPawnInFlight(false);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_PsionicStorm.cs
@@ -442,7 +442,10 @@ namespace TorannMagic
                 bool flag4 = this.explosion;
                 if (flag4)
                 {
-                    GenExplosion.DoExplosion(base.Position, base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                    GenExplosion.DoExplosion(
+                        Position, Map, 0.9f, DamageDefOf.Stun, this,
+                        armorPenetration: 0
+                    );
                 }
             }
             GenSpawn.Spawn(this.flyingThing, base.Position, base.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ShadowBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ShadowBolt.cs
@@ -296,7 +296,13 @@ namespace TorannMagic
             {
                 cleaveVector = this.ExactPosition + (Quaternion.AngleAxis(-45, Vector3.up) * ((1.5f + (.5f*pwrVal)) * this.direction));
                 intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
-                //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f * this.def.projectile.GetDamageAmount(1,null), 1.1f * this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+                /*GenExplosion.DoExplosion(
+                    intVec, Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, launcher as Pawn,
+                    damAmount: Mathf.RoundToInt((Rand.Range(.6f * def.projectile.GetDamageAmount(1), 1.1f * def.projectile.GetDamageAmount(1)) + 5f * pwrVal) * arcaneDmg),
+                    explosionSound: def.projectile.soundExplode,
+                    weapon: def,
+                    damageFalloff: true
+                );*/
 
                 if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
                 {
@@ -312,7 +318,13 @@ namespace TorannMagic
                 }
                 cleaveVector = this.ExactPosition + (Quaternion.AngleAxis(45, Vector3.up) * ((1.5f + (.5f * pwrVal)) * this.direction));
                 intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
-                //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f * this.def.projectile.GetDamageAmount(1,null), 1.1f * this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+                /*GenExplosion.DoExplosion(
+                    intVec, Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, launcher as Pawn,
+                    damAmount: Mathf.RoundToInt((Rand.Range(.6f * def.projectile.GetDamageAmount(1), 1.1f * def.projectile.GetDamageAmount(1)) + 5f * pwrVal) * arcaneDmg),
+                    explosionSound: def.projectile.soundExplode,
+                    weapon: def,
+                    damageFalloff: true
+                );*/
 
                 if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
                 {
@@ -328,7 +340,13 @@ namespace TorannMagic
                 }
                 cleaveVector = this.ExactPosition + ((2 + (.3f * (float)pwrVal)) * this.direction);
                 intVec = cleaveVector.ToIntVec3() + GenRadial.RadialPattern[i];
-                //GenExplosion.DoExplosion(intVec, base.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f*this.def.projectile.GetDamageAmount(1,null), 1.1f*this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+                /*GenExplosion.DoExplosion(
+                    intVec, Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, launcher as Pawn,
+                    damAmount: Mathf.RoundToInt((Rand.Range(.6f*def.projectile.GetDamageAmount(1), 1.1f*def.projectile.GetDamageAmount(1)) + 5f * pwrVal) * arcaneDmg),
+                    explosionSound: def.projectile.soundExplode,
+                    weapon: def,
+                    damageFalloff: true
+                );*/
 
                 if (intVec.IsValid && intVec.InBoundsWithNullCheck(this.Map))
                 {
@@ -345,7 +363,13 @@ namespace TorannMagic
                 }
             }
             this.Destroy(DestroyMode.Vanish);
-            //GenExplosion.DoExplosion(base.Position, base.Map, this.radius, TMDamageDefOf.DamageDefOf.TM_DeathBolt, this.launcher as Pawn, Mathf.RoundToInt((Rand.Range(.6f*this.def.projectile.GetDamageAmount(1,null), 1.1f*this.def.projectile.GetDamageAmount(1,null)) + (5f * pwrVal)) * this.arcaneDmg), this.def.projectile.soundExplode, def, null, null, 0f, 1, false, null, 0f, 0, 0.0f, true);
+            /*GenExplosion.DoExplosion(
+                base.Position, Map, radius, TMDamageDefOf.DamageDefOf.TM_DeathBolt, launcher as Pawn,
+                damAmount: Mathf.RoundToInt((Rand.Range(.6f*def.projectile.GetDamageAmount(1), 1.1f*def.projectile.GetDamageAmount(1)) + 5f * pwrVal) * arcaneDmg),
+                explosionSound: def.projectile.soundExplode,
+                weapon: def,
+                damageFalloff: true
+            );*/
         }
 
         public void DamageThingsAtPosition()

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Spinning.cs
@@ -424,7 +424,14 @@ namespace TorannMagic
                                 Vector3 moteDirection = TM_Calc.GetVector(this.ExactPosition.ToIntVec3(), intVec);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Rubble, this.ExactPosition, base.Map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
                                 TM_MoteMaker.ThrowGenericFleck(FleckDefOf.Smoke, this.ExactPosition, base.Map, Rand.Range(.9f, 1.2f), .3f, .02f, Rand.Range(.25f, .4f), Rand.Range(-100, 100), Rand.Range(5f, 8f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
-                                GenExplosion.DoExplosion(intVec, base.Map, .4f, DamageDefOf.Blunt, pawn, 0, 0, SoundDefOf.Pawn_Melee_Punch_HitBuilding, null, null, null, ThingDefOf.Filth_RubbleRock, .25f, 1, false, null, 0f, 1, 0, false);
+                                GenExplosion.DoExplosion(
+                                    intVec, Map, .4f, DamageDefOf.Blunt, pawn,
+                                    damAmount: 0,
+                                    armorPenetration: 0,
+                                    explosionSound: SoundDefOf.Pawn_Melee_Punch_HitBuilding,
+                                    postExplosionSpawnThingDef: ThingDefOf.Filth_RubbleRock,
+                                    postExplosionSpawnChance: .25f
+                                );
                                 //FleckMaker.ThrowSmoke(intVec.ToVector3Shifted(), base.Map, Rand.Range(.6f, 1f));
                             }
                         }
@@ -508,7 +515,14 @@ namespace TorannMagic
                                 Vector3 moteDirection = TM_Calc.GetVector(this.ExactPosition.ToIntVec3(), intVec);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_BloodSquirt, this.ExactPosition, base.Map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(4f, 13f), (Quaternion.AngleAxis(Rand.Range(60, 120), Vector3.up) * moteDirection).ToAngleFlat(), 0);
                                 TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_BloodMist, this.ExactPosition, base.Map, Rand.Range(.9f, 1.2f), .3f, .02f, Rand.Range(.25f, .4f), Rand.Range(-100, 100), Rand.Range(5f, 8f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
-                                GenExplosion.DoExplosion(intVec, base.Map, .4f, DamageDefOf.Blunt, pawn, 0, 0, SoundDefOf.Pawn_Melee_Punch_HitBuilding, null, null, null, filth.def, .08f, 1, false, null, 0f, 1, 0, false);
+                                GenExplosion.DoExplosion(
+                                    intVec, Map, .4f, DamageDefOf.Blunt, pawn,
+                                    damAmount: 0,
+                                    armorPenetration: 0,
+                                    explosionSound: SoundDefOf.Pawn_Melee_Punch_HitBuilding,
+                                    postExplosionSpawnThingDef: filth.def,
+                                    postExplosionSpawnChance: .08f
+                                );
                                 //FleckMaker.ThrowSmoke(intVec.ToVector3Shifted(), base.Map, Rand.Range(.6f, 1f));
                             }
                         }
@@ -579,7 +593,13 @@ namespace TorannMagic
                             Vector3 moteDirection = TM_Calc.GetVector(this.ExactPosition.ToIntVec3(), intVec);
                             TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Rubble, this.ExactPosition, base.Map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
                             TM_MoteMaker.ThrowGenericFleck(FleckDefOf.Smoke, this.ExactPosition, base.Map, Rand.Range(.9f, 1.2f), .3f, .02f, Rand.Range(.25f, .4f), Rand.Range(-100, 100), Rand.Range(5f, 8f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
-                            GenExplosion.DoExplosion(intVec, base.Map, .4f, DamageDefOf.Blunt, pawn, 0, 0, SoundDefOf.Pawn_Melee_Punch_HitBuilding, null, null, null, null, .4f, 1, false, null, 0f, 1, 0, false);
+                            GenExplosion.DoExplosion(
+                                intVec, Map, .4f, DamageDefOf.Blunt, pawn,
+                                damAmount: 0,
+                                armorPenetration: 0,
+                                explosionSound: SoundDefOf.Pawn_Melee_Punch_HitBuilding,
+                                postExplosionSpawnChance: .4f
+                            );
                             //FleckMaker.ThrowSmoke(intVec.ToVector3Shifted(), base.Map, Rand.Range(.6f, 1f));
                         }
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritStorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_SpiritStorm.cs
@@ -30,8 +30,6 @@ namespace TorannMagic
 
         public bool damageLaunched = true;
 
-        public bool explosion = false;
-
         public int timesToDamage = 3;
 
         public int weaponDmg = 0;
@@ -104,7 +102,6 @@ namespace TorannMagic
             Scribe_Values.Look<int>(ref this.timesToDamage, "timesToDamage", 0, false);
             Scribe_Values.Look<int>(ref this.searchDelay, "searchDelay", 10, false);
             Scribe_Values.Look<bool>(ref this.damageLaunched, "damageLaunched", true, false);
-            Scribe_Values.Look<bool>(ref this.explosion, "explosion", false, false);
             Scribe_Values.Look<bool>(ref this.initialized, "initialized", false, false);
             Scribe_References.Look<Thing>(ref this.assignedTarget, "assignedTarget", false);
             //Scribe_References.Look<Thing>(ref this.launcher, "launcher", false);
@@ -336,11 +333,6 @@ namespace TorannMagic
                     {
                         hitThing.TakeDamage(this.impactDamage.Value);
                     }
-                }
-                bool flag4 = this.explosion;
-                if (flag4)
-                {
-                    GenExplosion.DoExplosion(base.Position, base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
                 }
             }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ValiantCharge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_ValiantCharge.cs
@@ -33,8 +33,6 @@ namespace TorannMagic
 
         public bool damageLaunched = true;
 
-        public bool explosion = false;
-
         public int timesToDamage = 3;
 
         public int weaponDmg = 0;
@@ -120,7 +118,6 @@ namespace TorannMagic
             Scribe_Values.Look<int>(ref this.verVal, "verVal", 0, false);
             Scribe_Values.Look<int>(ref this.pwrVal, "pwrVal", 0, false);
             Scribe_Values.Look<bool>(ref this.damageLaunched, "damageLaunched", true, false);
-            Scribe_Values.Look<bool>(ref this.explosion, "explosion", false, false);
             Scribe_References.Look<Thing>(ref this.assignedTarget, "assignedTarget", false);
             //Scribe_References.Look<Thing>(ref this.launcher, "launcher", false);
             Scribe_Deep.Look<Thing>(ref this.flyingThing, "flyingThing", new object[0]);
@@ -361,11 +358,6 @@ namespace TorannMagic
                     {
                         hitThing.TakeDamage(this.impactDamage.Value);
                     }
-                }
-                bool flag4 = this.explosion;
-                if (flag4)
-                {
-                    GenExplosion.DoExplosion(base.Position, base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
                 }
             }
             try

--- a/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Whirlwind.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/FlyingObject_Whirlwind.cs
@@ -97,7 +97,6 @@ namespace TorannMagic
             Scribe_Values.Look<int>(ref this.timesToDamage, "timesToDamage", 0, false);
             Scribe_Values.Look<int>(ref this.weaponDmg, "weaponDmg", 0, false);
             Scribe_Values.Look<bool>(ref this.damageLaunched, "damageLaunched", true, false);
-            Scribe_Values.Look<bool>(ref this.explosion, "explosion", false, false);
             Scribe_References.Look<Thing>(ref this.assignedTarget, "assignedTarget", false);
             Scribe_Deep.Look<Thing>(ref this.flyingThing, "flyingThing", new object[0]);
             Scribe_References.Look<Pawn>(ref this.pawn, "pawn", false);
@@ -364,11 +363,6 @@ namespace TorannMagic
                     {
                         hitThing.TakeDamage(this.impactDamage.Value);
                     }
-                }
-                bool flag4 = this.explosion;
-                if (flag4)
-                {
-                    GenExplosion.DoExplosion(base.Position, base.Map, 0.9f, DamageDefOf.Stun, this, -1, 0, null, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
                 }
             }
             GenSpawn.Spawn(this.flyingThing, base.Position, base.Map);

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_Awakening.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/CompProperties_GolemAbilityEffect_Awakening.cs
@@ -82,7 +82,11 @@ namespace TorannMagic.Golems
                     TM_Action.DamageEntities(enemyCaster, null, 10f, DamageDefOf.Stun, caster);
                     if (manaDamage != 0)
                     {
-                        GenExplosion.DoExplosion(enemyCaster.Position, enemyCaster.Map, expRad, TMDamageDefOf.DamageDefOf.TM_Shadow, caster, Mathf.RoundToInt(manaDamage), damageFalloff: true);
+                        GenExplosion.DoExplosion(
+                            enemyCaster.Position, enemyCaster.Map, expRad, TMDamageDefOf.DamageDefOf.TM_Shadow, caster,
+                            damAmount: Mathf.RoundToInt(manaDamage),
+                            damageFalloff: true
+                        );
                     }
 
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Golems/JobGiver_MechaGolemExtinguish.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Golems/JobGiver_MechaGolemExtinguish.cs
@@ -23,7 +23,12 @@ namespace TorannMagic.Golems
             {
                 if(gu.golemUpgradeDef.label.ToLower() == "extinguisher" && gu.currentLevel > 0)
                 {
-                    GenExplosion.DoExplosion(pawn.Position, pawn.Map, Rand.Range(4f, 6f), DamageDefOf.Extinguish, pawn, 500, 0, SoundDefOf.Artillery_ShellLoaded);
+                    GenExplosion.DoExplosion(
+                        pawn.Position, pawn.Map, Rand.Range(4f, 6f), DamageDefOf.Extinguish, pawn,
+                        damAmount: 500,
+                        armorPenetration: 0,
+                        explosionSound: SoundDefOf.Artillery_ShellLoaded
+                    );
                     flag = true;
                 }                
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -4613,7 +4613,12 @@ namespace TorannMagic
                 if (patient.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadHD")) || patient.health.hediffSet.HasHediff(HediffDef.Named("TM_UndeadAnimalHD")))
                 {
                     Messages.Message("Something went horribly wrong while trying to perform a surgery on " + patient.LabelShort + ", perhaps it's best to leave the bodies of the undead alone.", MessageTypeDefOf.NegativeHealthEvent);
-                    GenExplosion.DoExplosion(surgeon.Position, surgeon.Map, 2f, TMDamageDefOf.DamageDefOf.TM_CorpseExplosion, patient, Rand.Range(6, 12), 10, TMDamageDefOf.DamageDefOf.TM_CorpseExplosion.soundExplosion, null, null, null, null, 0, 0, false, null, 0, 0, 0, false);
+                    GenExplosion.DoExplosion(
+                        surgeon.Position, surgeon.Map, 2f, TMDamageDefOf.DamageDefOf.TM_CorpseExplosion, patient,
+                        damAmount: Rand.Range(6, 12),
+                        armorPenetration: 10,
+                        explosionSound: TMDamageDefOf.DamageDefOf.TM_CorpseExplosion.soundExplosion
+                    );
                     __result = true;
                     return false;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PsionicBarrier.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_PsionicBarrier.cs
@@ -165,9 +165,22 @@ namespace TorannMagic
                             }
                             if(cellList[j].def.projectile.explosionRadius > 0 && cellList[j].def != TorannMagicDefOf.Projectile_FogOfTorment)
                             {
-                                GenExplosion.DoExplosion(barrierCells[i], this.pawn.Map, cellList[j].def.projectile.explosionRadius, cellList[j].def.projectile.damageDef, this.pawn, (int)projectileDamage, cellList[j].def.projectile.GetArmorPenetration(1, null), cellList[j].def.projectile.soundExplode,
-                                    null, cellList[j].def, null, cellList[j].def.projectile.postExplosionSpawnThingDef, cellList[j].def.projectile.postExplosionSpawnChance, cellList[j].def.projectile.postExplosionSpawnThingCount, cellList[j].def.projectile.applyDamageToExplosionCellsNeighbors,
-                                    cellList[j].def.projectile.preExplosionSpawnThingDef, cellList[j].def.projectile.preExplosionSpawnChance, cellList[j].def.projectile.preExplosionSpawnThingCount, cellList[j].def.projectile.explosionChanceToStartFire, cellList[j].def.projectile.explosionDamageFalloff);
+                                GenExplosion.DoExplosion(
+                                    barrierCells[i], pawn.Map, cellList[j].def.projectile.explosionRadius, cellList[j].def.projectile.damageDef, pawn,
+                                    damAmount: (int)projectileDamage,
+                                    armorPenetration: cellList[j].def.projectile.GetArmorPenetration(1),
+                                    explosionSound: cellList[j].def.projectile.soundExplode,
+                                    projectile: cellList[j].def,
+                                    postExplosionSpawnThingDef: cellList[j].def.projectile.postExplosionSpawnThingDef,
+                                    postExplosionSpawnChance: cellList[j].def.projectile.postExplosionSpawnChance,
+                                    postExplosionSpawnThingCount: cellList[j].def.projectile.postExplosionSpawnThingCount,
+                                    applyDamageToExplosionCellsNeighbors: cellList[j].def.projectile.applyDamageToExplosionCellsNeighbors,
+                                    preExplosionSpawnThingDef: cellList[j].def.projectile.preExplosionSpawnThingDef,
+                                    preExplosionSpawnChance: cellList[j].def.projectile.preExplosionSpawnChance,
+                                    preExplosionSpawnThingCount: cellList[j].def.projectile.preExplosionSpawnThingCount,
+                                    chanceToStartFire: cellList[j].def.projectile.explosionChanceToStartFire,
+                                    damageFalloff: cellList[j].def.projectile.explosionDamageFalloff
+                                );
                             }
                             cellList[j].Destroy(DestroyMode.Vanish);
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_AntiArmor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_AntiArmor.cs
@@ -77,8 +77,24 @@ namespace TorannMagic
                         FleckMaker.ThrowMicroSparks(victim.Position.ToVector3(), map);
                         for (int i = 0; i < 1 + verVal; i++)
                         {
-                            GenExplosion.DoExplosion(newPos, map, Rand.Range((.1f) * (1 + verVal), (.3f) * (1 + verVal)), DamageDefOf.Bomb, this.launcher, (this.def.projectile.GetDamageAmount(1, null) / 4) * (1 + verVal), .4f, SoundDefOf.MetalHitImportant, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, true);
-                            GenExplosion.DoExplosion(newPos, map, Rand.Range((.2f) * (1 + verVal), (.4f) * (1 + verVal)), DamageDefOf.Stun, this.launcher, (this.def.projectile.GetDamageAmount(1, null) / 2) * (1 + verVal), .4f, SoundDefOf.MetalHitImportant, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, true);
+                            GenExplosion.DoExplosion(
+                                newPos, map, Rand.Range(.1f * (1 + verVal), .3f * (1 + verVal)), DamageDefOf.Bomb, launcher,
+                                damAmount: this.def.projectile.GetDamageAmount(1) / 4 * (1 + verVal),
+                                armorPenetration: .4f,
+                                explosionSound: SoundDefOf.MetalHitImportant,
+                                weapon: def,
+                                projectile: equipmentDef,
+                                damageFalloff: true
+                            );
+                            GenExplosion.DoExplosion(
+                                newPos, map, Rand.Range(.2f * (1 + verVal), .4f * (1 + verVal)), DamageDefOf.Stun, launcher,
+                                damAmount: this.def.projectile.GetDamageAmount(1) / 2 * (1 + verVal),
+                                armorPenetration: .4f,
+                                explosionSound: SoundDefOf.MetalHitImportant,
+                                weapon : def,
+                                projectile: equipmentDef,
+                                damageFalloff: true
+                            );
                             newPos = GetNewPos(newPos, pawn.Position.x <= victim.Position.x, pawn.Position.z <= victim.Position.z, false, 0, 0, xProb, 1 - xProb);
                             FleckMaker.ThrowMicroSparks(victim.Position.ToVector3(), base.Map);
                             FleckMaker.ThrowDustPuff(newPos, map, Rand.Range(1.2f, 2.4f));

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ArcaneBolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ArcaneBolt.cs
@@ -14,13 +14,18 @@ namespace TorannMagic
 
         protected override void Impact(Thing hitThing)
         {
-            Map map = base.Map;
             base.Impact(hitThing);
-            ThingDef def = this.def;
-            Pawn pawn = this.launcher as Pawn;
-            Pawn victim = hitThing as Pawn;
+            Pawn pawn = launcher as Pawn;
             CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
-            GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius, TMDamageDefOf.DamageDefOf.TM_Arcane, this.launcher,  Mathf.RoundToInt(Rand.Range(5,this.def.projectile.GetDamageAmount(1, null))* comp.arcaneDmg), 1, this.def.projectile.soundExplode, def, this.equipmentDef, this.intendedTarget.Thing, null, 0f, 1, false, null, 0f, 1, 0.0f, false);
+            GenExplosion.DoExplosion(
+                Position, Map, def.projectile.explosionRadius, TMDamageDefOf.DamageDefOf.TM_Arcane, launcher,
+                damAmount: Mathf.RoundToInt(Rand.Range(5, def.projectile.GetDamageAmount(1))* comp.arcaneDmg),
+                armorPenetration: 1,
+                explosionSound: def.projectile.soundExplode,
+                weapon: def,
+                projectile: equipmentDef,
+                intendedTarget: intendedTarget.Thing
+            );
         }
 
         public override void Draw()

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Attraction.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Attraction.cs
@@ -82,7 +82,13 @@ namespace TorannMagic
                 this.duration = this.duration + (120 * verVal);
                 this.strikeDelay = this.strikeDelay - verVal;
                 this.radius = this.def.projectile.explosionRadius + (1.5f * pwrVal);
-                //GenExplosion.DoExplosion(base.Position, this.Map, this.radius, TMDamageDefOf.DamageDefOf.TM_Shadow, this.pawn, (int)((this.def.projectile.GetDamageAmount(1, null) * (1 + .15 * pwrVal)) * this.arcaneDmg * Rand.Range(.75f, 1.25f)), 0, TorannMagicDefOf.TM_SoftExplosion, def, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                /*GenExplosion.DoExplosion(
+                    Position, Map, radius, TMDamageDefOf.DamageDefOf.TM_Shadow, pawn,
+                    damAmount: (int)((def.projectile.GetDamageAmount(1) * (1 + .15 * pwrVal)) * arcaneDmg * Rand.Range(.75f, 1.25f)),
+                    armorPenetration: 0,
+                    explosionSound: TorannMagicDefOf.TM_SoftExplosion,
+                    weapon: def
+                );*/
 
                 this.initialized = true;
                 IEnumerable<IntVec3> hediffCells = GenRadial.RadialCellsAround(base.Position, 2, true);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_BreachingCharge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_BreachingCharge.cs
@@ -44,7 +44,15 @@ namespace TorannMagic
         {
             if (explosionCount > 0)
             {
-                GenExplosion.DoExplosion(base.Position, base.Map, this.def.projectile.explosionRadius-explosionCount, this.def.projectile.damageDef, this.launcher as Pawn, Mathf.RoundToInt((this.def.projectile.GetDamageAmount(1f) * (1f + (.15f * verVal))) * mightPwr), this.def.projectile.damageDef.defaultArmorPenetration, this.def.projectile.damageDef.soundExplosion, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, true);
+                GenExplosion.DoExplosion(
+                    Position, Map, def.projectile.explosionRadius-explosionCount, def.projectile.damageDef, launcher as Pawn,
+                    damAmount: Mathf.RoundToInt(def.projectile.GetDamageAmount(1f) * (1f + .15f * verVal) * mightPwr),
+                    armorPenetration: def.projectile.damageDef.defaultArmorPenetration,
+                    explosionSound: def.projectile.damageDef.soundExplosion,
+                    weapon: def,
+                    projectile: equipmentDef,
+                    damageFalloff: true
+                );
             }
             else
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChainLightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ChainLightning.cs
@@ -221,7 +221,11 @@ namespace TorannMagic
                 IntVec3 hitCell = from + (dir * range).ToIntVec3();
                 //Log.Message("random strike " + hitCell);
                 //DamageCell(hitCell, caster);
-                GenExplosion.DoExplosion(hitCell, this.Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, caster, Mathf.RoundToInt(Rand.Range(4 + pwrVal, 8 + pwrVal) * arcaneDmg), 1.2f); 
+                GenExplosion.DoExplosion(
+                    hitCell, Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, caster,
+                    damAmount: Mathf.RoundToInt(Rand.Range(4 + pwrVal, 8 + pwrVal) * arcaneDmg),
+                    armorPenetration: 1.2f
+                );
                 this.Map.weatherManager.eventHandler.AddEvent(new TM_WeatherEvent_MeshGeneric(this.Map, TM_MatPool.thinLightning, from, hitCell, 2f, AltitudeLayer.MoteLow, strikeDelay, strikeDelay, 2));
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_CorpseExplosion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_CorpseExplosion.cs
@@ -152,7 +152,15 @@ namespace TorannMagic
                             this.targetPawn.Destroy();
                         }
                     }
-                    GenExplosion.DoExplosion(this.targetPawn.Position, map, this.radius, TMDamageDefOf.DamageDefOf.TM_CorpseExplosion, this.launcher, Mathf.RoundToInt((Rand.Range(22f, 36f) + (5f * pwrVal)) * this.arcaneDmg), 0, this.def.projectile.soundExplode, def, this.equipmentDef, null, null, 0f, 01, false, null, 0f, 0, 0.0f, true);
+                    GenExplosion.DoExplosion(
+                        targetPawn.Position, map, radius, TMDamageDefOf.DamageDefOf.TM_CorpseExplosion, launcher,
+                        damAmount: Mathf.RoundToInt((Rand.Range(22f, 36f) + 5f * pwrVal) * arcaneDmg),
+                        armorPenetration: 0,
+                        explosionSound: this.def.projectile.soundExplode,
+                        weapon: def,
+                        projectile: equipmentDef,
+                        damageFalloff: true
+                    );
 
                 }
             }
@@ -196,7 +204,15 @@ namespace TorannMagic
                         corpsePawn.equipment.DropAllEquipment(this.targetCorpse.Position, false);
                         corpsePawn.apparel.DropAll(this.targetCorpse.Position, false);
                     }
-                    GenExplosion.DoExplosion(this.targetCorpse.Position, map, this.radius, TMDamageDefOf.DamageDefOf.TM_CorpseExplosion, this.launcher, Mathf.RoundToInt((Rand.Range(18f, 30f) + (5f * pwrVal))*this.arcaneDmg), 0, this.def.projectile.soundExplode, def, this.equipmentDef, null, null, 0f, 01, false, null, 0f, 0, 0.0f, true);
+                    GenExplosion.DoExplosion(
+                        targetCorpse.Position, map, radius, TMDamageDefOf.DamageDefOf.TM_CorpseExplosion, launcher,
+                        damAmount: Mathf.RoundToInt((Rand.Range(18f, 30f) + 5f * pwrVal)*arcaneDmg),
+                        armorPenetration: 0,
+                        explosionSound: this.def.projectile.soundExplode,
+                        weapon: def,
+                        projectile: equipmentDef,
+                        damageFalloff: true
+                    );
                     if (!this.targetCorpse.Destroyed)
                     {
                         this.targetCorpse.Destroy();

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_EMP.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_EMP.cs
@@ -15,7 +15,15 @@ namespace TorannMagic
             Map map = base.Map;
             base.Impact(hitThing);
             ThingDef def = this.def;            
-            GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius, this.def.projectile.damageDef, this.launcher, (int)(this.def.projectile.GetDamageAmount(1,null) * comp.arcaneDmg), 0, SoundDefOf.Artillery_ShellLoaded, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, true);
+            GenExplosion.DoExplosion(
+                Position, map, this.def.projectile.explosionRadius, this.def.projectile.damageDef, launcher,
+                damAmount: (int)(this.def.projectile.GetDamageAmount(1) * comp.arcaneDmg),
+                armorPenetration: 0,
+                explosionSound: SoundDefOf.Artillery_ShellLoaded,
+                weapon: def,
+                projectile: equipmentDef,
+                damageFalloff: true
+            );
             if (caster != null && comp != null)
             {
                 if (comp.MagicData?.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_ver").level >= 14)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ES_Fire.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ES_Fire.cs
@@ -21,7 +21,15 @@ namespace TorannMagic
             MagicPowerSkill ver = pawn.GetCompAbilityUserMagic().MagicData.MagicPowerSkill_TechnoWeapon.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_TechnoWeapon_ver");
             verVal = ver.level;
 
-            GenExplosion.DoExplosion(base.Position, map, 1f + (verVal * .05f), DamageDefOf.Burn, this.launcher, Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1,null) * comp.arcaneDmg * (1f + .02f * verVal)), 0, this.def.projectile.soundExplode, def, this.equipmentDef, this.intendedTarget.Thing, null, 0f, 1, false, null, 0f, 1, 0.0f, false);
+            GenExplosion.DoExplosion(
+                Position, map, 1f + verVal * .05f, DamageDefOf.Burn, launcher,
+                damAmount: Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1) * comp.arcaneDmg * (1f + .02f * verVal)),
+                armorPenetration: 0,
+                explosionSound: this.def.projectile.soundExplode,
+                weapon: def,
+                projectile: equipmentDef,
+                intendedTarget: intendedTarget.Thing
+            );
 
         }
     }    

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Explosion.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Explosion.cs
@@ -197,7 +197,14 @@ namespace TorannMagic
                 {
                     float energy = 80000 * this.arcaneDmg;
                     GenTemperature.PushHeat(this.strikePos, this.Map, energy);
-                    GenExplosion.DoExplosion(this.strikePos, this.Map, this.radius/(4-this.expandingTick), DamageDefOf.Bomb, this.launcher, Mathf.RoundToInt(Rand.Range(this.damage *.7f, this.damage*.9f)), 1, DamageDefOf.Bomb.soundExplosion, null, null, null, null, 0, 0, false, null, 0, 0, .4f, true);
+                    GenExplosion.DoExplosion(
+                        strikePos, Map, radius/(4-expandingTick), DamageDefOf.Bomb, launcher,
+                        damAmount: Mathf.RoundToInt(Rand.Range(damage *.7f, damage*.9f)),
+                        armorPenetration: 1,
+                        explosionSound: DamageDefOf.Bomb.soundExplosion,
+                        chanceToStartFire: .4f,
+                        damageFalloff: true
+                    );
                 }
             }
             this.Destroy(DestroyMode.Vanish);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Extinguish.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Extinguish.cs
@@ -15,7 +15,14 @@ namespace TorannMagic
             Map map = base.Map;
             base.Impact(hitThing);
             ThingDef def = this.def;
-            GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius, this.def.projectile.damageDef, this.launcher, this.def.projectile.GetDamageAmount(1, null), 0, SoundDefOf.Artillery_ShellLoaded, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+            GenExplosion.DoExplosion(
+                Position, map, this.def.projectile.explosionRadius, this.def.projectile.damageDef, launcher,
+                damAmount: this.def.projectile.GetDamageAmount(1),
+                armorPenetration: 0,
+                explosionSound: SoundDefOf.Artillery_ShellLoaded,
+                weapon: def,
+                projectile: equipmentDef
+            );
             Pawn p = this.launcher as Pawn;
             if (p != null)
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_FireSuppressionFlask.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_FireSuppressionFlask.cs
@@ -12,11 +12,19 @@ namespace TorannMagic
 	{
         protected override void Impact(Thing hitThing)
         {
-            Map map = base.Map;
             base.Impact(hitThing);
             ThingDef def = this.def;
-            GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius, this.def.projectile.damageDef, this.launcher, this.def.projectile.GetDamageAmount(1, null), 0, DamageDefOf.Smoke.soundExplosion, def, this.equipmentDef, null, this.def.projectile.postExplosionSpawnThingDef, this.def.projectile.postExplosionSpawnChance, 1, true, null, 0f, 1, 0f, false);
-           
+            GenExplosion.DoExplosion(
+	            Position, Map, this.def.projectile.explosionRadius, this.def.projectile.damageDef, launcher,
+	            damAmount: this.def.projectile.GetDamageAmount(1),
+	            armorPenetration: 0,
+	            explosionSound: DamageDefOf.Smoke.soundExplosion,
+	            weapon: def,
+	            projectile: equipmentDef,
+	            postExplosionSpawnThingDef: this.def.projectile.postExplosionSpawnThingDef,
+	            postExplosionSpawnChance: this.def.projectile.postExplosionSpawnChance,
+	            applyDamageToExplosionCellsNeighbors: true
+	        );
         }		
 	}	
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireball.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Fireball.cs
@@ -14,12 +14,24 @@ namespace TorannMagic
 
 		protected override void Impact(Thing hitThing)
 		{
-            
-            Map map = base.Map;
+			Map map = Map;
 			base.Impact(hitThing);
-			ThingDef def = this.def;
-            //GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius, DamageDefOf.Bomb, this.launcher, SoundDefOf.PlanetkillerImpact, def, this.equipmentDef, null, 0f, 1, false, null, 0f, 1);
-            GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius, DamageDefOf.Bomb, this.launcher, Mathf.RoundToInt(Rand.Range(this.def.projectile.GetDamageAmount(1,null)/2, this.def.projectile.GetDamageAmount(1,null)) * this.arcaneDmg), 0, TorannMagicDefOf.TM_SoftExplosion, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0.1f, true);
+            /*GenExplosion.DoExplosion(base.
+				Position, map, def.projectile.explosionRadius, DamageDefOf.Bomb, launcher,
+				explosionSound: SoundDefOf.PlanetkillerImpact,
+				weapon: def,
+				projectile: equipmentDef
+			);*/
+            GenExplosion.DoExplosion(
+	            Position, map, def.projectile.explosionRadius, DamageDefOf.Bomb, launcher,
+	            damAmount: Mathf.RoundToInt(Rand.Range(def.projectile.GetDamageAmount(1)/2, def.projectile.GetDamageAmount(1)) * arcaneDmg),
+	            armorPenetration: 0,
+	            explosionSound: TorannMagicDefOf.TM_SoftExplosion,
+	            weapon: def,
+	            projectile: equipmentDef,
+	            chanceToStartFire: 0.1f,
+	            damageFalloff: true
+	        );
             CellRect cellRect = CellRect.CenteredOn(base.Position, 5);
 			cellRect.ClipInsideMap(map);
             ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firebolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firebolt.cs
@@ -33,7 +33,16 @@ namespace TorannMagic
                 }
             }
             
-            GenExplosion.DoExplosion(base.Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Firebolt, this.launcher, Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1, null) * arcaneDmg), 0, this.def.projectile.soundExplode, def, this.equipmentDef, this.intendedTarget.Thing, null, 0f, 1, false, null, 0f, 1, 0.6f, false);
+            GenExplosion.DoExplosion(
+                Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Firebolt, launcher,
+                damAmount: Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1) * arcaneDmg),
+                armorPenetration: 0,
+                explosionSound: this.def.projectile.soundExplode,
+                weapon: def,
+                projectile: equipmentDef,
+                intendedTarget: intendedTarget.Thing,
+                chanceToStartFire: 0.6f
+            );
             CellRect cellRect = CellRect.CenteredOn(base.Position, 3);
             cellRect.ClipInsideMap(map);
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firestorm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Firestorm.cs
@@ -101,7 +101,15 @@ namespace TorannMagic
             {
                 if (ticksTillHeavy[i] == 0)
                 {
-                    GenExplosion.DoExplosion(shrapnelPos[heavyCount], map, .4f, TMDamageDefOf.DamageDefOf.TM_Firestorm_Small, this.launcher, Rand.Range(5, this.def.projectile.GetDamageAmount(1,null)), 0, SoundDefOf.BulletImpact_Ground, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0.2f, false);
+                    GenExplosion.DoExplosion(
+                        shrapnelPos[heavyCount], map, .4f, TMDamageDefOf.DamageDefOf.TM_Firestorm_Small, launcher,
+                        damAmount: Rand.Range(5, this.def.projectile.GetDamageAmount(1)),
+                        armorPenetration: 0,
+                        explosionSound: SoundDefOf.BulletImpact_Ground,
+                        weapon: def,
+                        projectile: equipmentDef,
+                        chanceToStartFire: 0.2f
+                    );
                     ticksTillHeavy[i]--;
                 }
                 else

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
@@ -78,7 +78,16 @@ namespace TorannMagic
 
                 fog.gas.expireSeconds.min = this.duration/60;
                 fog.gas.expireSeconds.max = this.duration/60;
-                GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius + verVal, TMDamageDefOf.DamageDefOf.TM_Torment, this.launcher, 0, 0, this.def.projectile.soundExplode, def, this.equipmentDef, null, fog, 1f, 1, false, null, 0f, 0, 0.0f, false);
+                GenExplosion.DoExplosion(
+                    Position, map, this.def.projectile.explosionRadius + verVal, TMDamageDefOf.DamageDefOf.TM_Torment, launcher,
+                    damAmount: 0,
+                    armorPenetration: 0,
+                    explosionSound: this.def.projectile.soundExplode,
+                    weapon: def,
+                    projectile: equipmentDef,
+                    postExplosionSpawnThingDef: fog,
+                    postExplosionSpawnChance: 1f
+                );
                 
                 this.initialized = true;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
@@ -101,9 +101,15 @@ namespace TorannMagic
                 if (wrathAge[j] == this.timeToSmite/strikeNum)
                 {
                     TM_MoteMaker.MakePowerBeamMoteColor(smitePos[j], base.Map, this.radius * 3f, 2f, .5f, .1f, .5f, colorInt.ToColor);
-                    this.caster = this.launcher as Pawn;
-                    CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
-                    GenExplosion.DoExplosion(smitePos[j], map, 3f, TMDamageDefOf.DamageDefOf.TM_Overwhelm, this.launcher as Pawn, Mathf.RoundToInt((12 + TMDamageDefOf.DamageDefOf.TM_Overwhelm.defaultDamage + 3*pwrVal) * this.arcaneDmg), 0, TorannMagicDefOf.TM_Lightning, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                    caster = launcher as Pawn;
+                    GenExplosion.DoExplosion(
+                        smitePos[j], map, 3f, TMDamageDefOf.DamageDefOf.TM_Overwhelm, caster,
+                        damAmount: Mathf.RoundToInt((12 + TMDamageDefOf.DamageDefOf.TM_Overwhelm.defaultDamage + 3*pwrVal) * arcaneDmg),
+                        armorPenetration: 0,
+                        explosionSound: TorannMagicDefOf.TM_Lightning,
+                        weapon: def,
+                        projectile: equipmentDef
+                    );
                 }
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Icebolt.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Icebolt.cs
@@ -41,7 +41,14 @@ namespace TorannMagic
                 pwrVal = 3;
                 verVal = 3;
             }
-            GenExplosion.DoExplosion(base.Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Iceshard, this.launcher, Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1,null) * this.arcaneDmg), 0, this.def.projectile.soundExplode, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+            GenExplosion.DoExplosion(
+                Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Iceshard, launcher,
+                damAmount: Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1) * arcaneDmg),
+                armorPenetration: 0,
+                explosionSound: this.def.projectile.soundExplode,
+                weapon: def,
+                projectile: equipmentDef
+            );
             CellRect cellRect = CellRect.CenteredOn(base.Position, 3);
             cellRect.ClipInsideMap(map);
             for (int i = 0; i < Rand.Range((2 + verVal), (3 + 4*verVal)); i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_IgniteBlood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_IgniteBlood.cs
@@ -169,7 +169,12 @@ namespace TorannMagic
                     }
                 }
                 this.BF[i] = new BloodFire(this.BF[i].position, this.BF[i].pulseCount + 1);
-                GenExplosion.DoExplosion(this.BF[i].position, this.Map, .2f + (.4f * BF[i].pulseCount), TMDamageDefOf.DamageDefOf.TM_BloodBurn, this.launcher, Mathf.RoundToInt((Rand.Range(2.8f, 4.5f) * (1 + (.12f * pwrVal))) * this.arcaneDmg), .5f, TorannMagicDefOf.TM_FireWooshSD, null, null, null, null, 0f, 1, false, null, 0f, 1, 0.0f, false);
+                GenExplosion.DoExplosion(
+                    BF[i].position, Map, .2f + .4f * BF[i].pulseCount, TMDamageDefOf.DamageDefOf.TM_BloodBurn, launcher,
+                    damAmount: Mathf.RoundToInt(Rand.Range(2.8f, 4.5f) * (1 + .12f * pwrVal) * arcaneDmg),
+                    armorPenetration: .5f,
+                    explosionSound: TorannMagicDefOf.TM_FireWooshSD
+                );
                 if(this.BF[i].pulseCount >= 3)
                 {                    
                     this.BF.Remove(this.BF[i]);

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Lightning.cs
@@ -131,7 +131,11 @@ namespace TorannMagic
                         lastStrikeTick = Find.TickManager.TicksGame;
                         DrawBolt(mesh, TM_MatPool.standardLightning, origin, angle, GetFadedBrightness);
                         DamageCell(strikePos, this.launcher);
-                        GenExplosion.DoExplosion(strikePos, this.Map, 2f, TMDamageDefOf.DamageDefOf.TM_Lightning, this.launcher, Mathf.RoundToInt(Rand.Range(3 + pwrVal, 6 + pwrVal) * arcaneDmg), 1.2f, null);
+                        GenExplosion.DoExplosion(
+                            strikePos, Map, 2f, TMDamageDefOf.DamageDefOf.TM_Lightning, launcher,
+                            damAmount: Mathf.RoundToInt(Rand.Range(3 + pwrVal, 6 + pwrVal) * arcaneDmg),
+                            armorPenetration: 1.2f
+                        );
                         newStrikeLocs.Add(strikePos);
                     }
                     RandomStrikes(base.Position, this.launcher);
@@ -186,7 +190,11 @@ namespace TorannMagic
                 IntVec3 hitCell = from + (dir * range).ToIntVec3();
                 //Log.Message("random strike " + hitCell);
                 //DamageCell(hitCell, caster);
-                GenExplosion.DoExplosion(hitCell, this.Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, caster, Mathf.RoundToInt(Rand.Range(3 + pwrVal, 6 + pwrVal) * arcaneDmg), 1.2f, null); 
+                GenExplosion.DoExplosion(
+                    hitCell, Map, 1f, TMDamageDefOf.DamageDefOf.TM_Lightning, caster,
+                    damAmount: Mathf.RoundToInt(Rand.Range(3 + pwrVal, 6 + pwrVal) * arcaneDmg),
+                    armorPenetration: 1.2f
+                );
                 this.Map.weatherManager.eventHandler.AddEvent(new TM_WeatherEvent_MeshGeneric(this.Map, TM_MatPool.thinLightning, from, hitCell, 2f, AltitudeLayer.MoteLow, strikeDelay, strikeDelay, 2));
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Mk203GL.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Mk203GL.cs
@@ -35,14 +35,38 @@ namespace TorannMagic
                 this.initialized = true;
             }
 
-            GenExplosion.DoExplosion(this.strikePos, map, this.def.projectile.explosionRadius, this.def.projectile.damageDef, this.launcher as Pawn, Mathf.RoundToInt((this.def.projectile.GetDamageAmount(1f) + (1.5f * verVal)) * mightPwr), 3, this.def.projectile.soundExplode, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, true);
+            GenExplosion.DoExplosion(
+                strikePos, map, this.def.projectile.explosionRadius, this.def.projectile.damageDef, launcher as Pawn,
+                damAmount: Mathf.RoundToInt((this.def.projectile.GetDamageAmount(1f) + 1.5f * verVal) * mightPwr),
+                armorPenetration: 3,
+                explosionSound: this.def.projectile.soundExplode,
+                weapon: def,
+                projectile: equipmentDef,
+                damageFalloff: true
+            );
             strikePos.x += Mathf.RoundToInt(Rand.Range(-radius, radius));
             strikePos.z += Mathf.RoundToInt(Rand.Range(-radius, radius));
-            GenExplosion.DoExplosion(this.strikePos, map, this.def.projectile.explosionRadius/2f, this.def.projectile.damageDef, this.launcher as Pawn, Mathf.RoundToInt(((this.def.projectile.GetDamageAmount(1f)/2f) + (1f * verVal)) * mightPwr), 0, this.def.projectile.soundExplode, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, true);
+            GenExplosion.DoExplosion(
+                strikePos, map, this.def.projectile.explosionRadius/2f, this.def.projectile.damageDef, launcher as Pawn,
+                damAmount: Mathf.RoundToInt((this.def.projectile.GetDamageAmount(1f)/2f + 1f * verVal) * mightPwr),
+                armorPenetration: 0,
+                explosionSound: this.def.projectile.soundExplode,
+                weapon: def,
+                projectile: equipmentDef,
+                damageFalloff: true
+            );
             strikePos = base.Position;
             strikePos.x += Mathf.RoundToInt(Rand.Range(-radius, radius));
             strikePos.z += Mathf.RoundToInt(Rand.Range(-radius, radius));
-            GenExplosion.DoExplosion(this.strikePos, map, this.def.projectile.explosionRadius/2f, this.def.projectile.damageDef, this.launcher as Pawn, Mathf.RoundToInt(((this.def.projectile.GetDamageAmount(1f) / 2f) + (1f * verVal)) * mightPwr), 0, this.def.projectile.soundExplode, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, true);
+            GenExplosion.DoExplosion(
+                strikePos, map, this.def.projectile.explosionRadius/2f, this.def.projectile.damageDef, launcher as Pawn,
+                damAmount: Mathf.RoundToInt((this.def.projectile.GetDamageAmount(1f) / 2f + 1f * verVal) * mightPwr),
+                armorPenetration: 0,
+                explosionSound: this.def.projectile.soundExplode,
+                weapon: def,
+                projectile: equipmentDef,
+                damageFalloff: true
+            );
         }
 
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_OrbitalStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_OrbitalStrike.cs
@@ -100,7 +100,13 @@ namespace TorannMagic
             if (this.age == (this.targettingAge + this.beamDuration))
             {
                 TM_MoteMaker.MakePowerBeamMoteColor(this.strikePos, base.Map, this.radius * 4f, 2f, .5f, .1f, .5f, colorInt.ToColor);                
-                GenExplosion.DoExplosion(this.strikePos, map, this.def.projectile.explosionRadius, DamageDefOf.Bomb, this.launcher as Pawn, Mathf.RoundToInt((25 + 5*pwrVal) * this.arcaneDmg), 0, null, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                GenExplosion.DoExplosion(
+                    strikePos, map, this.def.projectile.explosionRadius, DamageDefOf.Bomb, launcher as Pawn,
+                    damAmount: Mathf.RoundToInt((25 + 5*pwrVal) * arcaneDmg),
+                    armorPenetration: 0,
+                    weapon: def,
+                    projectile: equipmentDef
+                );
                 Effecter OSEffect = TorannMagicDefOf.TM_OSExplosion.Spawn();
                 OSEffect.Trigger(new TargetInfo(this.strikePos, this.Map, false), new TargetInfo(this.strikePos, this.Map, false));
                 OSEffect.Cleanup();

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_PoisonFlask.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_PoisonFlask.cs
@@ -41,7 +41,15 @@ namespace TorannMagic
                     ThingDef fog = TorannMagicDefOf.Fog_Poison;
                     fog.gas.expireSeconds.min = duration / 60;
                     fog.gas.expireSeconds.max = duration / 60;
-                    GenExplosion.DoExplosion(base.Position, map, radius, TMDamageDefOf.DamageDefOf.TM_Poison, this, 0, 0, SoundDef.Named("TinyBell"), def, null, null, fog, 1f, 1, false, null, 0f, 0, 0.0f, false);
+                    GenExplosion.DoExplosion(
+                        Position, map, radius, TMDamageDefOf.DamageDefOf.TM_Poison, this,
+                        damAmount: 0,
+                        armorPenetration: 0,
+                        explosionSound: SoundDef.Named("TinyBell"),
+                        weapon: def,
+                        postExplosionSpawnThingDef: fog,
+                        postExplosionSpawnChance: 1f
+                    );
                 }
 
                 if (this.age >= this.lastStrike + this.strikeDelay)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsionicBlast.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsionicBlast.cs
@@ -48,7 +48,15 @@ namespace TorannMagic
 
             TM_MoteMaker.MakePowerBeamMotePsionic(base.Position, map, this.def.projectile.explosionRadius * 6f, 2f, .7f, .1f, .6f);
             float angle = (Quaternion.AngleAxis(90, Vector3.up) * GetVector(pawn.Position, base.Position)).ToAngleFlat();
-            GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius, TMDamageDefOf.DamageDefOf.TM_PsionicInjury, this.launcher, Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1, null) * pawn.GetStatValue(StatDefOf.PsychicSensitivity, false) * (1 + (0.15f * pwrVal)) * this.arcaneDmg), 0, this.def.projectile.soundExplode, def, this.equipmentDef, this.intendedTarget.Thing, null, 0f, 1, false, null, 0f, 1, 0.0f, false);
+            GenExplosion.DoExplosion(
+                Position, map, this.def.projectile.explosionRadius, TMDamageDefOf.DamageDefOf.TM_PsionicInjury, launcher,
+                damAmount: Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1) * pawn.GetStatValue(StatDefOf.PsychicSensitivity, false) * (1 + 0.15f * pwrVal) * arcaneDmg),
+                armorPenetration: 0,
+                explosionSound: this.def.projectile.soundExplode,
+                weapon: def,
+                projectile: equipmentDef,
+                intendedTarget: intendedTarget.Thing
+            );
         }
 
         public Vector3 GetVector(IntVec3 center, IntVec3 objectPos)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsychicShock.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_PsychicShock.cs
@@ -96,13 +96,27 @@ namespace TorannMagic
                             {
                                 if (victim.Faction != this.pawn.Faction)
                                 {
-                                    //GenExplosion.DoExplosion(curCell, pawn.Map, .4f, DamageDefOf.Stun, this.launcher, Mathf.RoundToInt((4 * (2+this.def.projectile.GetDamageAmount(1, null) + pwrVal) * this.arcaneDmg)), 0, SoundDefOf.Crunch, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                                    /*GenExplosion.DoExplosion(
+                                        curCell, pawn.Map, .4f, DamageDefOf.Stun, launcher,
+                                        damAmount: Mathf.RoundToInt((4 * (2+this.def.projectile.GetDamageAmount(1) + pwrVal) * arcaneDmg)),
+                                        armorPenetration: 0,
+                                        explosionSound: SoundDefOf.Crunch,
+                                        weapon: def,
+                                        projectile: this.equipmentDef
+                                    );*/
                                     damageEntities(victim, null, Mathf.RoundToInt((4 * (2 + this.def.projectile.GetDamageAmount(1, null) + pwrVal) * this.arcaneDmg)), DamageDefOf.Stun);
                                 }
                                 else
                                 {
                                     damageEntities(victim, null, Mathf.RoundToInt(((2 + this.def.projectile.GetDamageAmount(1, null) + pwrVal) * this.arcaneDmg)), DamageDefOf.Stun);
-                                    //GenExplosion.DoExplosion(curCell, pawn.Map, .4f, DamageDefOf.Stun, this.launcher, Mathf.RoundToInt(((2+this.def.projectile.GetDamageAmount(1, null) + pwrVal) * this.arcaneDmg)), 0, SoundDefOf.Crunch, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                                    /*GenExplosion.DoExplosion(
+                                        curCell, pawn.Map, .4f, DamageDefOf.Stun, launcher,
+                                        damAmount: Mathf.RoundToInt(((2+this.def.projectile.GetDamageAmount(1) + pwrVal) * arcaneDmg)),
+                                        armorPenetration: 0,
+                                        explosionSound: SoundDefOf.Crunch,
+                                        weapon: def,
+                                        projectile: this.equipmentDef
+                                    );*/
                                 }
                             }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
@@ -162,11 +162,21 @@ namespace TorannMagic
                         {
                             if(deadPawn.RaceProps.Humanlike)
                             {
-                                GenExplosion.DoExplosion(base.Position, this.Map, Rand.Range(10, 16), TMDamageDefOf.DamageDefOf.TM_Holy, this.launcher, Mathf.RoundToInt(Rand.Range(20, 32)), 6, TMDamageDefOf.DamageDefOf.TM_Holy.soundExplosion);
+                                GenExplosion.DoExplosion(
+                                    Position, Map, Rand.Range(10, 16), TMDamageDefOf.DamageDefOf.TM_Holy, launcher,
+                                    damAmount: Mathf.RoundToInt(Rand.Range(20, 32)),
+                                    armorPenetration: 6,
+                                    explosionSound: TMDamageDefOf.DamageDefOf.TM_Holy.soundExplosion
+                                );
                             }
                             else
                             {
-                                GenExplosion.DoExplosion(base.Position, this.Map, Rand.Range(10, 16), TMDamageDefOf.DamageDefOf.TM_Holy, this.launcher, Mathf.RoundToInt(Rand.Range(16, 24)), 3, TMDamageDefOf.DamageDefOf.TM_Holy.soundExplosion);
+                                GenExplosion.DoExplosion(
+                                    Position, Map, Rand.Range(10, 16), TMDamageDefOf.DamageDefOf.TM_Holy, launcher,
+                                    damAmount: Mathf.RoundToInt(Rand.Range(16, 24)),
+                                    armorPenetration: 3,
+                                    explosionSound: TMDamageDefOf.DamageDefOf.TM_Holy.soundExplosion
+                                );
                             }
                         }
                         else

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sabotage.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Sabotage.cs
@@ -132,8 +132,10 @@ namespace TorannMagic
                                 if (true)
                                 {
                                     //stun/electrical explosion
-                                    GenExplosion.DoExplosion(targetBuilding.Position, base.Map, 2 + pwrVal + Mathf.RoundToInt(cpt.powerOutputInt / 400), DamageDefOf.Stun, null);
-                                    GenExplosion.DoExplosion(targetBuilding.Position, base.Map, 1 + pwrVal + Mathf.RoundToInt(cpt.powerOutputInt / 600), TMDamageDefOf.DamageDefOf.TM_ElectricalBurn, null);
+                                    GenExplosion.DoExplosion(
+                                        targetBuilding.Position, Map, 2 + pwrVal + Mathf.RoundToInt(cpt.powerOutputInt / 400), DamageDefOf.Stun, null);
+                                    GenExplosion.DoExplosion(
+                                        targetBuilding.Position, Map, 1 + pwrVal + Mathf.RoundToInt(cpt.powerOutputInt / 600), TMDamageDefOf.DamageDefOf.TM_ElectricalBurn, null);
 
                                 }
                                 else if (rnd <= .66f)
@@ -158,7 +160,8 @@ namespace TorannMagic
                                 }
                                 else
                                 {
-                                    GenExplosion.DoExplosion(targetBattery.Position, base.Map, 2 + pwrVal + Mathf.RoundToInt(compB.StoredEnergy / 200), DamageDefOf.EMP, null);
+                                    GenExplosion.DoExplosion(
+                                        targetBattery.Position, Map, 2 + pwrVal + Mathf.RoundToInt(compB.StoredEnergy / 200), DamageDefOf.EMP, null);
                                     compB.DrawPower(compB.StoredEnergy);
                                 }
 
@@ -173,7 +176,8 @@ namespace TorannMagic
                                 }
                                 else
                                 {
-                                    GenExplosion.DoExplosion(targetTurret.Position, base.Map, 2 + pwrVal, TMDamageDefOf.DamageDefOf.TM_ElectricalBurn, null); //20 default damage
+                                    GenExplosion.DoExplosion(
+                                        targetTurret.Position, Map, 2 + pwrVal, TMDamageDefOf.DamageDefOf.TM_ElectricalBurn, null); //20 default damage
                                 }
                             }
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Scorn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Scorn.cs
@@ -185,7 +185,13 @@ namespace TorannMagic
                             IntVec3 curCell = targets[j];
                             if (this.map != null && curCell.IsValid && curCell.InBoundsWithNullCheck(this.map))
                             {
-                                GenExplosion.DoExplosion(curCell, this.Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, this.pawn, (int)((this.def.projectile.GetDamageAmount(1, null) * (1 + .15 * pwrVal)) * this.arcaneDmg * Rand.Range(.75f, 1.25f)), 0, TorannMagicDefOf.TM_SoftExplosion, def, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                                GenExplosion.DoExplosion(
+                                    curCell, Map, .4f, TMDamageDefOf.DamageDefOf.TM_Shadow, pawn,
+                                    damAmount: (int)(this.def.projectile.GetDamageAmount(1) * (1 + .15 * pwrVal) * arcaneDmg * Rand.Range(.75f, 1.25f)),
+                                    armorPenetration: 0,
+                                    explosionSound: TorannMagicDefOf.TM_SoftExplosion,
+                                    weapon: def
+                                );
                             }
                         }
                         this.strikeNum++;

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_ShadowStrike.cs
@@ -223,7 +223,14 @@ namespace TorannMagic
                 ThingDef fog = TorannMagicDefOf.Fog_Shadows;
                 fog.gas.expireSeconds.min = 2;
                 fog.gas.expireSeconds.max = 3;
-                GenExplosion.DoExplosion(caster.Position, caster.Map, radius, TMDamageDefOf.DamageDefOf.TM_Toxin, caster, 0, 0, TMDamageDefOf.DamageDefOf.TM_Toxin.soundExplosion, null, null, null, fog, 1f, 1, false, null, 0f, 0, 0.0f, false);
+                GenExplosion.DoExplosion(
+                    caster.Position, caster.Map, radius, TMDamageDefOf.DamageDefOf.TM_Toxin, caster,
+                    damAmount: 0,
+                    armorPenetration: 0,
+                    explosionSound: TMDamageDefOf.DamageDefOf.TM_Toxin.soundExplosion,
+                    postExplosionSpawnThingDef: fog,
+                    postExplosionSpawnChance: 1f
+                );
 
                 for (int i = 0; i < 6; i++)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_SmokeCloud.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_SmokeCloud.cs
@@ -49,7 +49,17 @@ namespace TorannMagic
                 }
             }
 
-            GenExplosion.DoExplosion(base.Position, map, explosionRadius, this.def.projectile.damageDef, this.launcher, this.def.projectile.GetDamageAmount(1,null), 0, SoundDefOf.Artillery_ShellLoaded, def, this.equipmentDef, null, ThingDefOf.Gas_Smoke, 1f, 1, false, null, 0f, 1, 0f, false);
+            // TODO This will break in 1.4. Use BlindingSmoke GasType instead
+            GenExplosion.DoExplosion(
+                Position, map, explosionRadius, this.def.projectile.damageDef, launcher,
+                damAmount: this.def.projectile.GetDamageAmount(1),
+                armorPenetration: 0,
+                explosionSound: SoundDefOf.Artillery_ShellLoaded,
+                weapon: def,
+                projectile: equipmentDef, null,
+                postExplosionSpawnThingDef: ThingDefOf.Gas_Smoke,
+                postExplosionSpawnChance: 1f
+            );
 
 		}		
 	}	

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Snowball.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Snowball.cs
@@ -39,7 +39,14 @@ namespace TorannMagic
                 pwrVal = 3;
                 verVal = 3;
             }
-            GenExplosion.DoExplosion(base.Position, map, Mathf.RoundToInt(this.def.projectile.explosionRadius + (0.7f * (float)pwrVal)), TMDamageDefOf.DamageDefOf.Snowball, this.launcher, (int)((this.def.projectile.GetDamageAmount(1,null) + 3*pwrVal) * this.arcaneDmg), 0, SoundDefOf.Crunch, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+            GenExplosion.DoExplosion(
+	            Position, map, Mathf.RoundToInt(this.def.projectile.explosionRadius + 0.7f * pwrVal), TMDamageDefOf.DamageDefOf.Snowball, launcher,
+	            damAmount: (int)((this.def.projectile.GetDamageAmount(1) + 3*pwrVal) * arcaneDmg),
+	            armorPenetration: 0,
+	            explosionSound: SoundDefOf.Crunch,
+	            weapon: def,
+	            projectile: equipmentDef
+	        );
             CellRect cellRect = CellRect.CenteredOn(base.Position, 3 + (verVal * 1));
 			cellRect.ClipInsideMap(map);
 			for (int i = 0; i < verVal * 4; i++)

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Action.cs
@@ -1853,7 +1853,12 @@ namespace TorannMagic
                 switch (rndBad)
                 {
                     case 0:
-                        GenExplosion.DoExplosion(p.Position, p.Map, 5f, DamageDefOf.Bomb, p, Rand.Range(8, 12), 1f, null, null, null, null, null, 0, 1, false, null, 0, 1, 0, true);
+                        GenExplosion.DoExplosion(
+                            p.Position, p.Map, 5f, DamageDefOf.Bomb, p,
+                            damAmount: Rand.Range(8, 12),
+                            armorPenetration: 1f,
+                            damageFalloff: true
+                        );
                         surgeText = "Explosion";
                         break;
                     case 1:
@@ -2425,7 +2430,12 @@ namespace TorannMagic
                     Pawn p = new Pawn();
                     p = pawn;
                     Map map = p.Map;
-                    GenExplosion.DoExplosion(p.Position, p.Map, 0f, DamageDefOf.Burn, p as Thing, 0, 0, SoundDefOf.Thunder_OnMap, null, null, null, null, 0f, 0, false, null, 0f, 0, 0.0f, false);
+                    GenExplosion.DoExplosion(
+                        p.Position, p.Map, 0f, DamageDefOf.Burn, p,
+                        damAmount: 0,
+                        armorPenetration: 0,
+                        explosionSound: SoundDefOf.Thunder_OnMap
+                    );
                     Effecter deathEffect = TorannMagicDefOf.TM_DeathExplosion.Spawn();
                     deathEffect.Trigger(new TargetInfo(p.Position, p.Map, false), new TargetInfo(p.Position, p.Map, false));
                     deathEffect.Cleanup();
@@ -2543,7 +2553,11 @@ namespace TorannMagic
                     }
                     break;
                 case 4: //stun pulse
-                    GenExplosion.DoExplosion(pos, pawn.Map, 6, DamageDefOf.Stun, pawn, 0, 0);
+                    GenExplosion.DoExplosion(
+                        pos, pawn.Map, 6, DamageDefOf.Stun, pawn,
+                        damAmount: 0,
+                        armorPenetration: 0
+                    );
                     pawns = TM_Calc.FindAllPawnsAround(pawn.Map, pos, 4f, pawn.Faction, friendlyFire);
                     if (pawns != null && pawns.Count > 0)
                     {
@@ -2624,7 +2638,12 @@ namespace TorannMagic
                     GenPlace.TryPlaceThing(pTrap, pawn.Position, pawn.Map, ThingPlaceMode.Direct);
                     break;
                 case 2: //burst into flames
-                    GenExplosion.DoExplosion(pawn.Position, pawn.Map, 2f, DamageDefOf.Flame, pawn, 10, 0, DamageDefOf.Flame.soundExplosion);
+                    GenExplosion.DoExplosion(
+                        pawn.Position, pawn.Map, 2f, DamageDefOf.Flame, pawn,
+                        damAmount: 10,
+                        armorPenetration: 0,
+                        explosionSound: DamageDefOf.Flame.soundExplosion
+                    );
                     break;
                 case 3: //wave of fear
                     SoundInfo info = SoundInfo.InMap(new TargetInfo(pawn.Position, pawn.Map, false), MaintenanceType.None);

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_WeatherEvent_MeshFlash.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_WeatherEvent_MeshFlash.cs
@@ -117,7 +117,11 @@ namespace TorannMagic
             if (!this.strikeLoc.Fogged(this.map))
             {
                 SoundDef exp = TorannMagicDefOf.TM_FireBombSD;
-                GenExplosion.DoExplosion(this.strikeLoc, this.map, (Rand.Range(.8f, 1.2f) * this.averageRadius), this.damageType, instigator, this.damageAmount, -1f, exp, null, null, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                GenExplosion.DoExplosion(
+                    strikeLoc, map, Rand.Range(.8f, 1.2f) * averageRadius, damageType, instigator,
+                    damAmount: damageAmount,
+                    explosionSound: exp
+                );
                 Vector3 loc = this.strikeLoc.ToVector3Shifted();
                 for (int i = 0; i < 4; i++)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowWalk.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShadowWalk.cs
@@ -111,7 +111,14 @@ namespace TorannMagic
                                 ThingDef fog = TorannMagicDefOf.Fog_Shadows;
                                 fog.gas.expireSeconds.min = 4;
                                 fog.gas.expireSeconds.max = 4;
-                                GenExplosion.DoExplosion(p.Position, p.Map, 2, TMDamageDefOf.DamageDefOf.TM_Toxin, caster, 0, 0, TMDamageDefOf.DamageDefOf.TM_Toxin.soundExplosion, null, null, null, fog, 1f, 1, false, null, 0f, 0, 0.0f, false);
+                                GenExplosion.DoExplosion(
+                                    p.Position, p.Map, 2, TMDamageDefOf.DamageDefOf.TM_Toxin, caster,
+                                    damAmount: 0,
+                                    armorPenetration: 0,
+                                    explosionSound: TMDamageDefOf.DamageDefOf.TM_Toxin.soundExplosion,
+                                    postExplosionSpawnThingDef: fog,
+                                    postExplosionSpawnChance: 1f
+                                );
 
                             }
                         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ShatterSentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ShatterSentinel.cs
@@ -85,7 +85,14 @@ namespace TorannMagic
                     Vector3 moteDirection = TM_Calc.GetVector(sentinel.DrawPos.ToIntVec3(), intVec);
                     TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Rubble, sentinel.DrawPos, map, Rand.Range(.3f, .6f), .2f, .02f, .05f, Rand.Range(-100, 100), Rand.Range(8f, 13f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
                     TM_MoteMaker.ThrowGenericFleck(FleckDefOf.Smoke, sentinel.DrawPos, map, Rand.Range(.9f, 1.2f), .3f, .02f, Rand.Range(.25f, .4f), Rand.Range(-100, 100), Rand.Range(5f, 8f), (Quaternion.AngleAxis(90, Vector3.up) * moteDirection).ToAngleFlat(), 0);
-                    GenExplosion.DoExplosion(intVec, map, .4f, DamageDefOf.Blunt, this.CasterPawn, 0, 0, SoundDefOf.Pawn_Melee_Punch_HitBuilding, null, null, null, ThingDefOf.Filth_RubbleRock, .4f, 1, false, null, 0f, 1, 0, false);
+                    GenExplosion.DoExplosion(
+                        intVec, map, .4f, DamageDefOf.Blunt, CasterPawn,
+                        damAmount: 0,
+                        armorPenetration: 0,
+                        explosionSound: SoundDefOf.Pawn_Melee_Punch_HitBuilding,
+                        postExplosionSpawnThingDef: ThingDefOf.Filth_RubbleRock,
+                        postExplosionSpawnChance: .4f
+                    );
                     //FleckMaker.ThrowSmoke(intVec.ToVector3Shifted(), base.Map, Rand.Range(.6f, 1f));
                 }
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_VeilOfShadows.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_VeilOfShadows.cs
@@ -38,7 +38,14 @@ namespace TorannMagic
                 ThingDef fog = TorannMagicDefOf.Fog_Shadows;
                 fog.gas.expireSeconds.min = 10 + pwrVal;
                 fog.gas.expireSeconds.max = 11  + pwrVal;
-                GenExplosion.DoExplosion(caster.Position, caster.Map, 3f + (.3f * verVal), TMDamageDefOf.DamageDefOf.TM_Toxin, caster, 0, 0, TMDamageDefOf.DamageDefOf.TM_Toxin.soundExplosion, null, null, null, fog, 1f, 1, false, null, 0f, 0, 0.0f, false);
+                GenExplosion.DoExplosion(
+                    caster.Position, caster.Map, 3f + .3f * verVal, TMDamageDefOf.DamageDefOf.TM_Toxin, caster,
+                    damAmount: 0,
+                    armorPenetration: 0,
+                    explosionSound: TMDamageDefOf.DamageDefOf.TM_Toxin.soundExplosion,
+                    postExplosionSpawnThingDef: fog,
+                    postExplosionSpawnChance: 1f
+                );
 
                 for (int i = 0; i < 6; i++)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_BlazingPower.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_BlazingPower.cs
@@ -34,7 +34,15 @@ namespace TorannMagic.Weapon
                     //    DamageEntities(thingList[i], null, this.def.projectile.GetDamageAmount(1, null), TMDamageDefOf.DamageDefOf.TM_BlazingPower, pawn);
                     //}
                     
-                    GenExplosion.DoExplosion(base.Position, map, .8f, TMDamageDefOf.DamageDefOf.TM_BlazingPower, this.launcher, Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1, null) * this.arcaneDmg), 2, SoundDefOf.Crunch, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0.0f, true);
+                    GenExplosion.DoExplosion(
+                        Position, map, .8f, TMDamageDefOf.DamageDefOf.TM_BlazingPower, launcher,
+                        damAmount: Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1) * arcaneDmg),
+                        armorPenetration: 2,
+                        explosionSound: SoundDefOf.Crunch,
+                        weapon: def,
+                        projectile: equipmentDef,
+                        damageFalloff: true
+                    );
                 }
                 catch
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_FireWand.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_FireWand.cs
@@ -25,7 +25,15 @@ namespace TorannMagic.Weapon
             Map map = this.launcher.Map;
             base.Impact(hitThing);
             ThingDef def = this.def;
-            GenExplosion.DoExplosion(base.Position, map, 1, DamageDefOf.Burn, this.launcher, Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1, null) * this.arcaneDmg), 2, SoundDefOf.Crunch, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0, true);
+            GenExplosion.DoExplosion(
+                Position, map, 1, DamageDefOf.Burn, launcher,
+                damAmount: Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1) * arcaneDmg),
+                armorPenetration: 2,
+                explosionSound: SoundDefOf.Crunch,
+                weapon: def,
+                projectile: equipmentDef,
+                damageFalloff: true
+            );
 
             try
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_IceWand.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/Projectile_IceWand.cs
@@ -26,7 +26,14 @@ namespace TorannMagic.Weapon
             }
             try
             {
-                GenExplosion.DoExplosion(base.Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Iceshard, this.launcher, Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1,null) * this.arcaneDmg), 1, this.def.projectile.soundExplode, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                GenExplosion.DoExplosion(
+                    Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Iceshard, launcher,
+                    damAmount: Mathf.RoundToInt(this.def.projectile.GetDamageAmount(1) * arcaneDmg),
+                    armorPenetration: 1,
+                    explosionSound: this.def.projectile.soundExplode,
+                    weapon: def,
+                    projectile: equipmentDef
+                );
             }
             catch
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/SeerRing_Fire.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/SeerRing_Fire.cs
@@ -16,7 +16,15 @@ namespace TorannMagic.Weapon
             ThingDef def = this.def;
             try
             {
-                GenExplosion.DoExplosion(base.Position, map, this.def.projectile.explosionRadius, DamageDefOf.Bomb, this.launcher, this.def.projectile.GetDamageAmount(1,null), 2, SoundDefOf.Crunch, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0.1f, false);
+                GenExplosion.DoExplosion(
+                    Position, map, this.def.projectile.explosionRadius, DamageDefOf.Bomb, launcher,
+                    damAmount: this.def.projectile.GetDamageAmount(1),
+                    armorPenetration: 2,
+                    explosionSound: SoundDefOf.Crunch,
+                    weapon: def,
+                    projectile: equipmentDef,
+                    chanceToStartFire: 0.1f
+                );
             }
             catch
             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Weapon/SeerRing_Ice.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Weapon/SeerRing_Ice.cs
@@ -15,7 +15,14 @@ namespace TorannMagic.Weapon
             Pawn pawn = this.launcher as Pawn;
             try
             {
-                GenExplosion.DoExplosion(base.Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Iceshard, this.launcher, this.def.projectile.GetDamageAmount(1,null), 3, this.def.projectile.soundExplode, def, this.equipmentDef, null, null, 0f, 1, false, null, 0f, 1, 0f, false);
+                GenExplosion.DoExplosion(
+                    Position, map, 0.4f, TMDamageDefOf.DamageDefOf.Iceshard, launcher,
+                    damAmount: this.def.projectile.GetDamageAmount(1),
+                    armorPenetration: 3,
+                    explosionSound: this.def.projectile.soundExplode,
+                    weapon: def,
+                    projectile: equipmentDef
+                );
             }
             catch
             {


### PR DESCRIPTION
Use named arguments to prepare for the addition of an argument to DoExplosion. 1 will still need updating for 1.4 as smoke is no longer a ThingDef in 1.4