### PR TITLE
Remove GetHediff<T> calls for 1.4 compatibility

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
@@ -506,27 +506,12 @@ namespace TorannMagic.AutoCast
                 {
                     if (minSeverity != 0)
                     {
-                        float injurySeverity = 0f;
-                        using (IEnumerator<BodyPartRecord> enumerator = caster.health.hediffSet.GetInjuredParts().GetEnumerator())
-                        {
-                            while (enumerator.MoveNext())
-                            {
-                                BodyPartRecord rec = enumerator.Current;
-                                IEnumerable<Hediff_Injury> arg_BB_0 = caster.health.hediffSet.GetHediffs<Hediff_Injury>();
-                                Func<Hediff_Injury, bool> arg_BB_1;
-                                arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
+                        float injurySeverity = caster.health.hediffSet.hediffs
+                            .OfType<Hediff_Injury>()
+                            .Where(injury => injury.CanHealNaturally() && !injury.IsPermanent())
+                            .Sum(injury => injury.Severity);
 
-                                foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                                {
-                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                    if (flag5)
-                                    {
-                                        injurySeverity += current.Severity;
-                                    }
-                                }
-                            }
-                        }
-                        if(injurySeverity >= minSeverity)
+                        if (injurySeverity >= minSeverity)
                         {
                             Job job = ability.GetJob(AbilityContext.AI, jobTarget);
                             DoJob.Execute(job, caster);
@@ -881,26 +866,11 @@ namespace TorannMagic.AutoCast
 
             if (casterComp.Mana.CurLevel >= casterComp.ActualManaCost(abilitydef) && ability.CooldownTicksLeft <= 0 && jobTarget.Thing != null)
             {
-                float injurySeverity = 0;
-                using (IEnumerator<BodyPartRecord> enumerator = caster.health.hediffSet.GetInjuredParts().GetEnumerator())
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-                        IEnumerable<Hediff_Injury> arg_BB_0 = caster.health.hediffSet.GetHediffs<Hediff_Injury>();
-                        Func<Hediff_Injury, bool> arg_BB_1;
-                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
+                float injurySeverity = caster.health.hediffSet.hediffs
+                    .OfType<Hediff_Injury>()
+                    .Where(injury => injury.CanHealNaturally() && !injury.IsPermanent())
+                    .Sum(injury => injury.Severity);
 
-                        foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                        {
-                            bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                            if (flag5)
-                            {
-                                injurySeverity += current.Severity;                                
-                            }
-                        }
-                    }
-                }
                 if (injurySeverity != 0 && !(caster.health.hediffSet.HasHediff(HediffDef.Named("TM_HediffShield"))))
                 {
                     Job job = ability.GetJob(AbilityContext.AI, jobTarget);

--- a/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
@@ -508,7 +508,7 @@ namespace TorannMagic.AutoCast
                     {
                         float injurySeverity = caster.health.hediffSet.hediffs
                             .OfType<Hediff_Injury>()
-                            .Where(injury => injury.CanHealNaturally() && !injury.IsPermanent())
+                            .Where(injury => injury.CanHealNaturally())
                             .Sum(injury => injury.Severity);
 
                         if (injurySeverity >= minSeverity)
@@ -868,7 +868,7 @@ namespace TorannMagic.AutoCast
             {
                 float injurySeverity = caster.health.hediffSet.hediffs
                     .OfType<Hediff_Injury>()
-                    .Where(injury => injury.CanHealNaturally() && !injury.IsPermanent())
+                    .Where(injury => injury.CanHealNaturally())
                     .Sum(injury => injury.Severity);
 
                 if (injurySeverity != 0 && !(caster.health.hediffSet.HasHediff(HediffDef.Named("TM_HediffShield"))))

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -4757,13 +4757,12 @@ namespace TorannMagic
 
         public void RemoveTMagicHediffs()
         {
-            List<Hediff> allHediffs = this.Pawn.health.hediffSet.GetHediffs<Hediff>().ToList();
-            for (int i = 0; i < allHediffs.Count(); i++)
+            List<Hediff> allHediffs = Pawn.health.hediffSet.hediffs;
+            for (int i = 0; i < allHediffs.Count; i++)
             {
-                Hediff hediff = allHediffs[i];
-                if (hediff.def.defName.Contains("TM_"))
+                if (allHediffs[i].def.defName.Contains("TM_"))
                 {
-                    this.Pawn.health.RemoveHediff(hediff);
+                    this.Pawn.health.RemoveHediff(allHediffs[i]);
                 }
 
             }
@@ -8584,7 +8583,7 @@ namespace TorannMagic
                 _maxMPUpkeep += TorannMagicDefOf.TM_Recall.upkeepEnergyCost * (1 - (TorannMagicDefOf.TM_Recall.upkeepEfficiencyPercent * this.MagicData.MagicPowerSkill_Recall.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Recall_eff").level));
                 _mpRegenRateUpkeep += TorannMagicDefOf.TM_Recall.upkeepRegenCost * (1 - (TorannMagicDefOf.TM_Recall.upkeepEfficiencyPercent * this.MagicData.MagicPowerSkill_Recall.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Recall_eff").level));
             }
-            using (IEnumerator<Hediff> enumerator = this.Pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+            using (IEnumerator<Hediff> enumerator = Pawn.health.hediffSet.hediffs.GetEnumerator())
             {
                 while (enumerator.MoveNext())
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
@@ -3274,7 +3274,7 @@ namespace TorannMagic
 
             IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
                 .OfType<Hediff_Injury>()
-                .Where(injury => injury.CanHealNaturally() && !injury.IsPermanent())
+                .Where(injury => injury.CanHealNaturally())
                 .DistinctBy(injury => injury.Part, numberOfInjuriesPerPart)
                 .Take(1 + verVal);
 

--- a/RimWorldOfMagic/RimWorldOfMagic/CompPolymorph.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompPolymorph.cs
@@ -276,7 +276,7 @@ namespace TorannMagic
         {
             IEnumerable<Hediff_Injury> injuriesToAdd = pawn.health.hediffSet.hediffs
                 .OfType<Hediff_Injury>()
-                .Where(injury => injury.CanHealNaturally() && !injury.IsPermanent());
+                .Where(injury => injury.CanHealNaturally());
             injuries.AddRange(injuriesToAdd);
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/CompPolymorph.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompPolymorph.cs
@@ -274,25 +274,10 @@ namespace TorannMagic
 
         public void CopyDamage(Pawn pawn)
         {
-            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-            {
-                while (enumerator.MoveNext())
-                {
-                    BodyPartRecord rec = enumerator.Current;
-                    IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                    Func<Hediff_Injury, bool> arg_BB_1;
-                    arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                    foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                    {
-                        bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                        if (flag5)
-                        {
-                            this.injuries.Add(current);
-                        }                            
-                    }                    
-                }
-            }
+            IEnumerable<Hediff_Injury> injuriesToAdd = pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally() && !injury.IsPermanent());
+            injuries.AddRange(injuriesToAdd);
         }
 
         public override void PostDestroy(DestroyMode mode, Map previousMap)

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSentinel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSentinel.cs
@@ -260,10 +260,8 @@ namespace TorannMagic
             AbilityUser.SpawnThings spawnables = new SpawnThings();
             spawnables.def = ThingDef.Named("TM_Sentinel");
             spawnables.spawnCount = 1;
-            bool flag = spawnables.def != null;
-            if (flag)
+            if (spawnables.def != null)
             {
-                Faction faction = this.sustainerPawn.Faction;
                 ThingDef def = spawnables.def;
                 ThingDef stuff = null;
                 bool madeFromStuff = def.MadeFromStuff;
@@ -272,30 +270,15 @@ namespace TorannMagic
                     stuff = ThingDef.Named("BlocksGranite");
                 }
                 spawnedThing = ThingMaker.MakeThing(def, stuff);
-                GenSpawn.Spawn(spawnedThing, this.sentinelLoc, this.Pawn.Map, this.rotation, WipeMode.Vanish, false);
-                float totalHealth = 0;
-                float healthDeficit = 0;
-                using (IEnumerator<BodyPartRecord> enumerator = this.Pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-                        totalHealth += rec.def.hitPoints;
-                        IEnumerable<Hediff_Injury> arg_BB_0 = this.Pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                        Func<Hediff_Injury, bool> arg_BB_1;
+                GenSpawn.Spawn(spawnedThing, sentinelLoc, Pawn.Map, rotation);
+                float injurySeverity = Pawn.health.hediffSet.hediffs
+                    .OfType<Hediff_Injury>()
+                    .Sum(injury => injury.Severity);
 
-                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                        foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                        {                            
-                            healthDeficit += current.Severity;
-                        }
-                    }
-                }
-                CompAbilityUserMagic comp = this.sustainerPawn.GetCompAbilityUserMagic();
-                comp.summonedSentinels.Remove(this.Pawn);
+                CompAbilityUserMagic comp = sustainerPawn.GetCompAbilityUserMagic();
+                comp.summonedSentinels.Remove(Pawn);
                 comp.summonedSentinels.Add(spawnedThing);
-                DamageInfo dinfo = new DamageInfo(DamageDefOf.Blunt, 10*healthDeficit, 0, (float)-1, this.Pawn, null, null, DamageInfo.SourceCategory.ThingOrUnknown);
+                DamageInfo dinfo = new DamageInfo(DamageDefOf.Blunt, 10*injurySeverity, 0, -1, Pawn);
                 spawnedThing.TakeDamage(dinfo);
 
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/HediffComp_Health.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/HediffComp_Health.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UnityEngine;
 using System;
 using System.Collections.Generic;
+using TorannMagic.Utils;
 
 namespace TorannMagic.Enchantment
 {
@@ -22,39 +23,15 @@ namespace TorannMagic.Enchantment
 
         public override void HediffActionTick()
         {
-            Pawn pawn = this.Pawn;
-            int num = 2;
+            IEnumerable<Hediff_Injury> injuries = Pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally() && !injury.IsPermanent())
+                .DistinctBy(injury => injury.Part)
+                .Take(2);
 
-            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+            foreach (Hediff_Injury injury in injuries)
             {
-                while (enumerator.MoveNext())
-                {
-                    BodyPartRecord rec = enumerator.Current;
-                    bool flag2 = num > 0;
-                    int num2 = 1;
-                    if (flag2)
-                    {
-                        IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                        Func<Hediff_Injury, bool> arg_BB_1;
-
-                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                        foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                        {
-                            bool flag3 = num2 > 0;
-                            if (flag3)
-                            {
-                                bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                if (flag5)
-                                {
-                                    current.Heal(Rand.Range(.1f, .3f));
-                                    num--;
-                                    num2--;
-                                }
-                            }
-                        }
-                    }
-                }
+                injury.Heal(Rand.Range(.1f, .3f));
             }
         }
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Enchantment/HediffComp_Health.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Enchantment/HediffComp_Health.cs
@@ -25,7 +25,7 @@ namespace TorannMagic.Enchantment
         {
             IEnumerable<Hediff_Injury> injuries = Pawn.health.hediffSet.hediffs
                 .OfType<Hediff_Injury>()
-                .Where(injury => injury.CanHealNaturally() && !injury.IsPermanent())
+                .Where(injury => injury.CanHealNaturally())
                 .DistinctBy(injury => injury.Part)
                 .Take(2);
 

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -1462,7 +1462,7 @@ namespace TorannMagic
                                 if (injuries.Any())
                                 {
                                     Hediff_Injury injury = injuries.RandomElement();
-                                    if (injury.CanHealNaturally() && !injury.IsPermanent())
+                                    if (injury.CanHealNaturally())
                                     {
                                         float healAmt = Rand.Range(.025f, .15f);
 

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -1458,8 +1458,8 @@ namespace TorannMagic
                             Pawn pawn = map.mapPawns.AllPawnsSpawned[i];
                             if (!pawn.Position.Roofed(map) && Rand.Chance(.3f))
                             {
-                                IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                                if (injuries != null && injuries.Count() > 0)
+                                IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs.OfType<Hediff_Injury>().ToList();
+                                if (injuries.Any())
                                 {
                                     Hediff_Injury injury = injuries.RandomElement();
                                     if (injury.CanHealNaturally() && !injury.IsPermanent())

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BloodForBlood.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BloodForBlood.cs
@@ -180,7 +180,7 @@ namespace TorannMagic
             // Heal first injury
             Hediff_Injury linkedInjury = linkedPawn.health.hediffSet.hediffs
                 .OfType<Hediff_Injury>()
-                .FirstOrDefault(injury => !injury.CanHealNaturally() && injury.IsPermanent());
+                .FirstOrDefault(injury => injury.IsPermanent());
             if (linkedInjury == default) return;
 
             if (linkedInjury.Part.def.tags.Contains(BodyPartTagDefOf.ConsciousnessSource))
@@ -193,7 +193,7 @@ namespace TorannMagic
         {
             Hediff_Injury injuryToHeal = Pawn.health.hediffSet.hediffs
                 .OfType<Hediff_Injury>()
-                .FirstOrDefault(injury => injury.CanHealNaturally() && !injury.IsPermanent());
+                .FirstOrDefault(injury => injury.CanHealNaturally());
             if (injuryToHeal == default) return;
 
             injuryToHeal.Heal(2f + .25f * Pawn.health.hediffSet.BleedRateTotal);

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BloodShield.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BloodShield.cs
@@ -139,42 +139,25 @@ namespace TorannMagic
 
         public void HealWounds(float healAmount)
         {
-            this.woundsHealed = false;
-            int num = 1;
-            using (IEnumerator<BodyPartRecord> enumerator = this.Pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-            {
-                while (enumerator.MoveNext())
-                {
-                    BodyPartRecord rec = enumerator.Current;
-                    bool flag2 = num > 0;
+            woundsHealed = false;
+            Hediff_Injury injuryToHeal = Pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .FirstOrDefault(injury => injury.CanHealNaturally() && !injury.IsPermanent());
+            if (injuryToHeal == default) return;
 
-                    if (flag2)
-                    {
-                        int num2 = 1;
-                        IEnumerable<Hediff_Injury> arg_BB_0 = this.Pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                        Func<Hediff_Injury, bool> arg_BB_1;
-
-                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                        foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                        {
-                            bool flag4 = num2 > 0;
-                            if (flag4)
-                            {                                
-                                bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                if (flag5)
-                                {
-                                    current.Heal(healAmount);
-                                    TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_BloodMist, this.Pawn.DrawPos, this.Pawn.Map, Rand.Range(.5f, .75f), .2f, 0.05f, 1f, Rand.Range(-50, 50), Rand.Range(.5f, .7f), Rand.Range(30,40), Rand.Range(0, 360));
-                                    num--;
-                                    num2--;
-                                    this.woundsHealed = true;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            injuryToHeal.Heal(healAmount);
+            TM_MoteMaker.ThrowGenericMote(
+                TorannMagicDefOf.Mote_BloodMist, Pawn.DrawPos, Pawn.Map,
+                scale: Rand.Range(.5f, .75f),
+                solidTime: .2f,
+                fadeIn: 0.05f,
+                fadeOut: 1f,
+                rotationRate: Rand.Range(-50, 50),
+                velocity: Rand.Range(.5f, .7f),
+                velocityAngle: Rand.Range(30,40),
+                lookAngle: Rand.Range(0, 360)
+            );
+            woundsHealed = true;
         }
 
         public override bool CompShouldRemove

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BurningFury.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_BurningFury.cs
@@ -139,7 +139,7 @@ namespace TorannMagic
         {
             Hediff_Injury injuryToTend = Pawn.health.hediffSet.hediffs
                 .OfType<Hediff_Injury>()
-                .FirstOrDefault(injury => injury.CanHealNaturally() && !injury.IsPermanent() && injury.TendableNow());
+                .FirstOrDefault(injury => injury.CanHealNaturally() && injury.TendableNow());
             if (injuryToTend == default) return;
 
             if (Rand.Chance(.15f))

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Demon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Demon.cs
@@ -65,16 +65,16 @@ namespace TorannMagic
                         }
                         if (Find.TickManager.TicksGame % 300 == 0)
                         {
-                            IEnumerable<Hediff_Injury> injuries = this.Pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                            if(injuries.Count() > 20 && this.parent.Severity < 1f)
+                            List<Hediff_Injury> injuries = Pawn.health.hediffSet.hediffs.OfType<Hediff_Injury>().ToList();
+                            if(injuries.Count > 20 && parent.Severity < 1f)
                             {
-                                HealthUtility.AdjustSeverity(this.Pawn, this.Def, -10);
-                                HealthUtility.AdjustSeverity(this.Pawn, this.Def, 1.5f);
+                                HealthUtility.AdjustSeverity(Pawn, Def, -10);
+                                HealthUtility.AdjustSeverity(Pawn, Def, 1.5f);
                             }
-                            else if(injuries.Count() > 40 && this.parent.Severity < 2f)
+                            else if(injuries.Count > 40 && parent.Severity < 2f)
                             {
-                                HealthUtility.AdjustSeverity(this.Pawn, this.Def, -10);
-                                HealthUtility.AdjustSeverity(this.Pawn, this.Def, 2.5f);
+                                HealthUtility.AdjustSeverity(Pawn, Def, -10);
+                                HealthUtility.AdjustSeverity(Pawn, Def, 2.5f);
                             }
                         }
                     }

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_DiseaseImmunity.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_DiseaseImmunity.cs
@@ -48,8 +48,7 @@ namespace TorannMagic
                     {
                         if(this.verVal >= 3)
                         {
-                            IEnumerable<Hediff> hdEnum = this.Pawn.health.hediffSet.GetHediffs<Hediff>();
-                            foreach (Hediff hd in hdEnum)
+                            foreach (Hediff hd in Pawn.health.hediffSet.hediffs)
                             {
                                 if (hd.def.defName == "BloodRot")
                                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_HerbalElixir.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_HerbalElixir.cs
@@ -53,11 +53,9 @@ namespace TorannMagic
 
         public void TickAction()
         {
-            Pawn pawn = this.Pawn;
+            Pawn pawn = Pawn;
 
-
-            IEnumerable<Hediff> hds = this.Pawn.health.hediffSet.GetHediffs<Hediff>();
-            foreach (Hediff current in hds)
+            foreach (Hediff current in pawn.health.hediffSet.hediffs)
             {
                 if (verVal >= 1)
                 {
@@ -76,27 +74,16 @@ namespace TorannMagic
                 }
             }
 
-            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+            foreach (Hediff_Injury injury in pawn.health.hediffSet.hediffs.OfType<Hediff_Injury>())
             {
-                while (enumerator.MoveNext())
+                if (injury.CanHealNaturally() && !injury.IsPermanent())
                 {
-                    BodyPartRecord rec = enumerator.Current;
-                    IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                    Func<Hediff_Injury, bool> arg_BB_1;
-                    arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-                    foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                    {
-                        bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                        if (flag5)
-                        {
-                            float healBleedingBonus = (current.Bleeding ? .2f : 0f);                                
-                            current.Heal((Rand.Range(.2f, .3f) + healBleedingBonus) * this.parent.Severity * (1f + (.1f * pwrVal))); //140-200 applications = 14 - 39 healing for every wound                            
-                        }        
-                        else if(verVal >= 3)
-                        {
-                            current.Heal(Rand.Range(.008f, .012f) * this.parent.Severity * (1f + (.1f * pwrVal))); //.56 - 1.56 permanent injury healing for every wound
-                        }
-                    }                    
+                    float healBleedingBonus = injury.Bleeding ? .2f : 0f;
+                    injury.Heal((Rand.Range(.2f, .3f) + healBleedingBonus) * parent.Severity * (1f + .1f * pwrVal)); //140-200 applications = 14 - 39 healing for every wound
+                }
+                else if(verVal >= 3)
+                {
+                    injury.Heal(Rand.Range(.008f, .012f) * parent.Severity * (1f + .1f * pwrVal)); //.56 - 1.56 permanent injury healing for every wound
                 }
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_HerbalElixir.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_HerbalElixir.cs
@@ -76,7 +76,7 @@ namespace TorannMagic
 
             foreach (Hediff_Injury injury in pawn.health.hediffSet.hediffs.OfType<Hediff_Injury>())
             {
-                if (injury.CanHealNaturally() && !injury.IsPermanent())
+                if (injury.CanHealNaturally())
                 {
                     float healBleedingBonus = injury.Bleeding ? .2f : 0f;
                     injury.Heal((Rand.Range(.2f, .3f) + healBleedingBonus) * parent.Severity * (1f + .1f * pwrVal)); //140-200 applications = 14 - 39 healing for every wound

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_InnerHealing.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_InnerHealing.cs
@@ -3,6 +3,7 @@ using Verse;
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using TorannMagic.Utils;
 
 namespace TorannMagic
 {
@@ -80,78 +81,24 @@ namespace TorannMagic
 
         public void TickAction()
         {
-            Pawn pawn = this.Pawn;
-            int num = 2;
+            IEnumerable<Hediff_Injury> injuries = Pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally())
+                .DistinctBy(injury => injury.Part)
+                .Take(2);
 
-            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+            foreach (Hediff_Injury injury in injuries)
             {
-                while (enumerator.MoveNext())
-                {
-                    BodyPartRecord rec = enumerator.Current;
-                    bool flag2 = num > 0;
-                    int num2 = 1;
-                    if (flag2)
-                    {
-                        IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                        Func<Hediff_Injury, bool> arg_BB_1;
-
-                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                        foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                        {
-                            bool flag3 = num2 > 0;
-                            if (flag3)
-                            {
-                                bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                if (flag5)
-                                {
-                                    current.Heal(Rand.Range(.2f, 1f));
-                                    num--;
-                                    num2--;
-                                }
-                            }
-                        }
-                    }
-                }
+                injury.Heal(Rand.Range(.2f, 1f));
             }
         }
 
         public void TickActionPerm()
         {
-            Pawn pawn = this.Pawn;
-            int num = 1;
-            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-            {
-                while (enumerator.MoveNext())
-                {
-                    BodyPartRecord rec = enumerator.Current;
-                    bool flag2 = num > 0;
-                    if (flag2)
-                    {
-                        int num2 = 1;
-                        IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                        Func<Hediff_Injury, bool> arg_BB_1;
-
-                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                        foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                        {
-                            bool flag4 = num2 > 0;
-                            if (flag4)
-                            {
-                                bool flag5 = !current.CanHealNaturally() && current.IsPermanent();
-                                if (flag5)
-                                {
-                                    current.Heal(Rand.Range(.1f, .3f));
-                                    num--;
-                                    num2--;
-
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            Hediff_Injury injuryToHeal = Pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .FirstOrDefault(injury => injury.IsPermanent());
+            injuryToHeal?.Heal(Rand.Range(.1f, .3f));
         }
 
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Lich.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Lich.cs
@@ -55,18 +55,12 @@ namespace TorannMagic
                 }
             }
 
-
             if (Find.TickManager.TicksGame % 16 == 0)
             {
-                IEnumerable<Hediff> hdEnum = this.Pawn.health.hediffSet.GetHediffs<Hediff>();
-                foreach (Hediff hd in hdEnum)
-                {
-                    if (hd.def.defName == "SpaceHypoxia")
-                    {
-                        this.Pawn.health.RemoveHediff(hd);
-                        break;
-                    }
-                }
+                Hediff hediffToRemove =
+                    Pawn?.health.hediffSet.hediffs.FirstOrDefault(hd => hd.def.defName == "SpaceHypoxia");
+                if (hediffToRemove != default)
+                    Pawn.health.RemoveHediff(hediffToRemove);
             }
 
             bool flag4 = Find.TickManager.TicksGame % 600 == 0;
@@ -81,46 +75,9 @@ namespace TorannMagic
                     }
                     
                 }
-                Pawn pawn = base.Pawn;
-                int num = 1;
-                int num2 = 1;
-                using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-                        bool flag2 = num > 0;
-
-                        if (flag2)
-                        {
-                            IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                            Func<Hediff_Injury, bool> arg_BB_1;
-
-                            arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                            foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                            {
-                                bool flag3 = num2 > 0;
-                                if (flag3)
-                                {
-                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                    if (flag5)
-                                    {
-                                        current.Heal(2.0f);
-                                        num--;
-                                        num2--;
-                                    }
-                                    else
-                                    {
-                                        current.Heal(1.0f);
-                                        num--;
-                                        num2--;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                Pawn pawn = Pawn;
+                Hediff_Injury injuryToHeal = pawn.health.hediffSet.hediffs.OfType<Hediff_Injury>().FirstOrDefault();
+                injuryToHeal?.Heal(injuryToHeal.CanHealNaturally() ? 2.0f : 1.0f);
 
                 using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffsTendable().GetEnumerator())
                 {
@@ -132,7 +89,6 @@ namespace TorannMagic
                             if (rec.Bleeding && rec is Hediff_MissingPart)
                             {
                                 Traverse.Create(root: rec).Field(name: "isFreshInt").SetValue(false);
-                                num--;
                             }
                             else
                             {
@@ -142,36 +98,32 @@ namespace TorannMagic
                     }
                 }
 
-                using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                 {
-                    while (enumerator.MoveNext())
+                    if (!hediff.IsPermanent())
                     {
-                        Hediff rec = enumerator.Current;
-                        if (!rec.IsPermanent())
+                        if (hediff.def.defName == "Cataract" || hediff.def.defName == "HearingLoss" || hediff.def.defName.Contains("ToxicBuildup"))
                         {
-                            if (rec.def.defName == "Cataract" || rec.def.defName == "HearingLoss" || rec.def.defName.Contains("ToxicBuildup"))
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                            if ((rec.def.defName == "Blindness" || rec.def.defName.Contains("Asthma") || rec.def.defName == "Cirrhosis" || rec.def.defName == "ChemicalDamageModerate"))
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                            if ((rec.def.defName == "Frail" || rec.def.defName == "BadBack" || rec.def.defName.Contains("Carcinoma") || rec.def.defName == "ChemicalDamageSevere"))
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                            if ((rec.def.defName.Contains("Alzheimers") || rec.def.defName == "Dementia" || rec.def.defName.Contains("HeartArteryBlockage") || rec.def.defName == "CatatonicBreakdown"))
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
+                            pawn.health.RemoveHediff(hediff);
                         }
-                        if (rec.def.makesSickThought)
+                        if ((hediff.def.defName == "Blindness" || hediff.def.defName.Contains("Asthma") || hediff.def.defName == "Cirrhosis" || hediff.def.defName == "ChemicalDamageModerate"))
                         {
-                            pawn.health.RemoveHediff(rec);
+                            pawn.health.RemoveHediff(hediff);
+                        }
+                        if ((hediff.def.defName == "Frail" || hediff.def.defName == "BadBack" || hediff.def.defName.Contains("Carcinoma") || hediff.def.defName == "ChemicalDamageSevere"))
+                        {
+                            pawn.health.RemoveHediff(hediff);
+                        }
+                        if ((hediff.def.defName.Contains("Alzheimers") || hediff.def.defName == "Dementia" || hediff.def.defName.Contains("HeartArteryBlockage") || hediff.def.defName == "CatatonicBreakdown"))
+                        {
+                            pawn.health.RemoveHediff(hediff);
                         }
                     }
-                }                
+                    if (hediff.def.makesSickThought)
+                    {
+                        pawn.health.RemoveHediff(hediff);
+                    }
+                }
             }
         }
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Medigel.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Medigel.cs
@@ -47,33 +47,21 @@ namespace TorannMagic
 
             if (this.Pawn.health.hediffSet.HasHediff(HediffDefOf.WoundInfection))
             {
-                IEnumerable<Hediff> hds = this.Pawn.health.hediffSet.GetHediffs<Hediff>();
-                foreach (Hediff current in hds)
+                foreach (Hediff hediff in Pawn.health.hediffSet.hediffs)
                 {
-                    if (current.def == HediffDefOf.WoundInfection)
+                    if (hediff.def == HediffDefOf.WoundInfection)
                     {
-                        current.Severity -= .001f;
+                        hediff.Severity -= .001f;
                     }
                 }
             }
 
-            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+            IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally());
+            foreach (Hediff_Injury injury in injuries)
             {
-                while (enumerator.MoveNext())
-                {
-                    BodyPartRecord rec = enumerator.Current;
-                    IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                    Func<Hediff_Injury, bool> arg_BB_1;
-                    arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-                    foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                    {
-                        bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                        if (flag5)
-                        {
-                            current.Heal(Rand.Range(.1f, .25f));
-                        }                        
-                    }                    
-                }
+                injury.Heal(Rand.Range(.1f, .25f));
             }
         }
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_NanoStimulant.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_NanoStimulant.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Verse;
 using RimWorld;
+using TorannMagic.Utils;
 using UnityEngine;
 
 namespace TorannMagic
@@ -57,74 +58,43 @@ namespace TorannMagic
                 }
             }
             this.age++;
-            
+
             if (age == duration)
             {
-                HealthUtility.AdjustSeverity(base.Pawn, HediffDef.Named("TM_NanoStimulantWithdrawalHD"), 1 - (.03f * this.hediffPwr));
-                Pawn pawn = base.Pawn as Pawn;
-                
+                HealthUtility.AdjustSeverity(Pawn, HediffDef.Named("TM_NanoStimulantWithdrawalHD"), 1 - .03f * hediffPwr);
+                Pawn pawn = Pawn;
+                if (pawn == null) return;
                 TM_MoteMaker.ThrowRegenMote(pawn.DrawPos, pawn.Map, 1f);
-                bool flag = pawn != null;
-                if (flag)
+
+                ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
+                int injuriesToHeal;
+                int injuriesPerBodyPart;
+                if(settingsRef.AIHardMode && !pawn.IsColonist)
                 {
-                    ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                    int num = 2 + Mathf.RoundToInt(this.hediffPwr * .2f);
-                    if(settingsRef.AIHardMode && !pawn.IsColonist)
-                    {
-                        num = 5;
-                    }
-  
-                    using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-                    {
-                        while (enumerator.MoveNext())
-                        {
-                            BodyPartRecord rec = enumerator.Current;
-                            bool flag2 = num > 0;
-
-                            if (flag2)
-                            {
-                                
-                                int num2 = 3 + Mathf.RoundToInt(this.hediffPwr * .35f); // + ver.level;
-                                if(settingsRef.AIHardMode && !pawn.IsColonist)
-                                {
-                                    num2 = 5;
-                                }
-                                IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                                Func<Hediff_Injury, bool> arg_BB_1;
-
-                                arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                                foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                                {
-                                    bool flag4 = num2 > 0;
-                                    if (flag4)
-                                    {
-                                        bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                        if (flag5)
-                                        {
-                                            
-                                            if(!pawn.IsColonist)
-                                            {
-                                                current.Heal(10f);
-                                            }
-                                            else
-                                            {
-                                                current.Heal(2f + (.35f * hediffPwr));
-                                            }
-                                            if(Rand.Chance(.4f + (.02f * hediffPwr)))
-                                            {
-                                                current.Tended(Rand.Range(.4f + (.02f * this.hediffPwr), .5f + (.03f * this.hediffPwr)), 1f);
-                                            }
-                                            num--;
-                                            num2--;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    injuriesToHeal = 5;
+                    injuriesPerBodyPart = 5;
                 }
-            }            
+                else
+                {
+                    injuriesToHeal = 2 + Mathf.RoundToInt(hediffPwr * .2f);
+                    injuriesPerBodyPart = 3 + Mathf.RoundToInt(hediffPwr * .35f);
+                }
+
+                IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                    .OfType<Hediff_Injury>()
+                    .Where(injury => injury.CanHealNaturally())
+                    .DistinctBy(injury => injury.Part, injuriesPerBodyPart)
+                    .Take(injuriesToHeal);
+
+                float healAmount = pawn.IsColonist ? 2f + .35f * hediffPwr : 10f;
+                float tendChance = .4f + .02f * hediffPwr;
+                foreach (Hediff_Injury injury in injuries)
+                {
+                    injury.Heal(healAmount);
+                    if (Rand.Chance(tendChance))
+                        injury.Tended(Rand.Range(.4f + .02f * hediffPwr, .5f + .03f * hediffPwr), 1f);
+                }
+            }
         }
 
         public override void CompExposeData()

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Provisioner.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Provisioner.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using HarmonyLib;
 using System.Linq;
+using TorannMagic.Utils;
 
 namespace TorannMagic
 {
@@ -107,39 +108,15 @@ namespace TorannMagic
 
         public void TickActionHealth()
         {
-            Pawn pawn = this.Pawn;
-            int num = 2;
+            IEnumerable<Hediff_Injury> injuries = Pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally())
+                .DistinctBy(injury => injury.Part)
+                .Take(2);
 
-            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+            foreach (Hediff_Injury injury in injuries)
             {
-                while (enumerator.MoveNext())
-                {
-                    BodyPartRecord rec = enumerator.Current;
-                    bool flag2 = num > 0;
-                    int num2 = 1;
-                    if (flag2)
-                    {
-                        IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                        Func<Hediff_Injury, bool> arg_BB_1;
-
-                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                        foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                        {
-                            bool flag3 = num2 > 0;
-                            if (flag3)
-                            {
-                                bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                if (flag5)
-                                {
-                                    current.Heal(Rand.Range(.2f, .5f) + (.1f * pwrVal));
-                                    num--;
-                                    num2--;
-                                }
-                            }
-                        }
-                    }
-                }
+                injury.Heal(Rand.Range(.2f, .5f) + .1f * pwrVal);
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_RangerBond.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_RangerBond.cs
@@ -88,47 +88,13 @@ namespace TorannMagic
             bool flag4 = Find.TickManager.TicksGame % 600 == 0;
             if (flag4)
             {
-                Pawn pawn = base.Pawn;
-                int num = 1;
-                int num2 = 1;
+                Pawn pawn = Pawn;
 
-                using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-                        bool flag2 = num > 0;
+                Hediff_Injury injuryToHeal = pawn?.health.hediffSet.hediffs
+                    .OfType<Hediff_Injury>()
+                    .FirstOrDefault();
+                injuryToHeal?.Heal(injuryToHeal.CanHealNaturally() ? 1.0f + parent.Severity / 3f : .2f);
 
-                        if (flag2)
-                        {
-                            IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                            Func<Hediff_Injury, bool> arg_BB_1;
-
-                            arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                            foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                            {
-                                bool flag3 = num2 > 0;
-                                if (flag3)
-                                {
-                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                    if (flag5)
-                                    {
-                                        current.Heal(1.0f + this.parent.Severity/3f);
-                                        num--;
-                                        num2--;
-                                    }
-                                    else
-                                    {
-                                        current.Heal(.2f);
-                                        num--;
-                                        num2--;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
                 if (this.bonderPawn != null && !this.bonderPawn.Destroyed && !this.bonderPawn.Dead)
                 {
                     RefreshBond();

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Regeneration.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Regeneration.cs
@@ -83,56 +83,17 @@ namespace TorannMagic
                     if (!flag)
                     {
                         ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                        int num = 1; // + ver.level;
-                        if (settingsRef.AIHardMode && !pawn.IsColonist)
+                        int injuriesToHeal = settingsRef.AIHardMode && !pawn.IsColonist ? 2 : 1;
+
+                        IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                            .OfType<Hediff_Injury>()
+                            .Where(injury => injury.CanHealNaturally())
+                            .Take(injuriesToHeal);
+
+                        float amountToHeal = pawn.IsColonist ? 4f + .5f * hediffPwr : 10f + 1.5f * hediffPwr;
+                        foreach (Hediff_Injury injury in injuries)
                         {
-                            num = 2;
-                        }
-
-                        using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-                        {
-                            while (enumerator.MoveNext())
-                            {
-                                BodyPartRecord rec = enumerator.Current;
-                                bool flag2 = num > 0;
-
-                                if (flag2)
-                                {
-
-                                    int num2 = 1; // + ver.level;
-                                    if (settingsRef.AIHardMode && !pawn.IsColonist)
-                                    {
-                                        num2 = 2;
-                                    }
-                                    IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                                    Func<Hediff_Injury, bool> arg_BB_1;
-
-                                    arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                                    foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                                    {
-                                        bool flag4 = num2 > 0;
-                                        if (flag4)
-                                        {
-                                            bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                            if (flag5)
-                                            {
-
-                                                if (!pawn.IsColonist)
-                                                {
-                                                    current.Heal(10f + (1.5f * hediffPwr));
-                                                }
-                                                else
-                                                {
-                                                    current.Heal(4f + (.5f * hediffPwr));
-                                                }
-                                                num--;
-                                                num2--;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
+                            injury.Heal(amountToHeal);
                         }
                     }
                     else

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_ReverseTime.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_ReverseTime.cs
@@ -117,7 +117,7 @@ namespace TorannMagic
         {
             float totalBleedRate = 0;
             int totalHDremoved = 0;
-            using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+            using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.hediffs.GetEnumerator())
             {
                 while (enumerator.MoveNext())
                 {                    
@@ -180,7 +180,7 @@ namespace TorannMagic
                     HealthUtility.AdjustSeverity(pawn, HediffDefOf.BloodLoss, -(totalBleedRate * ticks * this.parent.Severity) / (24 * 2500));
                 }
             }
-            List<Hediff> hediffList = pawn.health.hediffSet.GetHediffs<Hediff>().ToList();
+            List<Hediff> hediffList = pawn.health.hediffSet.hediffs;
             if (hediffList != null && hediffList.Count > 0)
             {
                 for (int i = 0; i < hediffList.Count; i++)
@@ -252,7 +252,7 @@ namespace TorannMagic
                 }
             }
             ReduceReverseTime(totalHDremoved);
-            //using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+            //using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.hediffs.GetEnumerator())
             //{
             //    while (enumerator.MoveNext())
             //    {
@@ -304,10 +304,12 @@ namespace TorannMagic
 
         public bool HasParentPart(Hediff_MissingPart mphd)
         {
+            return false;
+
             bool hasMissingParent = false;
             if (mphd.Part.parent != null)
             {
-                List<Hediff_MissingPart> hediffList = this.Pawn.health.hediffSet.GetHediffs<Hediff_MissingPart>().ToList();
+                List<Hediff_MissingPart> hediffList = this.Pawn.health.hediffSet.hediffs.OfType<Hediff_MissingPart>().ToList();
                 for (int i = 0; i < hediffList.Count; i++)
                 {
                     if(mphd.Part.parent == hediffList[i].Part)
@@ -321,7 +323,7 @@ namespace TorannMagic
 
         public bool RemoveChildParts(Hediff_MissingPart mphd)
         {
-            List<Hediff> hediffList = this.Pawn.health.hediffSet.GetHediffs<Hediff>().ToList();
+            List<Hediff> hediffList = this.Pawn.health.hediffSet.hediffs;
             for (int i = 0; i < hediffList.Count; i++)
             {
                 Hediff_MissingPart mpChild = hediffList[i] as Hediff_MissingPart;

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_SoulBond.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_SoulBond.cs
@@ -80,7 +80,7 @@ namespace TorannMagic
                     else
                     {
                         bool soulPawnHasHediff = false;
-                        using (IEnumerator<Hediff> enumerator = soulPawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                        using (IEnumerator<Hediff> enumerator = soulPawn.health.hediffSet.hediffs.GetEnumerator())
                         {
                             while (enumerator.MoveNext())
                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Undead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HediffComp_Undead.cs
@@ -113,10 +113,9 @@ namespace TorannMagic
             }
             if(Find.TickManager.TicksGame % 16 == 0)
             {
-                IEnumerable<Hediff> hdEnum = this.Pawn.health.hediffSet.GetHediffs<Hediff>();
-                foreach(Hediff hd in hdEnum)
+                foreach (Hediff hd in Pawn.health.hediffSet.hediffs)
                 {
-                    if(hd.def.defName == "SpaceHypoxia")
+                    if (hd.def.defName == "SpaceHypoxia")
                     {
                         this.Pawn.health.RemoveHediff(hd);
                         break;
@@ -189,99 +188,52 @@ namespace TorannMagic
                     //    base.Pawn.needs.mood.CurLevel = .5f;
                     //    base.Pawn.needs.space.CurLevel = .5f;
                     //}
-                    Pawn pawn = base.Pawn;
-                    int num = 1;
-                    int num2 = 1;
-                    using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+                    Pawn pawn = Pawn;
+
+                    Hediff_Injury injuryToHeal = pawn.health.hediffSet.hediffs
+                        .OfType<Hediff_Injury>()
+                        .FirstOrDefault();
+                    injuryToHeal?.Heal(injuryToHeal.CanHealNaturally() ? 2.0f : 1.0f);
+
+                    foreach (Hediff hediff in pawn.health.hediffSet.GetHediffsTendable())
                     {
-                        while (enumerator.MoveNext())
+                        if (hediff.Bleeding && hediff is Hediff_MissingPart)
+                            Traverse.Create(root: hediff).Field(name: "isFreshInt").SetValue(false);
+                        else
+                            TM_Action.TendWithoutNotice(hediff, 1f, 1f);
+                    }
+
+                    foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
+                    {
+                        if (!hediff.IsPermanent())
                         {
-                            BodyPartRecord rec = enumerator.Current;
-                            bool flag2 = num > 0;
-
-                            if (flag2)
+                            if (hediff.def.defName == "Cataract" || hediff.def.defName == "HearingLoss" || hediff.def.defName.Contains("ToxicBuildup") || hediff.def.defName == "Abasia" || hediff.def.defName == "BloodRot")
                             {
-                                IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                                Func<Hediff_Injury, bool> arg_BB_1;
-
-                                arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                                foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                                {
-                                    bool flag3 = num2 > 0;
-                                    if (flag3)
-                                    {
-                                        bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                        if (flag5)
-                                        {
-                                            current.Heal(2.0f);
-                                            num--;
-                                            num2--;
-                                        }
-                                        else
-                                        {
-                                            current.Heal(1.0f);
-                                            num--;
-                                            num2--;
-                                        }
-                                    }
-                                }
+                                pawn.health.RemoveHediff(hediff);
+                            }
+                            if ((hediff.def.defName == "Blindness" || hediff.def.defName.Contains("Asthma") || hediff.def.defName == "Cirrhosis" || hediff.def.defName == "ChemicalDamageModerate") || hediff.def.defName =="Scaria")
+                            {
+                                pawn.health.RemoveHediff(hediff);
+                            }
+                            if ((hediff.def.defName == "Frail" || hediff.def.defName == "BadBack" || hediff.def.defName.Contains("Carcinoma") || hediff.def.defName == "ChemicalDamageSevere"))
+                            {
+                                pawn.health.RemoveHediff(hediff);
+                            }
+                            if ((hediff.def.defName.Contains("Alzheimers") || hediff.def.defName == "Dementia" || hediff.def.defName.Contains("HeartArteryBlockage") || hediff.def.defName == "CatatonicBreakdown"))
+                            {
+                                pawn.health.RemoveHediff(hediff);
                             }
                         }
-                    }
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffsTendable().GetEnumerator())
-                    {
-                        while (enumerator.MoveNext())
+                        if (hediff.def.makesSickThought)
                         {
-                            Hediff rec = enumerator.Current;
-                            if (rec.TendableNow()) // && !currentTendable.IsPermanent()
-                            {
-                                if (rec.Bleeding && rec is Hediff_MissingPart)
-                                {
-                                    Traverse.Create(root: rec).Field(name: "isFreshInt").SetValue(false);
-                                    num--;
-                                }
-                                else
-                                {
-                                    TM_Action.TendWithoutNotice(rec, 1f, 1f);
-                                }
-                            }
+                            pawn.health.RemoveHediff(hediff);
+                        }
+                        if(hediff.def.defName.Contains("Pregnant") || hediff.def.defName == "DrugOverdose")
+                        {
+                            pawn.health.RemoveHediff(hediff);
                         }
                     }
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
-                    {
-                        while (enumerator.MoveNext())
-                        {
-                            Hediff rec = enumerator.Current;
-                            if (!rec.IsPermanent())
-                            {
-                                if (rec.def.defName == "Cataract" || rec.def.defName == "HearingLoss" || rec.def.defName.Contains("ToxicBuildup") || rec.def.defName == "Abasia" || rec.def.defName == "BloodRot")
-                                {
-                                    pawn.health.RemoveHediff(rec);
-                                }
-                                if ((rec.def.defName == "Blindness" || rec.def.defName.Contains("Asthma") || rec.def.defName == "Cirrhosis" || rec.def.defName == "ChemicalDamageModerate") || rec.def.defName =="Scaria")
-                                {
-                                    pawn.health.RemoveHediff(rec);
-                                }
-                                if ((rec.def.defName == "Frail" || rec.def.defName == "BadBack" || rec.def.defName.Contains("Carcinoma") || rec.def.defName == "ChemicalDamageSevere"))
-                                {
-                                    pawn.health.RemoveHediff(rec);
-                                }
-                                if ((rec.def.defName.Contains("Alzheimers") || rec.def.defName == "Dementia" || rec.def.defName.Contains("HeartArteryBlockage") || rec.def.defName == "CatatonicBreakdown"))
-                                {
-                                    pawn.health.RemoveHediff(rec);
-                                }
-                            }
-                            if (rec.def.makesSickThought)
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                            if(rec.def.defName.Contains("Pregnant") || rec.def.defName == "DrugOverdose")
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                        }
-                    }
+
                     CompHatcher cp_h = this.Pawn.TryGetComp<CompHatcher>();
                     if(cp_h != null)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Hediff_Possessor.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Hediff_Possessor.cs
@@ -163,8 +163,7 @@ namespace TorannMagic
             }            
             if (Find.TickManager.TicksGame % 31 == 0)
             {
-                IEnumerable<Hediff> hdEnum = this.pawn.health.hediffSet.GetHediffs<Hediff>();
-                foreach (Hediff hd in hdEnum)
+                foreach (Hediff hd in pawn.health.hediffSet.hediffs)
                 {
                     if (hd.def.defName == "SpaceHypoxia")
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Meditate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/JobDriver_Meditate.cs
@@ -74,7 +74,7 @@ namespace TorannMagic
                     if(Find.TickManager.TicksGame % 60 == 0)
                     {
                         List<Hediff> afflictionList = TM_Calc.GetPawnAfflictions(this.pawn);
-                        List<Hediff> addictionList = TM_Calc.GetPawnAddictions(this.pawn);
+                        List<Hediff_Addiction> addictionList = TM_Calc.GetPawnAddictions(pawn);
 
                         if(chiHD != null)
                         {
@@ -119,18 +119,18 @@ namespace TorannMagic
                                 Traverse.Create(root: hediffTicks).Field(name: "ticksToDisappear").SetValue(ticksToDisappear);
                             }
                             chiHD.Severity -= 1f;
-                            comp.MightUserXP += (int)(2*chiMultiplier);
+                            comp.MightUserXP += 2 * chiMultiplier;
                         }
                         else if (addictionList != null && addictionList.Count > 0)
                         {
-                            Hediff hediff = addictionList.RandomElement();
-                            hediff.Severity -= .0015f * chiMultiplier * (1 + (.1f * pwrVal));
+                            Hediff_Addiction hediff = addictionList.RandomElement();
+                            hediff.Severity -= .0015f * chiMultiplier * (1 + .1f * pwrVal);
                             if (hediff.Severity <= 0)
                             {
-                                this.pawn.health.RemoveHediff(hediff);
+                                pawn.health.RemoveHediff(hediff);
                             }
                             chiHD.Severity -= 1f;
-                            comp.MightUserXP += (int)(2 * chiMultiplier);
+                            comp.MightUserXP += 2 * chiMultiplier;
                         }
                         else if(BreakRiskAlertUtility.PawnsAtRiskMinor.Contains(this.pawn) || BreakRiskAlertUtility.PawnsAtRiskMajor.Contains(this.pawn) || BreakRiskAlertUtility.PawnsAtRiskExtreme.Contains(this.pawn))
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/Need_Spirit.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Need_Spirit.cs
@@ -221,7 +221,7 @@ namespace TorannMagic
             if(amount > 0)
             {
                 List<Hediff> afflictionList = TM_Calc.GetPawnAfflictions(this.pawn);
-                List<Hediff> addictionList = TM_Calc.GetPawnAddictions(this.pawn);
+                List<Hediff_Addiction> addictionList = TM_Calc.GetPawnAddictions(this.pawn);
                 if (TM_Calc.IsPawnInjured(this.pawn, 0))
                 {
                     TM_Action.DoAction_HealPawn(this.pawn, this.pawn, 1, Rand.Range(1f, 3f) * amount);                    
@@ -242,9 +242,9 @@ namespace TorannMagic
                         Traverse.Create(root: hediffTicks).Field(name: "ticksToDisappear").SetValue(ticksToDisappear);
                     }
                 }
-                else if (addictionList != null && addictionList.Count > 0)
+                else if (addictionList.Any())
                 {
-                    Hediff hediff = addictionList.RandomElement();
+                    Hediff_Addiction hediff = addictionList.RandomElement();
                     hediff.Severity -= .15f * amount;
                     if (hediff.Severity <= 0)
                     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_FogOfTorment.cs
@@ -36,12 +36,10 @@ namespace TorannMagic
 
         protected override void Impact(Thing hitThing)
         {
-            Map map = base.Map;
+            Map map = Map;
             base.Impact(hitThing);
-            ThingDef def = this.def;
 
-            Pawn pawn = this.launcher as Pawn;
-            Pawn victim = null;
+            Pawn pawn = launcher as Pawn;
             CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if (comp != null)
             {
@@ -85,53 +83,20 @@ namespace TorannMagic
 
             if (this.age > this.lastStrike + this.strikeDelay)
             {
-                IntVec3 curCell;
-                IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(base.Position, this.def.projectile.explosionRadius + verVal, true);
-                for (int i = 0; i < targets.Count(); i++)
+                foreach (IntVec3 curCell in GenRadial.RadialCellsAround(Position, def.projectile.explosionRadius + verVal, true))
                 {
-                    curCell = targets.ToArray<IntVec3>()[i];
-
                     if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
                     {
-                        victim = curCell.GetFirstPawn(map);
+                        Pawn victim = curCell.GetFirstPawn(map);
                         if(victim != null && !victim.Dead && victim.RaceProps.IsFlesh)
                         {
                             if(TM_Calc.IsUndead(victim) || victim.needs.food == null)
                             {
                                 //heals undead
-                                int num = 1;
-                                int num2 = 1;
-                                using (IEnumerator<BodyPartRecord> enumerator = victim.health.hediffSet.GetInjuredParts().GetEnumerator())
-                                {
-                                    while (enumerator.MoveNext())
-                                    {
-                                        BodyPartRecord rec = enumerator.Current;
-                                        bool flag2 = num > 0;
-
-                                        if (flag2)
-                                        {
-                                            IEnumerable<Hediff_Injury> arg_BB_0 = victim.health.hediffSet.GetHediffs<Hediff_Injury>();
-                                            Func<Hediff_Injury, bool> arg_BB_1;
-
-                                            arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                                            foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                                            {
-                                                bool flag3 = num2 > 0;
-                                                if (flag3)
-                                                {
-                                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                                    if (flag5)
-                                                    {
-                                                        current.Heal(2.0f + pwrVal);
-                                                        num--;
-                                                        num2--;
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                                Hediff_Injury injuryToHeal = victim.health.hediffSet.hediffs
+                                    .OfType<Hediff_Injury>()
+                                    .FirstOrDefault(injury => injury.CanHealNaturally());
+                                injuryToHeal?.Heal(2.0f + pwrVal);
                             }
                             else
                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_HealingCircle.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_HealingCircle.cs
@@ -165,48 +165,20 @@ namespace TorannMagic
 
         public void Heal(Pawn pawn)
         {
-            bool flag = pawn != null && !pawn.Dead;
-            if (flag)
+            if (pawn == null || pawn.Dead) return;
+
+            IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally())
+                .Take(1 + verVal);
+
+            float healAmount = (10.0f + pwrVal * 2f) * arcaneDmg;
+            foreach (Hediff_Injury injury in injuries)
             {
-                int num = 1 + verVal;
-                
-                using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-                        bool flag2 = num > 0;                        
+                if (!Rand.Chance(.8f)) continue;  // 80% chance to heal, 20% chance to skip
 
-                        if (flag2)
-                        {
-                            int num2 = 1 + verVal;
-                            IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                            Func<Hediff_Injury, bool> arg_BB_1;
-
-                            arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                            foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                            {
-                                bool flag4 = num2 > 0;
-                                if (flag4)
-                                {
-                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                    if (flag5)
-                                    {
-                                        //current.Heal((float)((int)current.Severity + 1));
-                                        if (Rand.Chance(.8f))
-                                        {
-                                            current.Heal((10.0f + (float)pwrVal * 2f) * this.arcaneDmg); // power affects how much to heal
-                                            TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, 1.2f);
-                                        }
-                                        num--;
-                                        num2--;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                injury.Heal(healAmount);
+                TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, 1.2f);
             }
         }        
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_HolyWrath.cs
@@ -5,6 +5,7 @@ using AbilityUser;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using TorannMagic.Utils;
 using UnityEngine;
 
 namespace TorannMagic
@@ -121,18 +122,14 @@ namespace TorannMagic
 
         public void GetAffectedPawns(IntVec3 center, Map map)
         {
-            Pawn victim = null;
-            IntVec3 curCell;
-            IEnumerable<IntVec3> targets = GenRadial.RadialCellsAround(center, this.def.projectile.explosionRadius, true);
-            for (int i = 0; i < targets.Count(); i++)
+            foreach (IntVec3 curCell in GenRadial.RadialCellsAround(center, def.projectile.explosionRadius, true))
             {
-                curCell = targets.ToArray<IntVec3>()[i];
-                if (curCell.InBoundsWithNullCheck(map) && curCell.IsValid)
-                {
-                    victim = curCell.GetFirstPawn(map);
-                }
+                if (!curCell.InBoundsWithNullCheck(map) || !curCell.IsValid) return;
 
-                if (victim != null &&  victim.Faction == this.caster.Faction && !victim.Dead)
+                Pawn victim = curCell.GetFirstPawn(map);
+                if (victim == null || victim.Dead) return;
+
+                if (victim.Faction == caster.Faction)
                 {
                     if(verVal >= 1)
                     {
@@ -146,53 +143,20 @@ namespace TorannMagic
                     }
                     if (verVal >= 2)
                     {
-                        Pawn pawn = victim;
-                        bool flag = pawn != null && !pawn.Dead && !TM_Calc.IsUndead(pawn);
-                        bool undeadFlag = pawn != null && !pawn.Dead && TM_Calc.IsUndead(pawn);
-                        if (flag)
+                        if (!victim.Dead && !TM_Calc.IsUndead(victim))
                         {
-                            int num = 3;
-                            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+                            IEnumerable<Hediff_Injury> injuries = victim.health.hediffSet.hediffs
+                                .OfType<Hediff_Injury>()
+                                .Where(injury => injury.CanHealNaturally())
+                                .DistinctBy(injury => injury.Part)
+                                .Take(3);
+
+                            float healAmount = caster.IsColonist ? 5.0f * arcaneDmg : 20.0f;
+                            foreach (Hediff_Injury injury in injuries)
                             {
-                                while (enumerator.MoveNext())
-                                {
-                                    BodyPartRecord rec = enumerator.Current;
-                                    bool flag2 = num > 0;
-
-                                    if (flag2)
-                                    {
-                                        int num2 = 1;
-                                        IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                                        Func<Hediff_Injury, bool> arg_BB_1;
-
-                                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                                        foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                                        {
-                                            bool flag4 = num2 > 0;
-                                            if (flag4)
-                                            {
-                                                bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                                if (flag5)
-                                                {
-                                                    //current.Heal((float)((int)current.Severity + 1));
-                                                    if (!this.caster.IsColonist)
-                                                    {
-                                                        current.Heal(20.0f); // power affects how much to heal
-                                                    }
-                                                    else
-                                                    {
-                                                        current.Heal((5.0f * this.arcaneDmg)); // power affects how much to heal
-                                                    }
-                                                    TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, .6f);
-                                                    TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, .4f);
-                                                    num--;
-                                                    num2--;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                                injury.Heal(healAmount);
+                                TM_MoteMaker.ThrowRegenMote(victim.Position.ToVector3Shifted(), victim.Map, .6f);
+                                TM_MoteMaker.ThrowRegenMote(victim.Position.ToVector3Shifted(), victim.Map, .4f);
                             }
                         }                        
                     }
@@ -200,13 +164,11 @@ namespace TorannMagic
                     {
                         HealthUtility.AdjustSeverity(victim, HediffDef.Named("BestowMightHD"), 1f);
                     }
-
                 }
-                if(victim != null && !victim.Dead && TM_Calc.IsUndead(victim))
+                if(TM_Calc.IsUndead(victim))
                 {
                     TM_Action.DamageUndead(victim, Rand.Range(5f, 12f) * this.arcaneDmg, this.launcher);
                 }
-                targets.GetEnumerator().MoveNext();
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Possess.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Possess.cs
@@ -328,23 +328,19 @@ namespace TorannMagic
             Hediff disguiseHD = null;
             Hediff possessHD = null;
             Hediff possessCHD = null;
-            using (IEnumerator<Hediff> enumerator = hitPawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+            foreach (Hediff hediff in hitPawn.health.hediffSet.hediffs)
             {
-                while (enumerator.MoveNext())
+                if (hediff.def == TorannMagicDefOf.TM_DisguiseHD_II)
                 {
-                    Hediff rec = enumerator.Current;
-                    if (rec.def == TorannMagicDefOf.TM_DisguiseHD_II)
-                    {
-                        disguiseHD = rec;
-                    }
-                    if (rec.def == TorannMagicDefOf.TM_CoOpPossessionHD || rec.def == TorannMagicDefOf.TM_CoOpPossessionHD_I || rec.def == TorannMagicDefOf.TM_CoOpPossessionHD_II || rec.def == TorannMagicDefOf.TM_CoOpPossessionHD_III)
-                    {
-                        possessCHD = rec;
-                    }
-                    if (rec.def == TorannMagicDefOf.TM_PossessionHD || rec.def == TorannMagicDefOf.TM_PossessionHD_I || rec.def == TorannMagicDefOf.TM_PossessionHD_II || rec.def == TorannMagicDefOf.TM_PossessionHD_III)
-                    {
-                        possessHD = rec;
-                    }
+                    disguiseHD = hediff;
+                }
+                if (hediff.def == TorannMagicDefOf.TM_CoOpPossessionHD || hediff.def == TorannMagicDefOf.TM_CoOpPossessionHD_I || hediff.def == TorannMagicDefOf.TM_CoOpPossessionHD_II || hediff.def == TorannMagicDefOf.TM_CoOpPossessionHD_III)
+                {
+                    possessCHD = hediff;
+                }
+                if (hediff.def == TorannMagicDefOf.TM_PossessionHD || hediff.def == TorannMagicDefOf.TM_PossessionHD_I || hediff.def == TorannMagicDefOf.TM_PossessionHD_II || hediff.def == TorannMagicDefOf.TM_PossessionHD_III)
+                {
+                    possessHD = hediff;
                 }
             }
             if(disguiseHD != null)

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_RaiseUndead.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using System;
 using HarmonyLib;
+using TorannMagic.TMDefs;
 
 namespace TorannMagic
 {
@@ -491,79 +492,24 @@ namespace TorannMagic
 
         public static void RemoveHediffsAddictionsAndPermanentInjuries(Pawn pawn)
         {
-            List<Hediff> removeList = new List<Hediff>();
-            removeList.Clear();
-            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+            IEnumerable<Hediff> hediffsToRemove = pawn.health.hediffSet.hediffs.Where(hediff =>
+                hediff is Hediff_Injury injury && injury.CanHealNaturally()
+                || hediff is Hediff_Addiction
+                || (
+                    (
+                        hediff.IsPermanent()
+                        || hediff.def.tendable
+                        || hediff.source == null && hediff.sourceBodyPartGroup == null
+                    )
+                    && hediff.def != TorannMagicDefOf.TM_UndeadHD
+                    && hediff.def != TorannMagicDefOf.TM_UndeadStageHD
+                    && hediff.def != TorannMagicDefOf.TM_UndeadAnimalHD
+                )
+            );
+            foreach (Hediff hediff in hediffsToRemove)
             {
-                while (enumerator.MoveNext())
-                {
-                    BodyPartRecord rec = enumerator.Current;
-
-                    IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                    Func<Hediff_Injury, bool> arg_BB_1;
-
-                    arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                    foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                    {
-                        bool flag5 = !current.CanHealNaturally() && current.IsPermanent();
-                        if (flag5)
-                        {
-                            removeList.Add(current);
-                        }                        
-                    }                    
-                }
+                pawn.health.RemoveHediff(hediff);
             }
-            if(removeList.Count > 0)
-            {
-                for(int i = 0; i < removeList.Count; i++)
-                {
-                    pawn.health.RemoveHediff(removeList[i]);
-                }
-            }
-            removeList.Clear();
-
-            using (IEnumerator<Hediff_Addiction> enumerator = pawn.health.hediffSet.GetHediffs<Hediff_Addiction>().GetEnumerator())
-            {
-                while (enumerator.MoveNext())
-                {
-                    Hediff_Addiction rec = enumerator.Current;
-                    removeList.Add(rec);                  
-                }
-            }
-
-            if (removeList.Count > 0)
-            {
-                for (int i = 0; i < removeList.Count; i++)
-                {
-                    pawn.health.RemoveHediff(removeList[i]);
-                }
-            }
-            removeList.Clear();
-
-            using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
-            {
-                while(enumerator.MoveNext())
-                {
-                    Hediff hd = enumerator.Current;
-                    if(hd.IsPermanent() || (hd.IsTended() || hd.TendableNow()) || (hd.source == null && hd.sourceBodyPartGroup == null))
-                    {
-                        if (hd.def != TorannMagicDefOf.TM_UndeadHD && hd.def != TorannMagicDefOf.TM_UndeadStageHD && hd.def != TorannMagicDefOf.TM_UndeadAnimalHD)
-                        {
-                            removeList.Add(hd);
-                        }
-                    }
-                }
-            }
-
-            if (removeList.Count > 0)
-            {
-                for (int i = 0; i < removeList.Count; i++)
-                {
-                    pawn.health.RemoveHediff(removeList[i]);
-                }
-            }
-            removeList.Clear();
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Projectile_Resurrection.cs
@@ -176,18 +176,13 @@ namespace TorannMagic
                                 ResurrectionUtility.ResurrectWithSideEffects(deadPawn);
                                 SoundDef.Named("Thunder_OffMap").PlayOneShot(null);
                                 SoundDef.Named("Thunder_OffMap").PlayOneShot(null);
-                                using (IEnumerator<Hediff> enumerator = deadPawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                                foreach (Hediff hediff in deadPawn.health.hediffSet.hediffs)
                                 {
-                                    while (enumerator.MoveNext())
+                                    if (hediff.def.defName != "ResurrectionPsychosis") continue;
+
+                                    if (Rand.Chance(verVal * .33f))
                                     {
-                                        Hediff rec = enumerator.Current;
-                                        if (rec.def.defName == "ResurrectionPsychosis")
-                                        {
-                                            if (Rand.Chance(verVal * .33f))
-                                            {
-                                                deadPawn.health.RemoveHediff(rec);
-                                            }
-                                        }
+                                        deadPawn.health.RemoveHediff(hediff);
                                     }
                                 }
                                 HealthUtility.AdjustSeverity(deadPawn, HediffDef.Named("TM_ResurrectionHD"), 1f);

--- a/RimWorldOfMagic/RimWorldOfMagic/Recipe_RuneCarving.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Recipe_RuneCarving.cs
@@ -14,7 +14,7 @@ namespace TorannMagic
     {
 		public override IEnumerable<BodyPartRecord> GetPartsToApplyOn(Pawn pawn, RecipeDef recipe)
 		{
-			IEnumerable<BodyPartRecord> runeCarvedParts = from rch in pawn.health.hediffSet.GetHediffs<Hediff>()
+			IEnumerable<BodyPartRecord> runeCarvedParts = from rch in pawn.health.hediffSet.hediffs
 															where rch != null && rch.Part != null && (rch.def == TorannMagicDefOf.TM_RuneCarvedPartHD || rch.def == TorannMagicDefOf.TM_ArcaneTatooPartHD)
 															select rch.Part;
 			IEnumerable<BodyPartRecord> notMissingParts = from nmp in pawn.health.hediffSet.GetNotMissingParts()

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Projectile_SummonSpiritAnimals.cs" />
     <Compile Include="Thoughts\ThoughtWorker_TM_LivingPossessed.cs" />
     <Compile Include="TMDefs\TM_AdvancedClassOptions.cs" />
+    <Compile Include="Utils\LinqExtensions.cs" />
     <Compile Include="Utils\TraitIconMap.cs" />
     <Compile Include="Utils\SimpleCache.cs" />
     <Compile Include="Verb_Attraction.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMJobDriver_CastAbilityVerb.cs
@@ -164,15 +164,15 @@ namespace TorannMagic
                         {
                             verb.TryStartCastOn(target, false, true);                            
                         }
-                        using (IEnumerator<Hediff> enumerator = this.pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                        foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                         {
-                            while (enumerator.MoveNext())
+                            if (hediff.def == TorannMagicDefOf.TM_PossessionHD
+                                || hediff.def == TorannMagicDefOf.TM_DisguiseHD
+                                || hediff.def == TorannMagicDefOf.TM_DisguiseHD_I
+                                || hediff.def == TorannMagicDefOf.TM_DisguiseHD_II
+                                || hediff.def == TorannMagicDefOf.TM_DisguiseHD_III)
                             {
-                                Hediff rec = enumerator.Current;
-                                if (rec.def == TorannMagicDefOf.TM_PossessionHD || rec.def == TorannMagicDefOf.TM_DisguiseHD || rec.def == TorannMagicDefOf.TM_DisguiseHD_I || rec.def == TorannMagicDefOf.TM_DisguiseHD_II || rec.def == TorannMagicDefOf.TM_DisguiseHD_III)
-                                {
-                                    this.pawn.health.RemoveHediff(rec);
-                                }
+                                pawn.health.RemoveHediff(hediff);
                             }
                         }
                     }
@@ -322,15 +322,15 @@ namespace TorannMagic
                                 {
                                     verb.TryStartCastOn(target, false, canFreeIntercept2);
                                 }
-                                using (IEnumerator<Hediff> enumerator = this.pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                                foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                                 {
-                                    while (enumerator.MoveNext())
+                                    if (hediff.def == TorannMagicDefOf.TM_PossessionHD
+                                        || hediff.def == TorannMagicDefOf.TM_DisguiseHD
+                                        || hediff.def == TorannMagicDefOf.TM_DisguiseHD_I
+                                        || hediff.def == TorannMagicDefOf.TM_DisguiseHD_II
+                                        || hediff.def == TorannMagicDefOf.TM_DisguiseHD_III)
                                     {
-                                        Hediff rec = enumerator.Current;
-                                        if (rec.def == TorannMagicDefOf.TM_PossessionHD || rec.def == TorannMagicDefOf.TM_DisguiseHD || rec.def == TorannMagicDefOf.TM_DisguiseHD_I || rec.def == TorannMagicDefOf.TM_DisguiseHD_II || rec.def == TorannMagicDefOf.TM_DisguiseHD_III)
-                                        {
-                                            this.pawn.health.RemoveHediff(rec);
-                                        }
+                                        this.pawn.health.RemoveHediff(hediff);
                                     }
                                 }
                             };

--- a/RimWorldOfMagic/RimWorldOfMagic/TMPawnSummoned.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TMPawnSummoned.cs
@@ -278,27 +278,10 @@ namespace TorannMagic
 
         public void CopyDamage(Pawn pawn)
         {
-            using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
-            {
-                while (enumerator.MoveNext())
-                {
-                    BodyPartRecord rec = enumerator.Current;
-                    IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                    Func<Hediff_Injury, bool> arg_BB_1;
-                    arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                    foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                    {
-                        bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                        if (flag5)
-                        {
-                            this.injuries.Add(current);
-                            //this.bodypartDamage.Add(current.Severity);
-                            //this.bodypartDamageType.Add(current.)
-                        }                            
-                    }                    
-                }
-            }
+            IEnumerable<Hediff_Injury> injuriesToCopy = pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally());
+            injuries.AddRange(injuriesToCopy);
         }
 
         public void SpawnOriginal()

--- a/RimWorldOfMagic/RimWorldOfMagic/TorannMagicDefOf.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TorannMagicDefOf.cs
@@ -1175,6 +1175,7 @@ namespace TorannMagic
         public static HediffDef TM_HediffStrongBack;
         public static HediffDef TM_HediffGearRepair;
         public static HediffDef TM_HediffHeavyBlow;
+        public static HediffDef TM_HediffInnerHealing;
         public static HediffDef TM_HediffSprint;
         public static TMAbilityDef TM_Legion;
         public static TMAbilityDef TM_TempestStrike;

--- a/RimWorldOfMagic/RimWorldOfMagic/Utils/LinqExtensions.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Utils/LinqExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TorannMagic.Utils
+{
+    public static class LinqExtensions
+    {
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector
+        )
+        // Efficiently get the first elements that are distinct by a property or group (Like injury.Part)
+        {
+            HashSet<TKey> seenKeys = new HashSet<TKey>();
+            foreach (TSource element in source)
+            {
+                if (seenKeys.Contains(keySelector(element))) continue;
+
+                seenKeys.Add(keySelector(element));
+                yield return element;
+            }
+        }
+
+        public static IEnumerable<TSource> DistinctBy<TSource, TKey>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector,
+            int elementsPerGroup
+        )
+        // Efficiently get the first N elements that are distinct by a property or group (like injury.Part)
+        {
+            Dictionary<TKey, int> keyCounter = new Dictionary<TKey, int>();
+            foreach (TSource element in source)
+            {
+                keyCounter.TryGetValue(keySelector(element), out int timesElementSeen);
+                if (timesElementSeen >= elementsPerGroup) continue;
+
+                keyCounter[keySelector(element)] = timesElementSeen + 1;
+                yield return element;
+            }
+        }
+    }
+}

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_AdvancedHeal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_AdvancedHeal.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using AbilityUser;
 using Verse;
 using RimWorld;
+using TorannMagic.Utils;
 
 namespace TorannMagic
 {
@@ -57,80 +58,52 @@ namespace TorannMagic
             //    verVal = mver.level;
             //}
 
-            Pawn pawn = (Pawn)this.currentTarget;
-            bool flag = pawn != null && !pawn.Dead && !TM_Calc.IsUndead(pawn);
-            bool undeadFlag = pawn != null && !pawn.Dead && TM_Calc.IsUndead(pawn);
-            if (flag)
+            Pawn pawn = (Pawn)currentTarget;
+            if (pawn == null) return true;
+            if (pawn.Dead) return true;
+
+            if (!TM_Calc.IsUndead(pawn))
             {
-                int num = 3 + verVal;
-                using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+                int injuriesToHeal = 3 + verVal;
+                ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
+                int injuriesPerBodyPart = !CasterPawn.IsColonist && settingsRef.AIHardMode ? 5 : 1 + verVal;
+
+                IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                    .OfType<Hediff_Injury>()
+                    .Where(injury => injury.CanHealNaturally())
+                    .DistinctBy(injury => injury.Part, injuriesPerBodyPart);
+
+                int timesHealed = 0;
+                float baseHealAmount = CasterPawn.IsColonist ? 30.0f : 14.0f;
+                float healAmount = baseHealAmount + pwrVal * 3f;
+                // First go through any naturally healing injuries
+                foreach (Hediff_Injury injury in injuries)
                 {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-                        bool flag2 = num > 0;
+                    injury.Heal(healAmount);
+                    TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, 1f+.2f*pwrVal);
+                    TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, .8f+.1f*pwrVal);
+                    timesHealed++;
 
-                        if (flag2)
-                        {
-                            int num2 = 1 + verVal;
-                            ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                            if (!this.CasterPawn.IsColonist && settingsRef.AIHardMode)
-                            {
-                                num2 = 5;
-                            }
-                            IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                            Func<Hediff_Injury, bool> arg_BB_1;
+                    if (timesHealed >= injuriesToHeal) return true;
+                }
 
-                            arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
+                // Heal missing parts next
+                IEnumerable<Hediff_MissingPart> missingParts = pawn.health.hediffSet.hediffs
+                    .OfType<Hediff_MissingPart>()
+                    .Where(missingPart => missingPart.IsFresh);
+                foreach (Hediff_MissingPart missingPart in missingParts)
+                {
+                    missingPart.IsFresh = false;
+                    timesHealed++;
 
-                            foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                            {
-                                bool flag4 = num2 > 0;
-                                if (flag4)
-                                {
-                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                    if (flag5)
-                                    {
-                                        //current.Heal((float)((int)current.Severity + 1));
-                                        if (!this.CasterPawn.IsColonist)
-                                        {
-                                            current.Heal(30.0f + (float)pwrVal * 3f); // power affects how much to heal
-                                        }
-                                        else
-                                        {
-                                            current.Heal((14.0f + (float)pwrVal * 3f)*comp.arcaneDmg); // power affects how much to heal
-                                        }
-                                        TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, 1f+.2f*pwrVal);
-                                        TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, .8f+.1f*pwrVal);
-                                        num--;
-                                        num2--;
-                                    }
-                                }
-                            }
-                            using (IEnumerator<Hediff> enumerator1 = pawn.health.hediffSet.GetHediffsTendable().GetEnumerator())
-                            {
-                                while (enumerator1.MoveNext())
-                                {
-                                    if (num > 0)
-                                    {
-                                        Hediff rec1 = enumerator1.Current;
-                                        if (rec1.TendableNow() && rec1.Bleeding && rec1 is Hediff_MissingPart)
-                                        {
-                                            Traverse.Create(root: rec1).Field(name: "isFreshInt").SetValue(false);
-                                            num--;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    if (timesHealed >= injuriesToHeal) return true;
                 }
             }
-            if(undeadFlag)
+            else
             {
                 for (int i = 0; i < 2 + verVal; i++)
                 {
-                    TM_Action.DamageUndead(pawn, (8.0f + (float)pwrVal * 5f) * comp.arcaneDmg, this.CasterPawn);
+                    TM_Action.DamageUndead(pawn, (8.0f + pwrVal * 5f) * comp.arcaneDmg, CasterPawn);
                 }
             }
             return true;

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BattleHymn.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BattleHymn.cs
@@ -23,16 +23,12 @@ namespace TorannMagic
             {
                 if (pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_SingBattleHymnHD")))
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                    foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                     {
-                        while (enumerator.MoveNext())
+                        if (hediff.def.defName.Contains("TM_SingBattleHymnHD"))
                         {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def.defName.Contains("TM_SingBattleHymnHD"))
-                            {
-                                pawn.health.RemoveHediff(rec);
-                                TM_MoteMaker.ThrowSiphonMote(pawn.DrawPos, pawn.Map, 1f);
-                            }
+                            pawn.health.RemoveHediff(hediff);
+                            TM_MoteMaker.ThrowSiphonMote(pawn.DrawPos, pawn.Map, 1f);
                         }
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Blur.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Blur.cs
@@ -22,15 +22,11 @@ namespace TorannMagic
             {
                 if(pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_BlurHD, false))
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                    foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                     {
-                        while (enumerator.MoveNext())
+                        if (hediff.def == TorannMagicDefOf.TM_BlurHD)
                         {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def == TorannMagicDefOf.TM_BlurHD)
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
+                            pawn.health.RemoveHediff(hediff);
                         }
                     }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_BurningFury.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_BurningFury.cs
@@ -21,15 +21,11 @@ namespace TorannMagic
             {
                 if(pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_BurningFuryHD))
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                    foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                     {
-                        while (enumerator.MoveNext())
+                        if (hediff.def == TorannMagicDefOf.TM_BurningFuryHD)
                         {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def == TorannMagicDefOf.TM_BurningFuryHD)
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
+                            pawn.health.RemoveHediff(hediff);
                         }
                     }
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_CauterizeWound.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_CauterizeWound.cs
@@ -37,61 +37,46 @@ namespace TorannMagic
 
         protected override bool TryCastShot()
         {
-            Pawn caster = base.CasterPawn;
-            Pawn pawn = this.currentTarget.Thing as Pawn;
-            CompAbilityUserMagic comp = caster.GetCompAbilityUserMagic();
-            bool flag = pawn != null && pawn.health != null && pawn.health.hediffSet != null && pawn.health.hediffSet.GetInjuredParts() != null;
-            if (flag && comp != null)
+            Pawn pawn = currentTarget.Thing as Pawn;
+            CompAbilityUserMagic comp = base.CasterPawn.GetCompAbilityUserMagic();
+            if (pawn?.health?.hediffSet?.GetInjuredParts() == null || comp == null) return false;
+
+            IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally() && injury.TendableNow());
+
+            IEnumerator<Hediff_Injury> enumerator = injuries.GetEnumerator();
+            while (enumerator.MoveNext())
             {
-                Enumerate:
-                using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+                Hediff_Injury injury = enumerator.Current;
+                if (injury == null) break;  // Shouldn't be true, but since we are changing collection in iteration just be safe.
+
+                if (Rand.Chance(.25f / comp.arcaneDmg))
                 {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-
-                        IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                        Func<Hediff_Injury, bool> arg_BB_1;
-
-                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                        foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                        {
-                            bool flag5 = current.CanHealNaturally() && !current.IsPermanent() && current.TendableNow();
-                            if (flag5)
-                            {
-                                if (Rand.Chance(.25f / comp.arcaneDmg))
-                                {
-                                    DamageInfo dinfo;
-                                    dinfo = new DamageInfo(DamageDefOf.Burn, Mathf.RoundToInt(current.Severity/2), 0, (float)-1, this.CasterPawn, rec, null, DamageInfo.SourceCategory.ThingOrUnknown);
-                                    dinfo.SetAllowDamagePropagation(false);
-                                    dinfo.SetInstantPermanentInjury(true);                                  
-                                    current.Heal(100);                                    
-                                    pawn.TakeDamage(dinfo);
-                                    TM_MoteMaker.ThrowFlames(pawn.DrawPos, pawn.Map, Rand.Range(.2f, .5f));
-                                    goto Enumerate;
-                                }
-                                else
-                                {
-                                    //current.Tended(1, 1);
-                                    current.Tended(1f, 1f);
-                                    TM_MoteMaker.ThrowFlames(pawn.DrawPos, pawn.Map, Rand.Range(.1f, .4f));
-                                }                                
-                            }                           
-                        }                        
-                    }
+                    DamageInfo dinfo = new DamageInfo(
+                        DamageDefOf.Burn, Mathf.RoundToInt(injury.Severity/2), 0, -1, CasterPawn, injury.Part);
+                    dinfo.SetAllowDamagePropagation(false);
+                    dinfo.SetInstantPermanentInjury(true);
+                    injury.Heal(100);
+                    pawn.TakeDamage(dinfo);
+                    TM_MoteMaker.ThrowFlames(pawn.DrawPos, pawn.Map, Rand.Range(.2f, .5f));
+                    enumerator.Reset();
                 }
-                using (IEnumerator<Hediff> enumerator1 = pawn.health.hediffSet.GetHediffsTendable().GetEnumerator())
+                else
                 {
-                    while (enumerator1.MoveNext())
-                    {
-                        Hediff rec1 = enumerator1.Current;
-                        if (rec1.TendableNow() && rec1.Bleeding && rec1 is Hediff_MissingPart)
-                        {
-                            Traverse.Create(root: rec1).Field(name: "isFreshInt").SetValue(false);
-                        }                        
-                    }
+                    //current.Tended(1, 1);
+                    injury.Tended(1f, 1f);
+                    TM_MoteMaker.ThrowFlames(pawn.DrawPos, pawn.Map, Rand.Range(.1f, .4f));
                 }
+            }
+            enumerator.Dispose();
+
+            IEnumerable<Hediff_MissingPart> missingParts = pawn.health.hediffSet.GetHediffsTendable()
+                .OfType<Hediff_MissingPart>()
+                .Where(missingPart => missingPart.Bleeding);
+            foreach (Hediff_MissingPart missingPart in missingParts)
+            {
+                missingPart.IsFresh = false;
             }
             return false;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Utils;
 using Verse;
 using UnityEngine;
 
@@ -220,41 +221,16 @@ namespace TorannMagic
             TM_MoteMaker.ThrowManaPuff(caster.Position.ToVector3Shifted(), caster.Map, .8f);
         }
 
-        public void HealCaster(Pawn caster, int num, int num2, float healAmt)
+        public static void HealCaster(Pawn pawn, int injuriesToHeal, int injuriesPerBodyPart, float healAmt)
         {
-            if (num > 0)
+            IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally())
+                .DistinctBy(injury => injury.Part, injuriesPerBodyPart)
+                .Take(injuriesToHeal);
+            foreach (Hediff_Injury injury in injuries)
             {
-                using (IEnumerator<BodyPartRecord> enumerator = caster.health.hediffSet.GetInjuredParts().GetEnumerator())
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-                        bool flag2 = num > 0;
-
-                        if (flag2)
-                        {
-                            IEnumerable<Hediff_Injury> arg_BB_0 = caster.health.hediffSet.GetHediffs<Hediff_Injury>();
-                            Func<Hediff_Injury, bool> arg_BB_1;
-
-                            arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                            foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                            {
-                                bool flag3 = num2 > 0;
-                                if (flag3)
-                                {
-                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                    if (flag5)
-                                    {
-                                        current.Heal(healAmt);
-                                        num--;
-                                        num2--;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                injury.Heal(healAmt);
             }
         }
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse_Mass.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ConsumeCorpse_Mass.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Utils;
 using Verse;
 using UnityEngine;
 
@@ -215,41 +216,16 @@ namespace TorannMagic
             TM_MoteMaker.ThrowManaPuff(caster.Position.ToVector3Shifted(), caster.Map, .8f);
         }
 
-        public void HealCaster(Pawn caster, int num, int num2, float healAmt)
+        public static void HealCaster(Pawn pawn, int injuriesToHeal, int injuriesPerBodyPart, float healAmt)
         {
-            if (num > 0)
+            IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally())
+                .DistinctBy(injury => injury.Part, injuriesPerBodyPart)
+                .Take(injuriesToHeal);
+            foreach (Hediff_Injury injury in injuries)
             {
-                using (IEnumerator<BodyPartRecord> enumerator = caster.health.hediffSet.GetInjuredParts().GetEnumerator())
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-                        bool flag2 = num > 0;
-
-                        if (flag2)
-                        {
-                            IEnumerable<Hediff_Injury> arg_BB_0 = caster.health.hediffSet.GetHediffs<Hediff_Injury>();
-                            Func<Hediff_Injury, bool> arg_BB_1;
-
-                            arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                            foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                            {
-                                bool flag3 = num2 > 0;
-                                if (flag3)
-                                {
-                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                    if (flag5)
-                                    {
-                                        current.Heal(healAmt);
-                                        num--;
-                                        num2--;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                injury.Heal(healAmt);
             }
         }
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_CureDisease.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_CureDisease.cs
@@ -66,112 +66,106 @@ namespace TorannMagic
                 if(sevAdjustment >= .25f) 
                 {
                     bool success = false;
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                    List<TMDefs.TM_CategoryHediff> diseaseList = HediffCategoryList.Named("TM_Category_Hediffs").diseases;
+                    foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                     {
-                        while (enumerator.MoveNext())
+                        if (TM_Data.AddictionList().Contains(hediff.def))
                         {
-                            Hediff rec = enumerator.Current;
-                            bool flag2 = num > 0;
-
-                            if (TM_Data.AddictionList().Contains(rec.def))
+                            foreach (TMDefs.TM_CategoryHediff chd in diseaseList)
                             {
-                                List<TMDefs.TM_CategoryHediff> diseaseList = HediffCategoryList.Named("TM_Category_Hediffs").diseases;
-                                foreach (TMDefs.TM_CategoryHediff chd in diseaseList)
+                                if (chd.hediffDefname.Contains(hediff.def.defName))
                                 {
-                                    if (chd.hediffDefname.Contains(rec.def.defName))
+                                    if (comp != null && chd.requiredSkillName != "TM_Purify_ver")
                                     {
-                                        if (comp != null && chd.requiredSkillName != "TM_Purify_ver")
+                                        pwrVal = comp.MagicData.AllMagicPowerSkills.First(mps => mps.label == chd.powerSkillName).level;
+                                        verVal = comp.MagicData.AllMagicPowerSkills.First(mps => mps.label == chd.requiredSkillName).level;
+                                    }
+                                    if (verVal >= chd.requiredSkillLevel)
+                                    {
+                                        if (chd.removeOnCure)
                                         {
-                                            pwrVal = comp.MagicData.AllMagicPowerSkills.FirstOrDefault((MagicPowerSkill x) => x.label == chd.powerSkillName).level;
-                                            verVal = comp.MagicData.AllMagicPowerSkills.FirstOrDefault((MagicPowerSkill x) => x.label == chd.requiredSkillName).level;
-                                        }
-                                        if (verVal >= chd.requiredSkillLevel)
-                                        {
-                                            if (chd.removeOnCure)
+                                            if (Rand.Chance((chd.chanceToRemove + (chd.powerSkillAdjustment * pwrVal)) * arcaneDmg))
                                             {
-                                                if (Rand.Chance((chd.chanceToRemove + (chd.powerSkillAdjustment * pwrVal)) * arcaneDmg))
+                                                pawn.health.RemoveHediff(hediff);
+                                                if (chd.replacementHediffDefname != "")
                                                 {
-                                                    pawn.health.RemoveHediff(rec);
-                                                    if (chd.replacementHediffDefname != "")
-                                                    {
-                                                        HealthUtility.AdjustSeverity(pawn, HediffDef.Named(chd.replacementHediffDefname), chd.replacementHediffSeverity);
-                                                    }
-                                                    success = true;
-                                                    num--;
+                                                    HealthUtility.AdjustSeverity(pawn, HediffDef.Named(chd.replacementHediffDefname), chd.replacementHediffSeverity);
                                                 }
-                                                else
-                                                {
-                                                    MoteMaker.ThrowText(pawn.DrawPos, pawn.Map, "Failed to remove " + rec.Label + " ...");
-                                                }
-                                                break;
+                                                success = true;
+                                                num--;
                                             }
                                             else
                                             {
-                                                if (((rec.Severity - (chd.severityReduction + (chd.powerSkillAdjustment * pwrVal)) * arcaneDmg <= 0)))
-                                                {
-                                                    if (chd.replacementHediffDefname != "")
-                                                    {
-                                                        HealthUtility.AdjustSeverity(pawn, HediffDef.Named(chd.replacementHediffDefname), chd.replacementHediffSeverity);
-                                                    }
-                                                    success = true;
-                                                }
-                                                rec.Severity -= ((chd.severityReduction + (chd.powerSkillAdjustment * pwrVal)) * arcaneDmg);                                                
-                                                num--;
-                                                break;
+                                                MoteMaker.ThrowText(pawn.DrawPos, pawn.Map, "Failed to remove " + hediff.Label + " ...");
                                             }
+                                            break;
+                                        }
+                                        else
+                                        {
+                                            if (((hediff.Severity - (chd.severityReduction + (chd.powerSkillAdjustment * pwrVal)) * arcaneDmg <= 0)))
+                                            {
+                                                if (chd.replacementHediffDefname != "")
+                                                {
+                                                    HealthUtility.AdjustSeverity(pawn, HediffDef.Named(chd.replacementHediffDefname), chd.replacementHediffSeverity);
+                                                }
+                                                success = true;
+                                            }
+                                            hediff.Severity -= ((chd.severityReduction + (chd.powerSkillAdjustment * pwrVal)) * arcaneDmg);
+                                            num--;
+                                            break;
                                         }
                                     }
                                 }
                             }
-                            else
+                        }
+                        else
+                        {
+                            if (hediff.def.defName == "WoundInfection" || hediff.def.defName.Contains("Flu") || hediff.def.defName == "Animal_Flu" || hediff.def.defName.Contains("Infection"))
                             {
-                                if (rec.def.defName == "WoundInfection" || rec.def.defName.Contains("Flu") || rec.def.defName == "Animal_Flu" || rec.def.defName.Contains("Infection"))
-                                {
-                                    //rec.Severity -= sevAdjustment;
-                                    pawn.health.RemoveHediff(rec);
-                                    success = true;
-                                }
-                                if (verVal >= 1 && (rec.def.defName == "GutWorms" || rec.def == HediffDefOf.Malaria || rec.def == HediffDefOf.FoodPoisoning))
-                                {
-                                    //rec.Severity -= sevAdjustment;
-                                    pawn.health.RemoveHediff(rec);
-                                    success = true;
-                                }
-                                if (verVal >= 2 && (rec.def.defName == "SleepingSickness" || rec.def.defName == "MuscleParasites") || rec.def == HediffDefOf.Scaria)
-                                {
-                                    //rec.Severity -= sevAdjustment;
-                                    pawn.health.RemoveHediff(rec);
-                                    success = true;
-                                }
-                                if (verVal == 3 && (rec.def.makesSickThought && rec.def.isBad))
-                                {
-                                    //rec.Severity -= sevAdjustment;
-                                    if (rec.def.defName == "BloodRot")
-                                    {
-                                        rec.Severity = 0.01f;
-                                        MoteMaker.ThrowText(pawn.DrawPos, pawn.Map, "Tended Blood Rot", -1f);
-                                        rec.Tended(1f, 1f);
-                                        TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3(), pawn.Map, 1.5f);
-                                        return false;
-                                    }
-                                    else if (rec.def.defName == "Abasia")
-                                    {
-                                        //do nothing
-                                    }
-                                    else
-                                    {
-                                        pawn.health.RemoveHediff(rec);
-                                        success = true;
-                                    }
-                                }
+                                //rec.Severity -= sevAdjustment;
+                                pawn.health.RemoveHediff(hediff);
+                                success = true;
                             }
-                            if(success)
+                            if (verVal >= 1 && (hediff.def.defName == "GutWorms" || hediff.def == HediffDefOf.Malaria || hediff.def == HediffDefOf.FoodPoisoning))
                             {
-                                break;
+                                //rec.Severity -= sevAdjustment;
+                                pawn.health.RemoveHediff(hediff);
+                                success = true;
+                            }
+                            if (verVal >= 2 && (hediff.def.defName == "SleepingSickness" || hediff.def.defName == "MuscleParasites") || hediff.def == HediffDefOf.Scaria)
+                            {
+                                //rec.Severity -= sevAdjustment;
+                                pawn.health.RemoveHediff(hediff);
+                                success = true;
+                            }
+                            if (verVal == 3 && (hediff.def.makesSickThought && hediff.def.isBad))
+                            {
+                                //rec.Severity -= sevAdjustment;
+                                if (hediff.def.defName == "BloodRot")
+                                {
+                                    hediff.Severity = 0.01f;
+                                    MoteMaker.ThrowText(pawn.DrawPos, pawn.Map, "Tended Blood Rot", -1f);
+                                    hediff.Tended(1f, 1f);
+                                    TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3(), pawn.Map, 1.5f);
+                                    return false;
+                                }
+                                else if (hediff.def.defName == "Abasia")
+                                {
+                                    //do nothing
+                                }
+                                else
+                                {
+                                    pawn.health.RemoveHediff(hediff);
+                                    success = true;
+                                }
                             }
                         }
+                        if(success)
+                        {
+                            break;
+                        }
                     }
-                    if (success == true)
+                    if (success)
                     {                        
                         TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3(), pawn.Map, 1.5f);
                         MoteMaker.ThrowText(pawn.DrawPos, pawn.Map, "Cure Disease" + ": " + StringsToTranslate.AU_CastSuccess, -1f);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelEnchantWeapon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_DispelEnchantWeapon.cs
@@ -36,19 +36,11 @@ namespace TorannMagic
 
         public static void RemoveExistingEnchantment(Pawn pawn)
         {
-            Hediff hediff = null;
-            List<Hediff> allHediffs = new List<Hediff>();
-            allHediffs.Clear();
-            allHediffs = pawn.health.hediffSet.GetHediffs<Hediff>().ToList();
-            if (allHediffs != null && allHediffs.Count > 0)
+            foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
             {
-                for (int i = 0; i < allHediffs.Count; i++)
+                if (hediff.def.defName.Contains("TM_WeaponEnchantment"))
                 {
-                    hediff = allHediffs[i];
-                    if (hediff.def.defName.Contains("TM_WeaponEnchantment"))
-                    {
-                        pawn.health.RemoveHediff(hediff);
-                    }
+                    pawn.health.RemoveHediff(hediff);
                 }
             }
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchantWeapon.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_EnchantWeapon.cs
@@ -119,16 +119,9 @@ namespace TorannMagic
 
         public void RemoveExistingEnchantment(Pawn pawn)
         {
-            Hediff hediff = null;
-            List<Hediff> allHediffs = new List<Hediff>();
-            allHediffs.Clear();
-            allHediffs = pawn.health.hediffSet.GetHediffs<Hediff>().ToList();
-            if (allHediffs != null && allHediffs.Count > 0)
-            {
-                for (int i = 0; i < allHediffs.Count; i++)
+                foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                 {
-                    hediff = allHediffs[i];
-                    if(hediff.def.defName.Contains("TM_WeaponEnchantment"))
+                    if (hediff.def.defName.Contains("TM_WeaponEnchantment"))
                     {
                         HediffComp_EnchantedWeapon ewComp = hediff.TryGetComp<HediffComp_EnchantedWeapon>();
                         if (ewComp != null)
@@ -142,7 +135,7 @@ namespace TorannMagic
                         pawn.health.RemoveHediff(hediff);
                     }
                 }
-            }
+
         }
     }
 }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Entertain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Entertain.cs
@@ -22,15 +22,11 @@ namespace TorannMagic
             {
                 if (pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_EntertainingHD")))
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                    foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                     {
-                        while (enumerator.MoveNext())
+                        if (hediff.def.defName.Contains("TM_EntertainingHD"))
                         {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def.defName.Contains("TM_EntertainingHD"))
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
+                            pawn.health.RemoveHediff(hediff);
                         }
                     }
                     

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_FirstAid.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_FirstAid.cs
@@ -19,46 +19,21 @@ namespace TorannMagic
         {
             Pawn caster = base.CasterPawn;
 
-            CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
+            // CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
             verVal = TM_Calc.GetSkillVersatilityLevel(caster, this.Ability.Def as TMAbilityDef);
             //pwrVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_FirstAid, "TM_FirstAid", "_pwr", true);
             //verVal = TM_Calc.GetMightSkillLevel(caster, comp.MightData.MightPowerSkill_FirstAid, "TM_FirstAid", "_ver", true);
 
-            bool flag = caster != null;
-            if (flag)
+            if (caster == null) return false;
+
+            IEnumerable<Hediff_Injury> injuriesToTend = caster.health.hediffSet.hediffs
+                .OfType<Hediff_Injury>()
+                .Where(injury => injury.CanHealNaturally() && injury.TendableNow())
+                .Take(2 + pwrVal);
+            foreach (Hediff_Injury injury in injuriesToTend)
             {
-                using (IEnumerator<BodyPartRecord> enumerator = caster.health.hediffSet.GetInjuredParts().GetEnumerator())
-                {
-                    int num = 2 + pwrVal;
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-
-                        IEnumerable<Hediff_Injury> arg_BB_0 = caster.health.hediffSet.GetHediffs<Hediff_Injury>();
-                        Func<Hediff_Injury, bool> arg_BB_1;
-
-                        arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                        if (num > 0)
-                        {
-                            int num2 = 2 + pwrVal;
-                            foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                            {
-                                if (num2 > 0)
-                                {
-                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent() && current.TendableNow();
-                                    if (flag5)
-                                    {
-                                        current.Tended(Rand.Range(0,0.4f) + (.1f * verVal), 1f);
-                                        num--;
-                                        num2--;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                injury.Tended(Rand.Range(0,0.4f) + .1f * verVal, 1f);
             }
             return false;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_GearRepair.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_GearRepair.cs
@@ -16,28 +16,22 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            bool flag = caster != null && !caster.Dead;
-            if (flag)
+            if (caster == null || caster.Dead) return true;
+
+            bool containedHediff = false;
+            for (int i = 0; i < caster.health.hediffSet.hediffs.Count; i++)
             {
-                if(caster.health.hediffSet.HasHediff(HediffDef.Named("TM_HediffGearRepair")))
+                if (caster.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_HediffGearRepair)
                 {
-                    using (IEnumerator<Hediff> enumerator = caster.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
-                    {
-                        while (enumerator.MoveNext())
-                        {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def.defName.Contains("TM_HediffGearRepair"))
-                            {
-                                caster.health.RemoveHediff(rec);
-                            }
-                        }
-                    }
+                    caster.health.RemoveHediff(caster.health.hediffSet.hediffs[i]);
+                    containedHediff = true;
+                    break;
                 }
-                else
-                {
-                    HealthUtility.AdjustSeverity(caster, HediffDef.Named("TM_HediffGearRepair"), .5f);
-                    FleckMaker.ThrowDustPuff(caster.Position, caster.Map, 1f);
-                }
+            }
+            if (!containedHediff)
+            {
+                HealthUtility.AdjustSeverity(caster, HediffDef.Named("TM_HediffGearRepair"), .5f);
+                FleckMaker.ThrowDustPuff(caster.Position, caster.Map, 1f);
             }
             return true;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Heal.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Heal.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
 using AbilityUser;
+using TorannMagic.Utils;
 using Verse;
 using UnityEngine;
 
@@ -66,61 +67,29 @@ namespace TorannMagic
             //    verVal = (tmpVerVal > verVal) ? tmpVerVal : verVal;
             //}
 
-            Pawn pawn = (Pawn)this.currentTarget;
-            bool flag = pawn != null && !pawn.Dead && !TM_Calc.IsUndead(pawn);
-            bool flagUndead = pawn != null && !pawn.Dead && TM_Calc.IsUndead(pawn);
-            if (flag)
+            Pawn pawn = (Pawn)currentTarget;
+            if (pawn == null || pawn.Dead) return true;
+
+            if (!TM_Calc.IsUndead(pawn))
             {
-                int num = 3 + verVal;
-                using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+                ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
+                int injuriesPerBodyPart = !CasterPawn.IsColonist && settingsRef.AIHardMode ? 5 : 1 + verVal;
+
+                IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                    .OfType<Hediff_Injury>()
+                    .Where(injury => injury.CanHealNaturally())
+                    .DistinctBy(injury => injury.Part, injuriesPerBodyPart)
+                    .Take(3 + verVal);
+
+                float healAmount = CasterPawn.IsColonist ? (8.0f + pwrVal * 2f) * comp.arcaneDmg : 20.0f + pwrVal * 3f;
+                foreach (Hediff_Injury injury in injuries)
                 {
-                    while (enumerator.MoveNext())
-                    {
-                        BodyPartRecord rec = enumerator.Current;
-                        bool flag2 = num > 0;
-                        
-                        if (flag2)
-                        {
-                            int num2 = 1 + verVal;
-                            ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                            if (!this.CasterPawn.IsColonist && settingsRef.AIHardMode)
-                            {
-                                num2 = 5;
-                            }
-                            IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                            Func<Hediff_Injury, bool> arg_BB_1;
-
-                            arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
-
-                            foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                            {
-                                bool flag4 = num2 > 0;
-                                if (flag4)
-                                {
-                                    bool flag5 = current.CanHealNaturally() && !current.IsPermanent();
-                                    if (flag5)
-                                    {
-                                        //current.Heal((float)((int)current.Severity + 1));
-                                        if (!this.CasterPawn.IsColonist)
-                                        {
-                                            current.Heal(20.0f + (float)pwrVal * 3f); // power affects how much to heal                                            
-                                        }
-                                        else
-                                        {
-                                            current.Heal((8.0f + (float)pwrVal * 2f)*comp.arcaneDmg); // power affects how much to heal
-                                        }
-                                        TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, .6f);
-                                        TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, .4f);
-                                        num--;
-                                        num2--;
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    injury.Heal(healAmount);
+                    TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, .6f);
+                    TM_MoteMaker.ThrowRegenMote(pawn.Position.ToVector3Shifted(), pawn.Map, .4f);
                 }
             }
-            if(flagUndead)
+            else
             {
                 for(int i = 0; i < 2+verVal; i++)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_HeavyBlow.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_HeavyBlow.cs
@@ -14,40 +14,34 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             Pawn caster = base.CasterPawn;
-            Pawn pawn = this.currentTarget.Thing as Pawn;
+            Pawn pawn = currentTarget.Thing as Pawn;
 
-            bool flag = pawn != null && !pawn.Dead;
-            if (flag)
+            if (pawn == null || pawn.Dead) return true;
+
+            bool hadHeavyBlow = false;
+            foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
             {
-                if(pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_HediffHeavyBlow))
+                if (hediff.def == TorannMagicDefOf.TM_HediffHeavyBlow)
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
-                    {
-                        while (enumerator.MoveNext())
-                        {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def == TorannMagicDefOf.TM_HediffHeavyBlow)
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    //if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer))
-                    //{
-                        int lvl = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_pwr").level;
-                        HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_HediffHeavyBlow, .95f + (.19f * lvl));
-                        FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
-                    //}
-                    //else
-                    //{
-                    //    HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_HediffHeavyBlow, .5f);
-                    //    FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
-                    //}
+                    pawn.health.RemoveHediff(hediff);
+                    hadHeavyBlow = true;
+                    break;
                 }
             }
+
+            if (hadHeavyBlow) return true;
+
+            //if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer))
+            //{
+            int lvl = pawn.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.First(mps => mps.label == "TM_FieldTraining_pwr").level;
+            HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_HediffHeavyBlow, .95f + .19f * lvl);
+            FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
+            //}
+            //else
+            //{
+            //    HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_HediffHeavyBlow, .5f);
+            //    FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
+            //}
             return true;
         }
     }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_InnerHealing.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_InnerHealing.cs
@@ -16,29 +16,22 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
+            if (pawn == null || pawn.Dead) return true;
 
-            bool flag = pawn != null && !pawn.Dead;
-            if (flag)
+            bool hadInnerHealing = false;
+            foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
             {
-                if(pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_HediffInnerHealing")))
+                if (hediff.def == TorannMagicDefOf.TM_HediffInnerHealing)
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
-                    {
-                        while (enumerator.MoveNext())
-                        {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def.defName.Contains("TM_HediffInnerHealing"))
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                        }
-                    }
+                    pawn.health.RemoveHediff(hediff);
+                    hadInnerHealing = true;
+                    break;
                 }
-                else
-                {
-                    HealthUtility.AdjustSeverity(pawn, HediffDef.Named("TM_HediffInnerHealing"), .5f );
-                    FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
-                }
+            }
+            if (!hadInnerHealing)
+            {
+                HealthUtility.AdjustSeverity(pawn, HediffDef.Named("TM_HediffInnerHealing"), .5f );
+                FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
             }
             return true;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Invisibility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Invisibility.cs
@@ -23,15 +23,11 @@ namespace TorannMagic
             {
                 if(pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_InvisibilityHD, false))
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                    for (int i = 0; i < pawn.health.hediffSet.hediffs.Count; i++)
                     {
-                        while (enumerator.MoveNext())
+                        if (pawn.health.hediffSet.hediffs[i].def == TorannMagicDefOf.TM_InvisibilityHD)
                         {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def == TorannMagicDefOf.TM_InvisibilityHD)
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
+                            pawn.health.RemoveHediff(pawn.health.hediffSet.hediffs[i]);
                         }
                     }
                     TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, .75f);

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_ManaShield.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_ManaShield.cs
@@ -40,54 +40,37 @@ namespace TorannMagic
         protected override bool TryCastShot()
         {
             bool result = false;
-            bool arg_40_0;
 
             Pawn pawn = this.CasterPawn;
             Map map = this.CasterPawn.Map;
 
             if (pawn != null && !pawn.Downed)
             {
-                if(pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_ManaShieldHD, false))
+                bool hadManaShield = false;
+                foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
+                    if (hediff.def == TorannMagicDefOf.TM_ManaShieldHD)
                     {
-                        while (enumerator.MoveNext())
-                        {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def.defName == "TM_ManaShieldHD")
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                        }
+                        pawn.health.RemoveHediff(hediff);
+                        hadManaShield = true;
+                        break;
                     }
-
-                    TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, .75f);
-                    TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, .75f);
-                    TM_MoteMaker.ThrowSiphonMote(pawn.DrawPos, pawn.Map, 1f);
                 }
-                else
+                if (!hadManaShield)
                 {
                     HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_ManaShieldHD, 1f);
-                    TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, .75f);
-                    TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, 1);
-                    TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, .75f);
                 }
-                arg_40_0 = true;
+                TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, .75f);
+                TM_MoteMaker.ThrowManaPuff(pawn.DrawPos, pawn.Map, .75f);
+                TM_MoteMaker.ThrowSiphonMote(pawn.DrawPos, pawn.Map, 1f);
+                result = true;
             }
-            else
-            {
-                arg_40_0 = false;
-            }
-            bool flag = arg_40_0;
-            if (flag)
-            {
-                
-            }
-            else
+
+            if (!result)
             {
                 Log.Warning("failed to TryCastShot");
             }
-            this.burstShotsLeft = 0;
+            burstShotsLeft = 0;
 
             return result;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_SoothingBalm.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_SoothingBalm.cs
@@ -5,6 +5,7 @@ using RimWorld;
 using AbilityUser;
 using Verse;
 using HarmonyLib;
+using TorannMagic.Utils;
 using UnityEngine;
 
 
@@ -39,7 +40,7 @@ namespace TorannMagic
         {
             Map map = this.CasterPawn.Map;
 
-            Pawn pawn = this.currentTarget.Thing as Pawn;
+            Pawn pawn = currentTarget.Thing as Pawn;
             Pawn caster = this.CasterPawn;
             CompAbilityUserMight comp = caster.GetCompAbilityUserMight();
 
@@ -48,81 +49,43 @@ namespace TorannMagic
 
             try
             {
-                bool flag = pawn != null && !pawn.Dead && !TM_Calc.IsUndead(pawn);
-                if (!pawn.DestroyedOrNull() && pawn.Spawned && map != null && pawn.health != null && pawn.health.hediffSet != null && flag)
-                {                   
-                    int num = 2 + Mathf.RoundToInt(.3f * verVal);
-                    HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_SoothingBalmHD, .3f - (.03f * verVal));
-                    using (IEnumerator<BodyPartRecord> enumerator = pawn.health.hediffSet.GetInjuredParts().GetEnumerator())
+                if (pawn == null || pawn.Dead || pawn.Destroyed || TM_Calc.IsUndead(pawn)) return false;
+                if (pawn.Spawned && map != null && pawn.health?.hediffSet != null)
+                {
+                    int injuriesToHeal = 2 + Mathf.RoundToInt(.3f * verVal);
+                    ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
+                    int injuriesPerBodyPart = !CasterPawn.IsColonist && settingsRef.AIHardMode ? 5 : 1 + Mathf.RoundToInt(.2f * verVal);
+
+                    IEnumerable<Hediff_Injury> injuries = pawn.health.hediffSet.hediffs
+                        .OfType<Hediff_Injury>()
+                        .Where(injury => injury.CanHealNaturally() && injury.TendableNow())
+                        .DistinctBy(injury => injury.Part, injuriesPerBodyPart)
+                        .Take(injuriesToHeal);
+
+                    HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_SoothingBalmHD, .3f - .03f * verVal);
+
+                    float healAmount = pawn.IsColonist ? 4.0f + pwrVal : 10 + pwrVal * 3f;
+                    foreach (Hediff_Injury injury in injuries)
                     {
-                        while (enumerator.MoveNext())
-                        {
-                            BodyPartRecord rec = enumerator.Current;
-                            bool flag2 = num > 0;
+                        injury.Heal(healAmount);
 
-                            if (flag2)
-                            {
-                                int num2 = 1 + Mathf.RoundToInt(.2f * verVal);
-                                ModOptions.SettingsRef settingsRef = new ModOptions.SettingsRef();
-                                if (!this.CasterPawn.IsColonist && settingsRef.AIHardMode)
-                                {
-                                    num2 = 5;
-                                }
-                                IEnumerable<Hediff_Injury> arg_BB_0 = pawn.health.hediffSet.GetHediffs<Hediff_Injury>();
-                                Func<Hediff_Injury, bool> arg_BB_1;
+                        HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_SoothingBalmHD, .04f);
+                        Vector3 pos = pawn.DrawPos;
+                        pos.x += Rand.Range(-.3f, .3f);
+                        pos.z += Rand.Range(-.3f, .3f);
+                        TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Healing_Small, pos, map, Rand.Range(.6f, 1f), .3f, .2f, .5f, 0, 0f, 0f, Rand.Range(0, 360));
 
-                                arg_BB_1 = ((Hediff_Injury injury) => injury.Part == rec);
+                        if (!injury.TendableNow()) continue;
 
-                                for (int i = 0; i < num; i++)
-                                {
-                                    Vector3 pos = pawn.DrawPos;
-                                    pos.x += Rand.Range(-.3f, .3f);
-                                    pos.z += Rand.Range(-.3f, .3f);
-                                    TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Healing_Small, pos, map, Rand.Range(.6f, 1f), .3f, .2f, .5f, 0, 0f, 0f, Rand.Range(0, 360));
-                                }
-
-                                foreach (Hediff_Injury current in arg_BB_0.Where(arg_BB_1))
-                                {
-                                    bool flag4 = num2 > 0;
-                                    if (flag4)
-                                    {
-                                        bool flag5 = current.CanHealNaturally() && !current.IsPermanent() && current.TendableNow(false);
-                                        if (flag5)
-                                        {
-                                            //current.Heal((float)((int)current.Severity + 1));
-                                            if (!this.CasterPawn.IsColonist)
-                                            {
-                                                current.Heal(10 + (float)pwrVal * 3f); // power affects how much to heal
-                                            }
-                                            else
-                                            {
-                                                current.Heal((4.0f + (float)pwrVal)); // power affects how much to heal
-                                            }
-                                            HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_SoothingBalmHD, .04f);
-                                            Vector3 pos = pawn.DrawPos;
-                                            pos.x += Rand.Range(-.3f, .3f);
-                                            pos.z += Rand.Range(-.3f, .3f);
-                                            TM_MoteMaker.ThrowGenericMote(TorannMagicDefOf.Mote_Healing_Small, pos, map, Rand.Range(.6f, 1f), .3f, .2f, .5f, 0, 0f, 0f, Rand.Range(0, 360));
-                                            num--;
-                                            num2--;
-                                            if(current.TendableNow())
-                                            {
-                                                float tendQuality = Rand.Range(.5f, .7f) + (pwrVal * .1f);
-                                                current.Tended(tendQuality, 1f);
-                                                pawn.records.Increment(RecordDefOf.TimesTendedTo);
-                                                caster.records.Increment(RecordDefOf.TimesTendedOther);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        float tendQuality = Rand.Range(.5f, .7f) + pwrVal * .1f;
+                        injury.Tended(tendQuality, 1f);
+                        pawn.records.Increment(RecordDefOf.TimesTendedTo);
+                        caster.records.Increment(RecordDefOf.TimesTendedOther);
                     }
-                    
                 }
                 else
                 {
-                    Messages.Message("TM_InvalidTarget".Translate(caster.LabelShort, this.Ability.Def.label), MessageTypeDefOf.NeutralEvent);
+                    Messages.Message("TM_InvalidTarget".Translate(caster.LabelShort, Ability.Def.label), MessageTypeDefOf.NeutralEvent);
                 }
             }
             catch (NullReferenceException ex)

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_Sprint.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_Sprint.cs
@@ -26,28 +26,22 @@ namespace TorannMagic
             //    pwrVal = caster.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_pwr").level;
             //}
             pwrVal = TM_Calc.GetSkillPowerLevel(caster, this.Ability.Def as TMAbilityDef);
-            bool flag = pawn != null && !pawn.Dead;
-            if (flag)
+            if (pawn == null || pawn.Dead) return true;
+
+            bool hadSprint = false;
+            foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
             {
-                if(pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_HediffSprint))
+                if (hediff.def == TorannMagicDefOf.TM_HediffSprint)
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
-                    {
-                        while (enumerator.MoveNext())
-                        {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def.defName.Contains("TM_HediffSprint"))
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                        }
-                    }
+                    pawn.health.RemoveHediff(hediff);
+                    hadSprint = true;
                 }
-                else
-                {
-                    HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_HediffSprint, .5f + pwrVal);
-                    FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
-                }
+            }
+
+            if (!hadSprint)
+            {
+                HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_HediffSprint, .5f + pwrVal);
+                FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
             }
             return true;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/Verb_StrongBack.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Verb_StrongBack.cs
@@ -16,38 +16,32 @@ namespace TorannMagic
             Pawn caster = base.CasterPawn;
             Pawn pawn = this.currentTarget.Thing as Pawn;
 
-            bool flag = pawn != null && !pawn.Dead;
-            if (flag)
+            if (pawn == null || pawn.Dead) return true;
+
+            bool hadStrongBack = false;
+            foreach (Hediff hediff in pawn.health.hediffSet.hediffs)
             {
-                if(pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_HediffStrongBack))
+                if (hediff.def == TorannMagicDefOf.TM_HediffStrongBack)
                 {
-                    using (IEnumerator<Hediff> enumerator = pawn.health.hediffSet.GetHediffs<Hediff>().GetEnumerator())
-                    {
-                        while (enumerator.MoveNext())
-                        {
-                            Hediff rec = enumerator.Current;
-                            if (rec.def.defName.Contains("TM_HediffStrongBack"))
-                            {
-                                pawn.health.RemoveHediff(rec);
-                            }
-                        }
-                    }
+                    pawn.health.RemoveHediff(hediff);
+                    hadStrongBack = true;
                 }
-                else
+            }
+
+            if (!hadStrongBack)
+            {
+                float val = .5f;
+                if (caster.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 3)
                 {
-                    float val = .5f;
-                    if (caster.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 3)
-                    {
-                        val = 1.5f;
-                    }
-                    if (caster.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 8)
-                    {
-                        val = 2.5f;
-                    }
-                    
-                    HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_HediffStrongBack, val);
-                    FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
+                    val = 1.5f;
                 }
+                if (caster.GetCompAbilityUserMight().MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_ver").level >= 8)
+                {
+                    val = 2.5f;
+                }
+
+                HealthUtility.AdjustSeverity(pawn, TorannMagicDefOf.TM_HediffStrongBack, val);
+                FleckMaker.ThrowDustPuff(pawn.Position, pawn.Map, 1f);
             }
             return true;
         }


### PR DESCRIPTION
While getting rid of GetHediff<T> I did notice a lot of loops that could be greatly simplified by using LINQ. I went ahead and changed what I could to use LINQ, though there is a small change of not guaranteeing order anymore. In the older code injuries being healed were guaranteed to be of the same body part until it reached the injury per body part limit. I removed that guarantee to provide simpler and faster code.

Some other things to note:
* CanHealNaturally() is just a pseudo function for !IsPermanent()
* DistinctBy is a custom LINQ-like function that is the same as Distinct except you provide a function to clarify what should be distinct, and optionally a number which allows you to have n items from that distinct group (ex: 2 injuries per body part)