### PR TITLE
Fix logic inside of IsMightUser and IsMagicUser as there was a mispla…

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -2236,7 +2236,7 @@ namespace TorannMagic
             }
         }
 
-        public bool IsMagicUser 
+        public bool IsMagicUser
         {
             get
             {
@@ -2261,13 +2261,22 @@ namespace TorannMagic
                         }
                     }
                 }
-                if (Pawn.story.traits.allTraits.Any(t => magicTraitIndexes.Contains(t.def.index) 
-                || TM_Calc.IsWanderer(base.Pawn) 
-                || (this.AdvancedClasses != null && this.AdvancedClasses.Count > 0)))
+
+                // Avoid LINQ since this is called inside of CompTick
+                bool hasMagicTrait = false;
+                for (int i = 0; i < Pawn.story.traits.allTraits.Count; i++)
+                {
+                    if (!magicTraitIndexes.Contains(Pawn.story.traits.allTraits[i].def.index)) continue;
+
+                    hasMagicTrait = true;
+                    break;
+                }
+
+                if (hasMagicTrait || TM_Calc.IsWanderer(Pawn) || AdvancedClasses.Count > 0)
                 {
                     return true;
                 }
-                else if(TM_Calc.HasAdvancedClass(this.Pawn))
+                if(TM_Calc.HasAdvancedClass(Pawn))
                 {
                     bool hasMageAdvClass = false;
                     foreach(TMDefs.TM_CustomClass cc in TM_ClassUtility.GetAdvancedClassesForPawn(this.Pawn))

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
@@ -1332,10 +1332,19 @@ namespace TorannMagic
                             return true;
                         }
                     }
-                }                
-                if (Pawn.story.traits.allTraits.Any(t => mightTraitIndexes.Contains(t.def.index)
-                || TM_Calc.IsWayfarer(base.Pawn)
-                || (this.AdvancedClasses != null && this.AdvancedClasses.Count > 0)))
+                }
+
+                // Avoid LINQ since this is called inside of CompTick
+                bool hasMightTrait = false;
+                for (int i = 0; i < Pawn.story.traits.allTraits.Count; i++)
+                {
+                    if (!mightTraitIndexes.Contains(Pawn.story.traits.allTraits[i].def.index)) continue;
+
+                    hasMightTrait = true;
+                    break;
+                }
+
+                if (hasMightTrait || TM_Calc.IsWayfarer(Pawn) || AdvancedClasses.Count > 0)
                 {
                     return true;
                 }                

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserTMBase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserTMBase.cs
@@ -16,26 +16,10 @@ namespace TorannMagic
 
         public TMDefs.TM_CustomClass customClass = null;
         private List<TMDefs.TM_CustomClass> advClasses = null;
-        public List<TMDefs.TM_CustomClass> AdvancedClasses
+        public List<TM_CustomClass> AdvancedClasses
         {
-            get
-            {
-                if (advClasses == null)
-                {
-                    advClasses = new List<TMDefs.TM_CustomClass>();
-                    advClasses.Clear();
-                }
-                return advClasses;
-            }
-            set
-            {
-                if (advClasses == null)
-                {
-                    advClasses = new List<TMDefs.TM_CustomClass>();
-                    advClasses.Clear();
-                }
-                advClasses = value;
-            }
+            get => advClasses ?? (advClasses = new List<TM_CustomClass>());
+            set => advClasses = value;
         }
 
         protected int age = -1;


### PR DESCRIPTION
Fix logic inside of IsMightUser and IsMagicUser as there was a misplaced parentheses. Also remove LINQ simply because CompTick is called a LOT and the overhead is only significant in places like that.