### PR TITLE
Optimize_DrawMesh_Cloaks_Patch

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2458,7 +2458,7 @@ namespace TorannMagic
                 if (mat == null) return true;
                 if (!ModOptions.Constants.GetCloaks().Contains(mat)) return true;
 
-                loc.y = ModOptions.Constants.GetCloaksNorth().Contains(mat) ? 8.75f : 8.17f;
+                loc.y = Array.IndexOf(ModOptions.Constants.GetCloaksNorth(), mat) != -1 ? 8.75f : 8.17f;
                 if (drawNow)
                 {
                     mat.SetPass(0);

--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -2455,39 +2455,20 @@ namespace TorannMagic
         {
             public static bool Prefix(Mesh mesh, Vector3 loc, Quaternion quat, Material mat, bool drawNow)
             {
-                if (mesh != null && loc != null && quat != null && mat != null)
-                {
-                    //Log.Message("item is " + mat.mainTexture.ToString() + " at y: " + loc.y);
-                    //if (mat.mainTexture != null && mat.mainTexture.name != null)
-                    //{
-                    //    Log.Message("thing: " + mat.mainTexture.name + " at loc.y:" + loc.y);
-                    //}
-                    if (mat.mainTexture != null && ModOptions.Constants.GetCloaks().Contains(mat.mainTexture))//mat.mainTexture.name != null && mat.mainTexture.ToString() != null && (mat.mainTexture.ToString().Contains("demonlordcloak") || mat.mainTexture.name.Contains("opencloak")))
-                    {
-                        //Log.Message("main texture is: " + mat.mainTexture);
-                        //Log.Message("pool contains " + ModOptions.Constants.GetCloaks()[0]);
-                        //Log.Message("item is " + mat.mainTexture.ToString() + " at y: " + loc.y);
-                        loc.y = 8.17f;  ///8.205f
-                        //loc.y += .010f; //was 0.015f
-                        if (ModOptions.Constants.GetCloaksNorth().Contains(mat.mainTexture))
-                        {
-                            //loc.y += .00175f; //was 0.006f
-                            loc.y = 8.75f; //7.9961f; 8.209, 8.309
-                        }
+                if (mat == null) return true;
+                if (!ModOptions.Constants.GetCloaks().Contains(mat)) return true;
 
-                        if (drawNow)
-                        {
-                            mat.SetPass(0);
-                            Graphics.DrawMeshNow(mesh, loc, quat);
-                        }
-                        else
-                        {
-                            Graphics.DrawMesh(mesh, loc, quat, mat, 0);
-                        }
-                        return false;
-                    }
+                loc.y = ModOptions.Constants.GetCloaksNorth().Contains(mat) ? 8.75f : 8.17f;
+                if (drawNow)
+                {
+                    mat.SetPass(0);
+                    Graphics.DrawMeshNow(mesh, loc, quat);
                 }
-                return true;
+                else
+                {
+                    Graphics.DrawMesh(mesh, loc, quat, mat, 0);
+                }
+                return false;
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/ModOptions/Constants.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/ModOptions/Constants.cs
@@ -159,64 +159,65 @@ namespace TorannMagic.ModOptions
             return shotgunSpecCount;
         }
 
-        private static List<Texture> cloaks;
-        public static List<Texture> GetCloaks()
+        private static HashSet<Material> cloaks;
+        public static HashSet<Material> GetCloaks()
         {
             return cloaks;            
         }
 
-        public static List<Texture> cloaksNorth;
-        public static List<Texture> GetCloaksNorth()
+        private static Material[] cloaksNorth;
+        public static Material[] GetCloaksNorth()
         {
             return cloaksNorth;
         }
 
         public static void InitializeCloaks()
         {
-            Constants.cloaks = new List<Texture>();
-            Constants.cloaks.Clear();
-            Constants.cloaksNorth = new List<Texture>();
-            Constants.cloaksNorth.Clear();
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/opencloak_Female_north").mainTexture);
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/opencloak_Hulk_north").mainTexture);
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/opencloak_Male_north").mainTexture);
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/opencloak_Thin_north").mainTexture);
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/opencloak_Fat_north").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Female_east").mainTexture);            
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Female_south").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Fat_east").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Fat_south").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Hulk_east").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Hulk_south").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Thin_east").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Thin_south").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Male_east").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_Male_south").mainTexture);
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Female_north").mainTexture);
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Hulk_north").mainTexture);
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Male_north").mainTexture);
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Thin_north").mainTexture);
-            Constants.cloaksNorth.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Fat_north").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Female_east").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Female_south").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Fat_east").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Fat_south").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Hulk_east").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Hulk_south").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Thin_east").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Thin_south").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Male_east").mainTexture);
-            Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_Male_south").mainTexture);
+            cloaksNorth = new [] {
+                MaterialPool.MatFrom("Equipment/opencloak_Female_north"),
+                MaterialPool.MatFrom("Equipment/opencloak_Hulk_north"),
+                MaterialPool.MatFrom("Equipment/opencloak_Male_north"),
+                MaterialPool.MatFrom("Equipment/opencloak_Thin_north"),
+                MaterialPool.MatFrom("Equipment/opencloak_Fat_north"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Female_north"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Hulk_north"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Male_north"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Thin_north"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Fat_north")
+            };
+            cloaks = new HashSet<Material>
+            {
+                MaterialPool.MatFrom("Equipment/opencloak_Female_east"),
+                MaterialPool.MatFrom("Equipment/opencloak_Female_south"),
+                MaterialPool.MatFrom("Equipment/opencloak_Fat_east"),
+                MaterialPool.MatFrom("Equipment/opencloak_Fat_south"),
+                MaterialPool.MatFrom("Equipment/opencloak_Hulk_east"),
+                MaterialPool.MatFrom("Equipment/opencloak_Hulk_south"),
+                MaterialPool.MatFrom("Equipment/opencloak_Thin_east"),
+                MaterialPool.MatFrom("Equipment/opencloak_Thin_south"),
+                MaterialPool.MatFrom("Equipment/opencloak_Male_east"),
+                MaterialPool.MatFrom("Equipment/opencloak_Male_south"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Female_east"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Female_south"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Fat_east"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Fat_south"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Hulk_east"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Hulk_south"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Thin_east"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Thin_south"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Male_east"),
+                MaterialPool.MatFrom("Equipment/demonlordcloakc_Male_south")
+            };
             if(ModsConfig.IsActive("ssulunge.BBBodySupport"))
             {
-                Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_FemaleBB_east").mainTexture);
-                Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_FemaleBB_south").mainTexture);
-                Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_FemaleBB_north").mainTexture);
-                Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_FemaleBB_east").mainTexture);
-                Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_FemaleBB_south").mainTexture);
-                Constants.cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_FemaleBB_south").mainTexture);
+                cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_FemaleBB_east"));
+                cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_FemaleBB_south"));
+                cloaks.Add(MaterialPool.MatFrom("Equipment/demonlordcloakc_FemaleBB_north"));
+                cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_FemaleBB_east"));
+                cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_FemaleBB_south"));
+                cloaks.Add(MaterialPool.MatFrom("Equipment/opencloak_FemaleBB_south"));
             }
-            Constants.cloaks.AddRange(cloaksNorth);
+            cloaks.AddRange(cloaksNorth);
         }
 
         public static Dictionary<string,IEnumerable<Gizmo>> reducedGizmoList;


### PR DESCRIPTION
* Remove unnecessarily added checks that we weren't using (`mesh != null`, `loc != null`, `quat != null`)
* Use Material for comparison instead of Texture since Material.mainTexture is expensive
* Convert cloaks to HashSet<Material> since HashSets are faster than checking lists of size over 10
* Convert northCloaks to Material[] since arrays are faster at iterating than Lists and HashSets are slower when the array is 10 items or less (as a rule. In this case HashSet is .001ms slower than array)

Overall speedup on my tests goes from .080ms -> .006ms