### PR TITLE
Cleanup if statements to reduce number of IsColonist calls

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/AutoCast/Scripts.cs
@@ -991,7 +991,7 @@ namespace TorannMagic.AutoCast
     {
         public static void Execute(Job job, Pawn caster)
         {
-            if (caster.IsColonist && ModOptions.Settings.Instance.autocastQueueing && !caster.Drafted && caster.CurJobDef != JobDefOf.Hunt)
+            if (ModOptions.Settings.Instance.autocastQueueing && !caster.Drafted && caster.CurJobDef != JobDefOf.Hunt && caster.IsColonist)
             {
                 if (caster.jobs.jobQueue.Count < 1)
                 {

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMArcaneForge.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMArcaneForge.cs
@@ -133,7 +133,7 @@ namespace TorannMagic
                     List<Pawn> mapPawns = this.Map.mapPawns.AllPawnsSpawned;
                     for(int j =0; j < mapPawns.Count; j++)
                     {
-                        if(mapPawns[j].IsColonist && mapPawns[j].RaceProps.Humanlike && mapPawns[j].CurJob != null && mapPawns[j].CurJob.bill != null)
+                        if(mapPawns[j].IsColonist && mapPawns[j].CurJob?.bill != null)
                         {
                             if (mapPawns[j].CurJob.bill.recipe.defName == this.BillStack[i].recipe.defName)
                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift.cs
@@ -165,7 +165,7 @@ namespace TorannMagic
                 for (int i = 0; i < animalList.Count; i++)
                 {
                     int j = Rand.Range(0, animalList.Count);
-                    if (animalList[j].RaceProps.Animal && !animalList[j].IsColonist && !animalList[j].def.defName.Contains("Elemental") && animalList[j].Faction == null)
+                    if (animalList[j].RaceProps.Animal && !animalList[j].def.defName.Contains("Elemental") && animalList[j].Faction == null)
                     {
                         animalList[j].mindState.mentalStateHandler.TryStartMentalState(MentalStateDefOf.ManhunterPermanent, null, true, false, null);
                         i = animalList.Count;

--- a/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift_Defenders.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Building_TMElementalRift_Defenders.cs
@@ -169,7 +169,7 @@ namespace TorannMagic
                 for (int i = 0; i < animalList.Count; i++)
                 {
                     int j = Rand.Range(0, animalList.Count);
-                    if (animalList[j].RaceProps.Animal && !animalList[j].IsColonist && !animalList[j].def.defName.Contains("Elemental") && animalList[j].Faction == null)
+                    if (animalList[j].RaceProps.Animal && !animalList[j].def.defName.Contains("Elemental") && animalList[j].Faction == null)
                     {
                         animalList[j].mindState.mentalStateHandler.TryStartMentalState(MentalStateDefOf.ManhunterPermanent, null, true, false, null);
                         i = animalList.Count;

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAIController.cs
@@ -217,7 +217,7 @@ namespace TorannMagic
                 {
                     for (int i = 0; i < threatPawns.Count; i++)
                     {
-                        if (threatPawns[i].Faction != null && this.Pawn.Faction != null && threatPawns[i].Faction.HostileTo(this.Pawn.Faction) && !threatPawns[i].IsColonist)
+                        if (threatPawns[i].Faction != null && Pawn.Faction != null && threatPawns[i].Faction.HostileTo(Pawn.Faction))
                         {
                             if (threatPawns[i].jobs != null && threatPawns[i].CurJob != null && threatPawns[i].CurJob.targetA != null && threatPawns[i].CurJob.targetA.Thing != null && threatPawns[i].CurJob.targetA.Thing != this.Pawn)
                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompSkeletonController.cs
@@ -350,7 +350,7 @@ namespace TorannMagic
                     int count = Mathf.Min(threatPawns.Count, 10);
                     for (int i = 0; i < count; i++)
                     {
-                        if (threatPawns[i].Faction != null && this.Pawn.Faction != null && threatPawns[i].Faction.HostileTo(this.Pawn.Faction) && !threatPawns[i].IsColonist)
+                        if (threatPawns[i].Faction != null && Pawn.Faction != null && threatPawns[i].Faction.HostileTo(Pawn.Faction))
                         {
                             if (threatPawns[i].jobs != null && threatPawns[i].CurJob != null && threatPawns[i].CurJob.targetA != null && threatPawns[i].CurJob.targetA.Thing != null && threatPawns[i].CurJob.targetA.Thing != this.Pawn)
                             {

--- a/RimWorldOfMagic/RimWorldOfMagic/MagicAbility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MagicAbility.cs
@@ -94,35 +94,33 @@ namespace TorannMagic
             //base.PostAbilityAttempt();
             
             
-            if (!this.Pawn.IsColonist && ModOptions.Settings.Instance.AIAggressiveCasting)// for AI
+            if (ModOptions.Settings.Instance.AIAggressiveCasting && !Pawn.IsColonist)// for AI
             {
-                this.CooldownTicksLeft = Mathf.RoundToInt(this.MaxCastingTicks/2f);
+                CooldownTicksLeft = Mathf.RoundToInt(MaxCastingTicks/2f);
             }
             else
             {
-                this.CooldownTicksLeft = Mathf.RoundToInt(this.MaxCastingTicks * this.MagicUser.coolDown);
+                this.CooldownTicksLeft = Mathf.RoundToInt(MaxCastingTicks * MagicUser.coolDown);
             }
             if(Rand.Chance(MagicUser.arcalleumCooldown))
             {
                 this.CooldownTicksLeft = 4;
             }
-            bool flag = this.magicDef != null;
-            if (flag)
+            if (magicDef != null)
             {
                 if (this.Pawn.IsColonist)
                 {
-                    Find.HistoryEventsManager.RecordEvent(new HistoryEvent(TorannMagicDefOf.TM_UsedMagic, this.Pawn.Named(HistoryEventArgsNames.Doer), this.Pawn.Named(HistoryEventArgsNames.Subject), this.Pawn.Named(HistoryEventArgsNames.AffectedFaction), this.Pawn.Named(HistoryEventArgsNames.Victim)), true);
+                    Find.HistoryEventsManager.RecordEvent(new HistoryEvent(TorannMagicDefOf.TM_UsedMagic, Pawn.Named(HistoryEventArgsNames.Doer), Pawn.Named(HistoryEventArgsNames.Subject), Pawn.Named(HistoryEventArgsNames.AffectedFaction), Pawn.Named(HistoryEventArgsNames.Victim)));
                 }
-                bool flag3 = this.MagicUser.Mana != null;
-                if (flag3)
+                if (MagicUser.Mana != null)
                 {
-                    if(!this.Pawn.IsColonist && ModOptions.Settings.Instance.AIAggressiveCasting)// for AI
+                    if(ModOptions.Settings.Instance.AIAggressiveCasting && !Pawn.IsColonist)// for AI
                     {
-                        this.MagicUser.Mana.UseMagicPower(this.MagicUser.ActualManaCost(magicDef)/2f);
+                        MagicUser.Mana.UseMagicPower(MagicUser.ActualManaCost(magicDef)/2f);
                     }
                     else
                     {                       
-                        this.MagicUser.Mana.UseMagicPower(this.MagicUser.ActualManaCost(magicDef));
+                        MagicUser.Mana.UseMagicPower(MagicUser.ActualManaCost(magicDef));
                     }
                                        
                     if(this.magicDef != TorannMagicDefOf.TM_TransferMana && magicDef.abilityHediff == null)

--- a/RimWorldOfMagic/RimWorldOfMagic/MightAbility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MightAbility.cs
@@ -105,13 +105,13 @@ namespace TorannMagic
         {
             //base.PostAbilityAttempt();
             
-            if (!this.Pawn.IsColonist && ModOptions.Settings.Instance.AIAggressiveCasting)// for AI
+            if (ModOptions.Settings.Instance.AIAggressiveCasting && !Pawn.IsColonist)// for AI
             {
-                this.CooldownTicksLeft = Mathf.RoundToInt(this.MaxCastingTicks/2f);
+                CooldownTicksLeft = Mathf.RoundToInt(MaxCastingTicks/2f);
             }
             else
             {
-                this.CooldownTicksLeft = Mathf.RoundToInt(this.MaxCastingTicks * this.MightUser.coolDown);
+                CooldownTicksLeft = Mathf.RoundToInt(MaxCastingTicks * MightUser.coolDown);
             }
             if (Rand.Chance(MightUser.arcalleumCooldown))
             {
@@ -126,16 +126,15 @@ namespace TorannMagic
                 }
                 if (mightDef.consumeEnergy)
                 {
-                    bool flag3 = this.MightUser.Stamina != null;
-                    if (flag3)
+                    if (MightUser.Stamina != null)
                     {
-                        if (!this.Pawn.IsColonist && ModOptions.Settings.Instance.AIAggressiveCasting)// for AI
+                        if (ModOptions.Settings.Instance.AIAggressiveCasting && !Pawn.IsColonist)// for AI
                         {
-                            this.MightUser.Stamina.UseMightPower(this.MightUser.ActualStaminaCost(mightDef) / 2f);
+                            MightUser.Stamina.UseMightPower(MightUser.ActualStaminaCost(mightDef) / 2f);
                         }
                         else
                         {
-                            this.MightUser.Stamina.UseMightPower(this.MightUser.ActualStaminaCost(mightDef));
+                            MightUser.Stamina.UseMightPower(MightUser.ActualStaminaCost(mightDef));
                         }
 
                         this.MightUser.MightUserXP += (int)((mightDef.staminaCost * 180) * this.MightUser.xpGain * ModOptions.Settings.Instance.xpMultiplier);

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_Bard.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Thoughts/InteractionWorker_Bard.cs
@@ -10,9 +10,8 @@ namespace TorannMagic.Thoughts
         public override float RandomSelectionWeight(Pawn initiator, Pawn recipient)
         {
             CompAbilityUserMagic compInit = initiator.GetCompAbilityUserMagic();
-            bool flag = !initiator.IsColonist || !recipient.IsColonist || compInit is null;
             float result = 0f;            
-            if (flag)
+            if (!initiator.IsColonist || !recipient.IsColonist || compInit is null)
             {
                 result = 0f;
             }

--- a/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_ChargeArcaneObject.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_ChargeArcaneObject.cs
@@ -39,21 +39,21 @@ namespace TorannMagic
             CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if (comp != null && portal != null && comp.IsMagicUser && comp.Mana.CurLevelPercentage >= .7f && portal.IsPaired && portal.ArcaneEnergyCur < .7f)
             {
-                if (pawn != null && pawn.RaceProps.Humanlike && pawn.workSettings.WorkIsActive(TorannMagicDefOf.TM_Magic) && pawn.health.capacities.GetLevel(TorannMagicDefOf.MagicManipulation) > 0 && pawn.IsColonist && pawn.Awake() && !pawn.Drafted && !pawn.Downed && pawn.CanReserveAndReach(portal, PathEndMode.InteractionCell, Danger.Some))
+                if (pawn != null && pawn.workSettings.WorkIsActive(TorannMagicDefOf.TM_Magic) && pawn.health.capacities.GetLevel(TorannMagicDefOf.MagicManipulation) > 0 && pawn.IsColonist && pawn.Awake() && !pawn.Drafted && !pawn.Downed && pawn.CanReserveAndReach(portal, PathEndMode.InteractionCell, Danger.Some))
                 {
                     return true;
                 }
             }
             if (comp != null && arcaneCapacitor != null && comp.IsMagicUser && comp.Mana.CurLevelPercentage >= .9f && arcaneCapacitor.ArcaneEnergyCur < arcaneCapacitor.TargetArcaneEnergyPct && arcaneCapacitor.CapacitorIsOn)
             {
-                if (pawn != null && pawn.RaceProps.Humanlike && pawn.workSettings.WorkIsActive(TorannMagicDefOf.TM_Magic) && pawn.health.capacities.GetLevel(TorannMagicDefOf.MagicManipulation) > 0 && pawn.IsColonist && pawn.Awake() && !pawn.Drafted && !pawn.Downed && pawn.CanReserveAndReach(arcaneCapacitor, PathEndMode.InteractionCell, Danger.Some))
+                if (pawn != null && pawn.workSettings.WorkIsActive(TorannMagicDefOf.TM_Magic) && pawn.health.capacities.GetLevel(TorannMagicDefOf.MagicManipulation) > 0 && pawn.IsColonist && pawn.Awake() && !pawn.Drafted && !pawn.Downed && pawn.CanReserveAndReach(arcaneCapacitor, PathEndMode.InteractionCell, Danger.Some))
                 {
                     return true;
                 }
             }
             if (comp != null && dmp != null && comp.IsMagicUser && comp.Mana.CurLevelPercentage >= .9f && dmp.ArcaneEnergyCur < dmp.TargetArcaneEnergyPct && dmp.IsOn)
             {
-                if (pawn != null && pawn.RaceProps.Humanlike && pawn.workSettings.WorkIsActive(TorannMagicDefOf.TM_Magic) && pawn.health.capacities.GetLevel(TorannMagicDefOf.MagicManipulation) > 0 && pawn.IsColonist && pawn.Awake() && !pawn.Drafted && !pawn.Downed && pawn.CanReserveAndReach(dmp, PathEndMode.InteractionCell, Danger.Some))
+                if (pawn != null && pawn.workSettings.WorkIsActive(TorannMagicDefOf.TM_Magic) && pawn.health.capacities.GetLevel(TorannMagicDefOf.MagicManipulation) > 0 && pawn.IsColonist && pawn.Awake() && !pawn.Drafted && !pawn.Downed && pawn.CanReserveAndReach(dmp, PathEndMode.InteractionCell, Danger.Some))
                 {
                     return true;
                 }

--- a/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoCommanderMotivate.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoCommanderMotivate.cs
@@ -39,7 +39,7 @@ namespace TorannMagic
                 HediffComp_CommanderAura hdComp = pawn.health.hediffSet.GetFirstHediffOfDef(TorannMagicDefOf.TM_CommanderAuraHD).TryGetComp<HediffComp_CommanderAura>();
                 if (hdComp != null && hdComp.nextSpeechTick < Find.TickManager.TicksGame)
                 {               
-                    if (pawn2 != null && pawn2 != pawn && pawn2.RaceProps.Humanlike && pawn2.IsColonist && pawn2.Awake() && !pawn2.Drafted && !pawn.Drafted && !pawn2.Downed)
+                    if (pawn2 != null && pawn2 != pawn && pawn2.IsColonist && pawn2.Awake() && !pawn2.Drafted && !pawn.Drafted && !pawn2.Downed)
                     {
                         if (pawn2.InMentalState && (pawn.Position - pawn2.Position).LengthHorizontal < 50f && !GenAI.EnemyIsNear(pawn2, 20f))
                         {

--- a/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoEntertain.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/WorkGiver_DoEntertain.cs
@@ -36,7 +36,7 @@ namespace TorannMagic
             CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
             if (pawn.health.hediffSet.HasHediff(HediffDef.Named("TM_EntertainingHD"), false) && comp.nextEntertainTick < Find.TickManager.TicksGame)
             {
-                if (pawn2 != null && pawn2 != pawn && pawn2.RaceProps.Humanlike && pawn2.IsColonist && pawn2.Awake() && !pawn2.Drafted && !pawn.Drafted && !pawn2.Downed && pawn2.CanCasuallyInteractNow())
+                if (pawn2 != null && pawn2 != pawn && pawn2.IsColonist && pawn2.Awake() && !pawn2.Drafted && !pawn.Drafted && !pawn2.Downed && pawn2.CanCasuallyInteractNow())
                 {
                     if ((pawn.Position - pawn2.Position).LengthHorizontal < 50f && !GenAI.EnemyIsNear(pawn2, 40f))
                     {


### PR DESCRIPTION
A lot of these are removing the HumanLike check since IsColonist already does this. Some are removed because there is no way IsColonist is true with the other conditions (RaceProps.Animal cannot be true and IsColonist). I do include a C# upgrade as it allows us to use LINQ without overhead whenever static is used in the Func.