### PR TITLE
remove_ResolveMagicPowers_as_it_does_nothing

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -1047,7 +1047,6 @@ namespace TorannMagic
                             this.firstTick = true;
                             this.Initialize();
                             this.ResolveMagicTab();
-                            this.ResolveMagicPowers();
                             this.ResolveMana();
                             this.DoOncePerLoad();
                         }
@@ -6840,14 +6839,6 @@ namespace TorannMagic
                     hediff.Severity = 1f;
                     base.Pawn.health.AddHediff(hediff, null, null);
                 }
-            }
-        }
-        public void ResolveMagicPowers()
-        {
-            bool flag = this.magicPowersInitialized;
-            if (!flag)
-            {
-                this.magicPowersInitialized = true;
             }
         }
         public void ResolveMagicTab()


### PR DESCRIPTION
magicPowersInitialized is always set to true in PostInitialize() which is called from Initialize()