### PR TITLE
Clean resolve effecter

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -462,14 +462,15 @@ namespace TorannMagic
 
         public int PowerModifier
         {
-            get
-            {
-                return powerModifier;
-            }
+            get => powerModifier;
             set
             {
-                TM_MoteMaker.ThrowSiphonMote(this.Pawn.DrawPos, this.Pawn.Map, 1f);
+                TM_MoteMaker.ThrowSiphonMote(Pawn.DrawPos, Pawn.Map, 1f);
                 powerModifier = Mathf.Clamp(value, 0, maxPower);
+
+                if (powerModifier != 0 || powerEffecter == null) return;
+                powerEffecter.Cleanup();
+                powerEffecter = null;
             }
         }
 
@@ -6290,21 +6291,15 @@ namespace TorannMagic
 
         public void ResolveEffecter()
         {
-            if (powerEffecter != null && PowerModifier == 0)
-            {
-                powerEffecter.Cleanup();
-                powerEffecter = null;
-            }
-            else if (PowerModifier > 0)
-            {
-                powerEffecter ??= EffecterDefOf.ProgressBar.Spawn();
-                powerEffecter.EffectTick(Pawn, TargetInfo.Invalid);
-                MoteProgressBar mote = ((SubEffecter_ProgressBar)powerEffecter.children[0]).mote;
-                if (mote == null) return;
+            if (PowerModifier <= 0) return;
 
-                mote.progress = Mathf.Clamp01((float)powerModifier / maxPower);
-                mote.offsetZ = +0.85f;
-            }
+            powerEffecter ??= EffecterDefOf.ProgressBar.Spawn();
+            powerEffecter.EffectTick(Pawn, TargetInfo.Invalid);
+            MoteProgressBar mote = ((SubEffecter_ProgressBar)powerEffecter.children[0]).mote;
+            if (mote == null) return;
+
+            mote.progress = Mathf.Clamp01((float)powerModifier / maxPower);
+            mote.offsetZ = +0.85f;
         }
 
         public void ResolveUndead()

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -6290,32 +6290,20 @@ namespace TorannMagic
 
         public void ResolveEffecter()
         {
-            bool spawned = this.Pawn.Spawned;
-            if (spawned)
+            if (powerEffecter != null && PowerModifier == 0)
             {
-                if (this.powerEffecter != null && this.PowerModifier == 0)
-                {
-                    this.powerEffecter.Cleanup();
-                    this.powerEffecter = null;
-                }
-                bool flag4 = this.powerEffecter == null && this.PowerModifier > 0;
-                if (flag4)
-                {
-                    EffecterDef progressBar = EffecterDefOf.ProgressBar;
-                    this.powerEffecter = progressBar.Spawn();
-                }
-                if (this.powerEffecter != null && this.PowerModifier > 0)
-                {
-                    this.powerEffecter.EffectTick(this.Pawn, TargetInfo.Invalid);
-                    MoteProgressBar mote = ((SubEffecter_ProgressBar)this.powerEffecter.children[0]).mote;
-                    bool flag5 = mote != null;
-                    if (flag5)
-                    {
-                        float value = (float)(this.powerModifier) / (float)(this.maxPower);
-                        mote.progress = Mathf.Clamp01(value);
-                        mote.offsetZ = +0.85f;
-                    }
-                }
+                powerEffecter.Cleanup();
+                powerEffecter = null;
+            }
+            else if (PowerModifier > 0)
+            {
+                powerEffecter ??= EffecterDefOf.ProgressBar.Spawn();
+                powerEffecter.EffectTick(Pawn, TargetInfo.Invalid);
+                MoteProgressBar mote = ((SubEffecter_ProgressBar)powerEffecter.children[0]).mote;
+                if (mote == null) return;
+
+                mote.progress = Mathf.Clamp01((float)powerModifier / maxPower);
+                mote.offsetZ = +0.85f;
             }
         }
 

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
* Move Cleanup check out of CompTick and instead do the check whenever powerModifier changes
* Remove Pawn.Spawned check since this is only called inside of an if statement that already has that.
* Use C# 8 ??= operator which is the same as `if (variable == null) variable = value`