### PR TITLE
Change can do random mental breaks patch to 2 closer patches

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/HarmonyPatches.cs
@@ -17,7 +17,6 @@ using TorannMagic.TMDefs;
 using TorannMagic.Golems;
 using System.Diagnostics;
 using System.Reflection.Emit;
-using MonoMod.Utils;
 using TorannMagic.Utils;
 
 namespace TorannMagic

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
CanDoRandomMentalBreaks gets called hundreds of thousands of times per every few seconds. Instead we could check for this hediff only when the break actually should occur and when viewing the needs tab since those are the only places the method actually does anything. Uses a transpiler which is less mantainable, but since this is called enough, I figured it probably is worth