### PR TITLE
Pawn tracker (Very large CompTick/IsMagicUser/IsMightUser speedup)

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -7565,6 +7565,12 @@ namespace TorannMagic
             }
         }
 
+        public override void PostSpawnSetup(bool respawningAfterLoad)
+        {
+            // We already set this on load
+            if (!respawningAfterLoad) TM_PawnTracker.ResolveMagicComp(this);
+        }
+
         public override void PostExposeData()
         {
             //base.PostExposeData();            

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMagic.cs
@@ -12,6 +12,7 @@ using Verse.Sound;
 using AbilityUserAI;
 using TorannMagic.Ideology;
 using TorannMagic.TMDefs;
+using TorannMagic.Utils;
 
 namespace TorannMagic
 {
@@ -278,6 +279,10 @@ namespace TorannMagic
         public FlyingObject_LivingWall livingWall = null;
         public int lastChaosTraditionTick = 0;
         public ThingOwner<ThingWithComps> magicWardrobe;
+
+        // Cached values calculated in TM_PawnTracker
+        private bool initializedIsMagicUser;
+        private bool isMagicUser;  // Cached version
 
         private static HashSet<ushort> magicTraitIndexes = new HashSet<ushort>()
         {
@@ -741,229 +746,163 @@ namespace TorannMagic
 
         public override void CompTick()
         {
-            bool flag = base.Pawn != null;
-            if (flag)
-            {
-                bool spawned = base.Pawn.Spawned;
-                if (spawned)
-                {
-                    bool isMagicUser = this.IsMagicUser && !this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless) && !this.Pawn.IsWildMan();
-                    if (isMagicUser)
-                    {
-                        bool flag3 = !this.firstTick;
-                        if (flag3)
-                        {
-                            this.PostInitializeTick();
-                        }
-                        if (this.doOnce)
-                        {
-                            SingleEvent();
-                        }
-                        base.CompTick();
-                        this.age++;
-                        if(this.chainedAbilitiesList != null && this.chainedAbilitiesList.Count > 0)
-                        {
-                            for(int i = 0; i < chainedAbilitiesList.Count; i++)
-                            {
-                                chainedAbilitiesList[i].expirationTicks--;
-                                if(chainedAbilitiesList[i].expires && chainedAbilitiesList[i].expirationTicks <= 0)
-                                {
-                                    this.RemovePawnAbility(chainedAbilitiesList[i].abilityDef);
-                                    this.chainedAbilitiesList.Remove(chainedAbilitiesList[i]);
-                                    break;
-                                }
-                            }                            
-                        }
-                        if (this.Mana != null)
-                        {
-                            if (Find.TickManager.TicksGame % 4 == 0 && this.Pawn.CurJob != null && this.Pawn.CurJobDef == JobDefOf.DoBill && this.Pawn.CurJob.targetA != null && this.Pawn.CurJob.targetA.Thing != null)
-                            {
-                                DoArcaneForging();
-                            }
-                            if (this.Mana.CurLevel >= (.99f * this.Mana.MaxLevel))
-                            {
-                                if (this.age > (lastXPGain + magicXPRate))
-                                {
-                                    MagicData.MagicUserXP++;
-                                    lastXPGain = this.age;
-                                }
-                            }
-                            if (Find.TickManager.TicksGame % 30 == 0)
-                            {
-                                bool flag5 = this.MagicUserXP > this.MagicUserXPTillNextLevel;
-                                if (flag5)
-                                {
-                                    this.LevelUp(false);
-                                }
-                            }
-                            if (Find.TickManager.TicksGame % 60 == 0)
-                            {
-                                if (this.Pawn.IsColonist && !this.magicPowersInitializedForColonist)
-                                {
-                                    ResolveFactionChange();
-                                }
-                                else if (!this.Pawn.IsColonist)
-                                {
-                                    this.magicPowersInitializedForColonist = false;
-                                }
+            Pawn pawn = this.Pawn;
+            if (pawn?.story == null) return;
 
-                                if (this.Pawn.IsColonist)
-                                {
-                                    ResolveEnchantments();
-                                    for (int i = 0; i < this.summonedMinions.Count; i++)
-                                    {
-                                        Pawn evaluateMinion = this.summonedMinions[i] as Pawn;
-                                        if (evaluateMinion == null || evaluateMinion.Dead || evaluateMinion.Destroyed)
-                                        {
-                                            this.summonedMinions.Remove(this.summonedMinions[i]);
-                                        }
-                                    }
-                                    ResolveMinions();
-                                    ResolveSustainers();
-                                    if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Necromancer) || this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Lich) || (this.customClass != null && this.customClass.isNecromancer))
-                                    {
-                                        ResolveUndead();
-                                    }
-                                    ResolveEffecter();
-                                    ResolveClassSkills();
-                                    ResolveSpiritOfLight();
-                                    ResolveChronomancerTimeMark();
-                                }
-                            }
-                            
-                            if (this.autocastTick < Find.TickManager.TicksGame)  //180 default
-                            {
-                                if (!this.Pawn.Dead && !this.Pawn.Downed && this.Pawn.Map != null && this.Pawn.story != null && this.Pawn.story.traits != null && this.MagicData != null && this.AbilityData != null && !this.Pawn.InMentalState)
-                                {
-                                    if (this.Pawn.IsColonist)
-                                    {
-                                        this.autocastTick = Find.TickManager.TicksGame + (int)Rand.Range(.8f * ModOptions.Settings.Instance.autocastEvaluationFrequency, 1.2f * ModOptions.Settings.Instance.autocastEvaluationFrequency);
-                                        ResolveAutoCast();
-                                    }
-                                    else if(ModOptions.Settings.Instance.AICasting && (!this.Pawn.IsPrisoner || this.Pawn.IsFighting()) && (this.Pawn.guest != null && !this.Pawn.IsSlave))
-                                    {
-                                        float tickMult = ModOptions.Settings.Instance.AIAggressiveCasting ? 1f : 2f;
-                                        this.autocastTick = Find.TickManager.TicksGame + (int)(Rand.Range(.75f * ModOptions.Settings.Instance.autocastEvaluationFrequency, 1.25f * ModOptions.Settings.Instance.autocastEvaluationFrequency) * tickMult);
-                                        ResolveAIAutoCast();
-                                    }
-                                }                                
-                            }
-                            if (!this.Pawn.IsColonist && ModOptions.Settings.Instance.AICasting && ModOptions.Settings.Instance.AIAggressiveCasting && Find.TickManager.TicksGame > this.nextAICastAttemptTick) //Aggressive AI Casting
-                            {
-                                this.nextAICastAttemptTick = Find.TickManager.TicksGame + Rand.Range(300, 500);
-                                if (this.Pawn.jobs != null && this.Pawn.CurJobDef != TorannMagicDefOf.TMCastAbilitySelf && this.Pawn.CurJobDef != TorannMagicDefOf.TMCastAbilityVerb)
-                                {
-                                    IEnumerable<AbilityUserAIProfileDef> enumerable = this.Pawn.EligibleAIProfiles();
-                                    if (enumerable != null && enumerable.Count() > 0)
-                                    {
-                                        foreach (AbilityUserAIProfileDef item in enumerable)
-                                        {
-                                            if (item != null)
-                                            {
-                                                AbilityAIDef useThisAbility = null;
-                                                if (item.decisionTree != null)
-                                                {
-                                                    useThisAbility = item.decisionTree.RecursivelyGetAbility(this.Pawn);
-                                                }
-                                                if (useThisAbility != null)
-                                                {
-                                                    ThingComp val = this.Pawn.AllComps.First((ThingComp comp) => ((object)comp).GetType() == item.compAbilityUserClass);
-                                                    CompAbilityUser compAbilityUser = val as CompAbilityUser;
-                                                    if (compAbilityUser != null)
-                                                    {
-                                                        PawnAbility pawnAbility = compAbilityUser.AbilityData.AllPowers.First((PawnAbility ability) => ability.Def == useThisAbility.ability);
-                                                        string reason = "";
-                                                        if (pawnAbility.CanCastPowerCheck(AbilityContext.AI, out reason))
-                                                        {
-                                                            LocalTargetInfo target = useThisAbility.Worker.TargetAbilityFor(useThisAbility, this.Pawn);
-                                                            if (target.IsValid)
-                                                            {
-                                                                pawnAbility.UseAbility(AbilityContext.Player, target);
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        if (Find.TickManager.TicksGame % this.overdriveFrequency == 0)
-                        {
-                            if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Technomancer) || (TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_Overdrive)))
-                            {
-                                ResolveTechnomancerOverdrive();
-                            }
-                        }
-                        if (Find.TickManager.TicksGame % 299 == 0) //cache weapon damage for tooltip and damage calculations
-                        {
-                            this.weaponDamage = GetSkillDamage(); // TM_Calc.GetSkillDamage(this.Pawn);
-                        }
-                        if (Find.TickManager.TicksGame % 601 == 0)
-                        {
-                            if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Warlock))
-                            {
-                                ResolveWarlockEmpathy();
-                            }
-                        }
-                        if (Find.TickManager.TicksGame % 602 == 0)
-                        {
-                            ResolveMagicUseEvents();             
-                        }
-                        if (Find.TickManager.TicksGame % 2001 == 0)
-                        {
-                            if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Succubus))
-                            {
-                                ResolveSuccubusLovin();
-                            }
-                        }
-                        if (deathRetaliating)
-                        {
-                            DoDeathRetaliation();
-                        }
-                        else if (Find.TickManager.TicksGame % 67 == 0 && !this.Pawn.IsColonist && this.Pawn.Downed)
-                        {
-                            DoDeathRetaliation();
-                        }
+            // If we aren't on map, handle ability cooldown per long tick
+            if (!pawn.Spawned)
+            {
+                if (pawn.Map != null || Find.TickManager.TicksGame % 600 != 0) return;  // Not time to caravan tick.
+                if (!this.IsMagicUser) return;  // We won't tick at all if we aren't a magic user
+
+                var allPowers = AbilityData.AllPowers;
+                for (int i = allPowers.Count - 1; i >= 0; i--)
+                {
+                    allPowers[i].CooldownTicksLeft = Math.Max(allPowers[i].CooldownTicksLeft - 600, 0);
+                }
+                return;
+            }
+
+            // If we aren't magic, check if we can be inspired
+            if (!this.IsMagicUser)
+            {
+                if (!ModsConfig.IdeologyActive) return;
+                if (Find.TickManager.TicksGame % 2501 != 0) return;
+                if (!pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Gifted)) return;
+
+                if (!pawn.Inspired && pawn.CurJobDef == JobDefOf.LayDown && Rand.Chance(.025f))
+                {
+                    pawn.mindState.inspirationHandler.TryStartInspiration(TorannMagicDefOf.ID_ArcanePathways);
+                }
+                return;
+            }
+
+            if (!this.TickConditionsMet) return;  // Cached in TM_PawnTracker
+
+            // Finally, let's do a magic tick!
+            if (!this.firstTick) this.PostInitializeTick();
+            base.CompTick();
+            this.age++;
+            if(this.chainedAbilitiesList != null && this.chainedAbilitiesList.Count > 0)
+            {
+                for(int i = 0; i < chainedAbilitiesList.Count; i++)
+                {
+                    chainedAbilitiesList[i].expirationTicks--;
+                    if(chainedAbilitiesList[i].expires && chainedAbilitiesList[i].expirationTicks <= 0)
+                    {
+                        this.RemovePawnAbility(chainedAbilitiesList[i].abilityDef);
+                        this.chainedAbilitiesList.Remove(chainedAbilitiesList[i]);
+                        break;
                     }
-                    else if(ModsConfig.IdeologyActive)
-                    {                        
-                        if(Find.TickManager.TicksGame % 2501 == 0 && base.Pawn.story != null && this.Pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Gifted))
-                        {                            
-                            if (!this.Pawn.Inspired && this.Pawn.CurJobDef == JobDefOf.LayDown && Rand.Chance(.025f))
+                }
+            }
+            if (this.Mana != null)
+            {
+                if (Find.TickManager.TicksGame % 4 == 0 && this.Pawn.CurJob != null && this.Pawn.CurJobDef == JobDefOf.DoBill && this.Pawn.CurJob.targetA != null && this.Pawn.CurJob.targetA.Thing != null)
+                {
+                    DoArcaneForging();
+                }
+                if (this.Mana.CurLevel >= (.99f * this.Mana.MaxLevel))
+                {
+                    if (this.age > (lastXPGain + magicXPRate))
+                    {
+                        MagicData.MagicUserXP++;
+                        lastXPGain = this.age;
+                    }
+                }
+                if (Find.TickManager.TicksGame % 30 == 0)
+                {
+                    bool flag5 = this.MagicUserXP > this.MagicUserXPTillNextLevel;
+                    if (flag5)
+                    {
+                        this.LevelUp(false);
+                    }
+                }
+                if (Find.TickManager.TicksGame % 60 == 0)
+                {
+                    if (this.Pawn.IsColonist && !this.magicPowersInitializedForColonist)
+                    {
+                        ResolveFactionChange();
+                    }
+                    else if (!this.Pawn.IsColonist)
+                    {
+                        this.magicPowersInitializedForColonist = false;
+                    }
+
+                    if (this.Pawn.IsColonist)
+                    {
+                        ResolveEnchantments();
+                        for (int i = 0; i < this.summonedMinions.Count; i++)
+                        {
+                            Pawn evaluateMinion = this.summonedMinions[i] as Pawn;
+                            if (evaluateMinion == null || evaluateMinion.Dead || evaluateMinion.Destroyed)
                             {
-                                this.Pawn.mindState.inspirationHandler.TryStartInspiration(TorannMagicDefOf.ID_ArcanePathways);
+                                this.summonedMinions.Remove(this.summonedMinions[i]);
                             }
+                        }
+                        ResolveMinions();
+                        ResolveSustainers();
+                        if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Necromancer) || this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Lich) || (this.customClass != null && this.customClass.isNecromancer))
+                        {
+                            ResolveUndead();
+                        }
+                        ResolveEffecter();
+                        ResolveClassSkills();
+                        ResolveSpiritOfLight();
+                        ResolveChronomancerTimeMark();
+                    }
+                }
+
+                if (this.autocastTick < Find.TickManager.TicksGame)  //180 default
+                {
+                    if (!this.Pawn.Dead && !this.Pawn.Downed && this.Pawn.Map != null && this.Pawn.story != null && this.Pawn.story.traits != null && this.MagicData != null && this.AbilityData != null && !this.Pawn.InMentalState)
+                    {
+                        if (this.Pawn.IsColonist)
+                        {
+                            this.autocastTick = Find.TickManager.TicksGame + (int)Rand.Range(.8f * ModOptions.Settings.Instance.autocastEvaluationFrequency, 1.2f * ModOptions.Settings.Instance.autocastEvaluationFrequency);
+                            ResolveAutoCast();
+                        }
+                        else if(ModOptions.Settings.Instance.AICasting && (!this.Pawn.IsPrisoner || this.Pawn.IsFighting()) && (this.Pawn.guest != null && !this.Pawn.IsSlave))
+                        {
+                            float tickMult = ModOptions.Settings.Instance.AIAggressiveCasting ? 1f : 2f;
+                            this.autocastTick = Find.TickManager.TicksGame + (int)(Rand.Range(.75f * ModOptions.Settings.Instance.autocastEvaluationFrequency, 1.25f * ModOptions.Settings.Instance.autocastEvaluationFrequency) * tickMult);
+                            ResolveAIAutoCast();
                         }
                     }
                 }
-                else
+                if (!this.Pawn.IsColonist && ModOptions.Settings.Instance.AICasting && ModOptions.Settings.Instance.AIAggressiveCasting && Find.TickManager.TicksGame > this.nextAICastAttemptTick) //Aggressive AI Casting
                 {
-                    if (Find.TickManager.TicksGame % 600 == 0)
+                    this.nextAICastAttemptTick = Find.TickManager.TicksGame + Rand.Range(300, 500);
+                    if (this.Pawn.jobs != null && this.Pawn.CurJobDef != TorannMagicDefOf.TMCastAbilitySelf && this.Pawn.CurJobDef != TorannMagicDefOf.TMCastAbilityVerb)
                     {
-                        if (this.Pawn.Map == null)
+                        IEnumerable<AbilityUserAIProfileDef> enumerable = this.Pawn.EligibleAIProfiles();
+                        if (enumerable != null && enumerable.Count() > 0)
                         {
-                            if (this.IsMagicUser)
+                            foreach (AbilityUserAIProfileDef item in enumerable)
                             {
-                                int num;
-                                if (AbilityData?.AllPowers != null)
+                                if (item != null)
                                 {
-                                    AbilityData obj = AbilityData;
-                                    num = ((obj != null && obj.AllPowers.Count > 0) ? 1 : 0);
-                                }
-                                else
-                                {
-                                    num = 0;
-                                }
-                                if (num != 0)
-                                {
-                                    foreach (PawnAbility allPower in AbilityData.AllPowers)
+                                    AbilityAIDef useThisAbility = null;
+                                    if (item.decisionTree != null)
                                     {
-                                        allPower.CooldownTicksLeft -= 600;
-                                        if (allPower.CooldownTicksLeft <= 0)
+                                        useThisAbility = item.decisionTree.RecursivelyGetAbility(this.Pawn);
+                                    }
+                                    if (useThisAbility != null)
+                                    {
+                                        ThingComp val = this.Pawn.AllComps.First((ThingComp comp) => ((object)comp).GetType() == item.compAbilityUserClass);
+                                        CompAbilityUser compAbilityUser = val as CompAbilityUser;
+                                        if (compAbilityUser != null)
                                         {
-                                            allPower.CooldownTicksLeft = 0;
+                                            PawnAbility pawnAbility = compAbilityUser.AbilityData.AllPowers.First((PawnAbility ability) => ability.Def == useThisAbility.ability);
+                                            string reason = "";
+                                            if (pawnAbility.CanCastPowerCheck(AbilityContext.AI, out reason))
+                                            {
+                                                LocalTargetInfo target = useThisAbility.Worker.TargetAbilityFor(useThisAbility, this.Pawn);
+                                                if (target.IsValid)
+                                                {
+                                                    pawnAbility.UseAbility(AbilityContext.Player, target);
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -972,9 +911,42 @@ namespace TorannMagic
                     }
                 }
             }
-            if (Initialized)
+            if (Find.TickManager.TicksGame % this.overdriveFrequency == 0)
             {
-                //custom code
+                if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Technomancer) || (TM_ClassUtility.ClassHasAbility(TorannMagicDefOf.TM_Overdrive)))
+                {
+                    ResolveTechnomancerOverdrive();
+                }
+            }
+            if (Find.TickManager.TicksGame % 299 == 0) //cache weapon damage for tooltip and damage calculations
+            {
+                this.weaponDamage = GetSkillDamage(); // TM_Calc.GetSkillDamage(this.Pawn);
+            }
+            if (Find.TickManager.TicksGame % 601 == 0)
+            {
+                if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Warlock))
+                {
+                    ResolveWarlockEmpathy();
+                }
+            }
+            if (Find.TickManager.TicksGame % 602 == 0)
+            {
+                ResolveMagicUseEvents();
+            }
+            if (Find.TickManager.TicksGame % 2001 == 0)
+            {
+                if (this.Pawn.story.traits.HasTrait(TorannMagicDefOf.Succubus))
+                {
+                    ResolveSuccubusLovin();
+                }
+            }
+            if (deathRetaliating)
+            {
+                DoDeathRetaliation();
+            }
+            else if (Find.TickManager.TicksGame % 67 == 0 && !this.Pawn.IsColonist && this.Pawn.Downed)
+            {
+                DoDeathRetaliation();
             }
         }
 
@@ -1029,93 +1001,67 @@ namespace TorannMagic
 
         public void PostInitializeTick()
         {
-            bool flag = base.Pawn != null;
-            if (flag)
+            if (this.doOnce) SingleEvent();
+            Trait t = this.Pawn.story.traits.GetTrait(TorannMagicDefOf.TM_Possessed);
+            if (t != null && !this.Pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_SpiritPossessionHD))
             {
-                bool spawned = base.Pawn.Spawned;
-                if (spawned)
-                {
-                    bool flag2 = base.Pawn.story != null;
-                    if (flag2)
-                    {
-                        Trait t = base.Pawn.story.traits.GetTrait(TorannMagicDefOf.TM_Possessed);
-                        if (t != null && !base.Pawn.health.hediffSet.HasHediff(TorannMagicDefOf.TM_SpiritPossessionHD))
-                        {
-                            base.Pawn.story.traits.RemoveTrait(t);
-                        }
-                        else
-                        {
-                            this.firstTick = true;
-                            this.Initialize();
-                            this.ResolveMagicTab();
-                            this.ResolveMagicPowers();
-                            this.ResolveMana();
-                            this.DoOncePerLoad();
-                        }
-                    }
-                }
+                this.Pawn.story.traits.RemoveTrait(t);
+            }
+            else
+            {
+                this.firstTick = true;
+                this.Initialize();
+                this.ResolveMagicTab();
+                this.ResolveMagicPowers();
+                this.ResolveMana();
+                this.DoOncePerLoad();
             }
         }
 
-        public bool IsMagicUser
+        public bool IsMagicUser => this.initializedIsMagicUser ? this.isMagicUser : this.SetIsMagicUser();
+        public bool SetIsMagicUser()
         {
-            get
+            if (Pawn?.story == null) return this.isMagicUser = false;
+            this.initializedIsMagicUser = true;
+
+            if (this.customClass != null) return this.isMagicUser = true;
+            if (this.customClass == null && this.customIndex == -2)
             {
-                if (Pawn?.story == null) return false;
-
-                if (this.customClass != null) return true;
-                if (this.customClass == null && this.customIndex == -2)
+                this.customIndex = TM_ClassUtility.CustomClassIndexOfBaseMageClass(this.Pawn.story.traits.allTraits);
+                if (this.customIndex >= 0)
                 {
-                    this.customIndex = TM_ClassUtility.CustomClassIndexOfBaseMageClass(this.Pawn.story.traits.allTraits);
-                    if (this.customIndex >= 0)
+                    TM_CustomClass foundCustomClass = TM_ClassUtility.CustomClasses[customIndex];
+                    if (!foundCustomClass.isMage)
                     {
-                        TM_CustomClass foundCustomClass = TM_ClassUtility.CustomClasses[customIndex];
-                        if (!foundCustomClass.isMage)
-                        {
-                            this.customIndex = -1;
-                            return false;
-                        }
-                        else
-                        {
-                            this.customClass = foundCustomClass;
-                            return true;
-                        }
+                        this.customIndex = -1;
+                        return this.isMagicUser = false;
                     }
+                    this.customClass = foundCustomClass;
+                    return this.isMagicUser = true;
                 }
-                //if (Pawn.story.traits.allTraits.Any(t => magicTraitIndexes.Contains(t.def.index) 
-                //|| TM_Calc.IsWanderer(base.Pawn) 
-                //|| (this.AdvancedClasses != null && this.AdvancedClasses.Count > 0)))
-                bool hasMagicTrait = false;
-                for (int i = 0; i < Pawn.story.traits.allTraits.Count; i++)
-                {
-                    if (!magicTraitIndexes.Contains(Pawn.story.traits.allTraits[i].def.index)) continue;
-
-                    hasMagicTrait = true;
-                    break;
-                }
-
-                if (hasMagicTrait || TM_Calc.IsWanderer(Pawn) || AdvancedClasses.Count > 0)
-                {
-                    return true;
-                }
-                if(TM_Calc.HasAdvancedClass(this.Pawn))
-                {
-                    bool hasMageAdvClass = false;
-                    foreach(TMDefs.TM_CustomClass cc in TM_ClassUtility.GetAdvancedClassesForPawn(this.Pawn))
-                    {
-                        if(cc.isMage)
-                        {
-                            this.AdvancedClasses.Add(cc);
-                            hasMageAdvClass = true;
-                        }
-                    }
-                    if(hasMageAdvClass)
-                    {
-                        return true;
-                    }
-                }
-                return false;
             }
+            // If any traits are in our generated set of magic traits, we are magic.
+            for (int i = Pawn.story.traits.allTraits.Count - 1; i >= 0; i--)
+            {
+                if (magicTraitIndexes.Contains(Pawn.story.traits.allTraits[i].def.index))
+                    return this.isMagicUser = true;
+            }
+
+            if (AdvancedClasses.Count > 0 || TM_Calc.IsWanderer(Pawn)) return this.isMagicUser = true;
+
+            if(TM_Calc.HasAdvancedClass(this.Pawn))
+            {
+                foreach(TMDefs.TM_CustomClass cc in TM_ClassUtility.GetAdvancedClassesForPawn(this.Pawn))
+                {
+                    if(cc.isMage)
+                    {
+                        this.AdvancedClasses.Add(cc);
+                        return this.isMagicUser = true;
+                    }
+                }
+            }
+
+            return this.isMagicUser = false;
         }
 
         private Dictionary<int, int> cacheXPFL = new Dictionary<int, int>();
@@ -3604,6 +3550,7 @@ namespace TorannMagic
             this.RemoveTraits();
             this.magicData = null;
             base.Initialized = false;
+            this.isMagicUser = false;
         }
 
         public int MagicAttributeEffeciencyLevel(string attributeName)
@@ -7738,15 +7685,11 @@ namespace TorannMagic
             Scribe_Values.Look<bool>(ref this.sigilSurging, "sigilSurging", false, false);
             Scribe_Values.Look<bool>(ref this.sigilDraining, "sigilDraining", false, false);
             Scribe_References.Look<FlyingObject_LivingWall>(ref this.livingWall, "livingWall");
-            Scribe_Deep.Look(ref this.magicWardrobe, "magicWardrobe", new object[0]);
-            //
-            Scribe_Deep.Look<MagicData>(ref this.magicData, "magicData", new object[]
+            Scribe_Deep.Look(ref this.magicWardrobe, "magicWardrobe");
+            Scribe_Deep.Look<MagicData>(ref this.magicData, "magicData", this);
+            if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
-                this
-            });
-            bool flag11 = Scribe.mode == LoadSaveMode.PostLoadInit;
-            if (flag11)
-            {
+                TM_PawnTracker.ResolveMagicComp(this);
                 Pawn abilityUser = base.Pawn;
                 int index = TM_ClassUtility.CustomClassIndexOfBaseMageClass(abilityUser.story.traits.allTraits);
                 if (index >= 0)

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserMight.cs
@@ -4538,6 +4538,12 @@ namespace TorannMagic
             }
         }
 
+        public override void PostSpawnSetup(bool respawningAfterLoad)
+        {
+            // We already set this on load
+            if (!respawningAfterLoad) TM_PawnTracker.ResolveMightComp(this);
+        }
+
         public override void PostExposeData()
         {
             //base.PostExposeData();

--- a/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserTMBase.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/CompAbilityUserTMBase.cs
@@ -38,6 +38,10 @@ namespace TorannMagic
 
         public float weaponDamage = 1;
 
+        // Cache values set in TM_PawnTracker
+        public bool IsFaceless;
+        public bool TickConditionsMet;
+
         //public List<TMDefs.TM_CustomClass> CombinedCustomClasses
         //{
         //    get

--- a/RimWorldOfMagic/RimWorldOfMagic/MagicCardUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MagicCardUtility.cs
@@ -3,6 +3,7 @@ using RimWorld;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Utils;
 using UnityEngine;
 using Verse;
 
@@ -2055,6 +2056,11 @@ namespace TorannMagic
                             }
                             skill.level++;
                             compMagic.MagicData.MagicAbilityPoints -= skill.costToLevel;
+                            // We need to recalculate IsMightUser when cantrips grants Might powers
+                            if (skill.label == "TM_Cantrips_eff" && skill.level >= 15)
+                            {
+                                TM_PawnTracker.ResolveMightComp(compMagic.Pawn.GetCompAbilityUserMight());
+                            }
                             if (skill.label == "TM_LightSkip_pwr")
                             {
                                 if (skill.level == 1)

--- a/RimWorldOfMagic/RimWorldOfMagic/MightCardUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/MightCardUtility.cs
@@ -3,6 +3,7 @@ using RimWorld;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using TorannMagic.Utils;
 using UnityEngine;
 using Verse;
 
@@ -1422,7 +1423,11 @@ namespace TorannMagic
                             skill.level++;
                             compMight.MightData.MightAbilityPoints -= skill.costToLevel;
                             
-                            
+                            // We need to recalculate IsMagicUser when field training grant Magic powers
+                            if (skill.label == "TM_FieldTraining_eff" && skill.level >= 15)
+                            {
+                                TM_PawnTracker.ResolveMagicComp(compMight.Pawn.GetCompAbilityUserMagic());
+                            }
                         }
                     }
                     num2 += (MightCardUtility.MightCardSize.x / 3) - MightCardUtility.SpacingOffset;

--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Building_TMTotem_Healing.cs" />
     <Compile Include="Building_TMTotem_Lightning.cs" />
     <Compile Include="Building_TM_DMP.cs" />
+    <Compile Include="Utils\TM_PawnTracker.cs" />
     <Compile Include="Verb_ShootTLine_Properties.cs" />
     <Compile Include="Verb_ShootDifferentProjectiles_Properties.cs" />
     <Compile Include="Verb_HurtOrSpawnInCone_Properties.cs" />

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_Calc.cs
@@ -24,13 +24,11 @@ namespace TorannMagic
         // Non-generic GetComp<CompAbilityUserMagic> for performance since isInst against generic T is slow
         public static CompAbilityUserMagic GetCompAbilityUserMagic(this ThingWithComps thingWithComps)
         {
-            if (thingWithComps?.AllComps != null)
+            if (thingWithComps == null) return null;
+
+            for (int i = thingWithComps.AllComps.Count - 1; i >= 0; i--)
             {
-                for (int i = 0; i < thingWithComps.AllComps.Count; i++)
-                {
-                    if (thingWithComps.AllComps[i] is CompAbilityUserMagic comp)
-                        return comp;
-                }
+                if (thingWithComps.AllComps[i] is CompAbilityUserMagic comp) return comp;
             }
 
             return null;
@@ -39,13 +37,11 @@ namespace TorannMagic
         // Non-generic GetComp<CompAbilityUserMight> for performance since isInst against generic T is slow
         public static CompAbilityUserMight GetCompAbilityUserMight(this ThingWithComps thingWithComps)
         {
-            if (thingWithComps?.AllComps != null)
+            if (thingWithComps == null) return null;
+
+            for (int i = thingWithComps.AllComps.Count - 1; i >= 0; i--)
             {
-                for (int i = 0; i < thingWithComps.AllComps.Count; i++)
-                {
-                    if (thingWithComps.AllComps[i] is CompAbilityUserMight comp)
-                        return comp;
-                }
+                if (thingWithComps.AllComps[i] is CompAbilityUserMight comp) return comp;
             }
 
             return null;
@@ -500,42 +496,28 @@ namespace TorannMagic
 
         public static bool IsWanderer(Pawn pawn)
         {
-            CompAbilityUserMight comp = pawn.GetCompAbilityUserMight();
-            if (comp != null)
+            CompAbilityUserMight comp = pawn?.GetCompAbilityUserMight();
+            if (comp == null) return false;
+
+            if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer)) return true;
+            if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer) || (comp.customClass != null && comp.customClass.classFighterAbilities.Contains(TorannMagicDefOf.TM_FieldTraining)))
             {
-                if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer))
-                {
-                    return true;
-                }
-                else if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer) || (comp.customClass != null && comp.customClass.classFighterAbilities.Contains(TorannMagicDefOf.TM_FieldTraining))) //pawn is a wayfarer with appropriate skill level
-                {
-                    int lvl = comp.MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_eff").level;
-                    if (lvl >= 15)
-                    {
-                        return true;
-                    }
-                }
+                int lvl = comp.MightData.MightPowerSkill_FieldTraining.FirstOrDefault((MightPowerSkill x) => x.label == "TM_FieldTraining_eff").level;
+                if (lvl >= 15) return true; // pawn has FieldTraining with appropriate skill level
             }
             return false;
         }
 
         public static bool IsWayfarer(Pawn pawn)
         {
-            CompAbilityUserMagic comp = pawn.GetCompAbilityUserMagic();
-            if (comp != null)
+            CompAbilityUserMagic comp = pawn?.GetCompAbilityUserMagic();
+            if (comp == null) return false;
+
+            if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer)) return true;
+            if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer) || (comp.customClass != null && comp.customClass.classMageAbilities.Contains(TorannMagicDefOf.TM_Cantrips)))
             {
-                if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wayfarer))
-                {
-                    return true;
-                }
-                else if (pawn.story.traits.HasTrait(TorannMagicDefOf.TM_Wanderer) || (comp.customClass != null && comp.customClass.classMageAbilities.Contains(TorannMagicDefOf.TM_Cantrips))) //pawn is a wanderer with appropriate skill level
-                {
-                    int lvl = comp.MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_eff").level;
-                    if (lvl >= 15)
-                    {
-                        return true;
-                    }
-                }
+                int lvl = comp.MagicData.MagicPowerSkill_Cantrips.FirstOrDefault((MagicPowerSkill x) => x.label == "TM_Cantrips_eff").level;
+                if (lvl >= 15) return true; // pawn has cantrips with appropriate skill level
             }
             return false;
         }

--- a/RimWorldOfMagic/RimWorldOfMagic/TM_ClassUtility.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/TM_ClassUtility.cs
@@ -285,7 +285,6 @@ namespace TorannMagic
         public static List<TM_CustomClass> GetAdvancedClassesForPawn(Pawn p)
         {
             List<TM_CustomClass> ccList = new List<TM_CustomClass>();
-            ccList.Clear();
             foreach(TM_CustomClass cc in CustomAdvancedClasses)
             {
                 if(p.story.traits.HasTrait(cc.classTrait))

--- a/RimWorldOfMagic/RimWorldOfMagic/Utils/TM_PawnTracker.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Utils/TM_PawnTracker.cs
@@ -5,8 +5,8 @@ using Verse;
 namespace TorannMagic.Utils
 {
     /*
-     * This class stores information about which Pawns are which classes, whether they are spawned, etc. It uses
-     * the harmony patches below the class to achieve this state tracking.
+     * This class stores information that is expensive to calculate, but easy enough to track changes.
+     * Specifically, it is used for classes that have a CompTick that need pawn information.
      */
     public static class TM_PawnTracker
     {

--- a/RimWorldOfMagic/RimWorldOfMagic/Utils/TM_PawnTracker.cs
+++ b/RimWorldOfMagic/RimWorldOfMagic/Utils/TM_PawnTracker.cs
@@ -1,0 +1,66 @@
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace TorannMagic.Utils
+{
+    /*
+     * This class stores information about which Pawns are which classes, whether they are spawned, etc. It uses
+     * the harmony patches below the class to achieve this state tracking.
+     */
+    public static class TM_PawnTracker
+    {
+        // For simplicity, use this not fully optimized function to prevent bugs that would be hard to find
+        public static void ResolveComps(Pawn pawn)
+        {
+            ResolveMagicComp(pawn.TryGetComp<CompAbilityUserMagic>());
+            ResolveMightComp(pawn.TryGetComp<CompAbilityUserMight>());
+        }
+        public static void ResolveMagicComp(CompAbilityUserMagic magicComp)
+        {
+            if (magicComp == null) return;
+
+            magicComp.IsFaceless = magicComp.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless);
+            magicComp.TickConditionsMet =
+                magicComp.SetIsMagicUser() && !magicComp.Pawn.IsWildMan() && !magicComp.IsFaceless;
+        }
+
+        public static void ResolveMightComp(CompAbilityUserMight mightComp)
+        {
+            if (mightComp == null) return;
+
+            mightComp.IsFaceless = mightComp.Pawn.story.traits.HasTrait(TorannMagicDefOf.Faceless);
+            mightComp.TickConditionsMet = mightComp.SetIsMightUser() && !mightComp.Pawn.NonHumanlikeOrWildMan();
+        }
+    }
+
+
+    // ====== Harmony Patches ======================================================================================
+    [HarmonyPatch(typeof(TraitSet), nameof(TraitSet.GainTrait))]
+    class TM_PawnTracker__GainTrait__Postfix
+    {
+        static void Postfix(Pawn ___pawn)
+        {
+            TM_PawnTracker.ResolveComps(___pawn);
+        }
+    }
+
+    [HarmonyPatch(typeof(TraitSet), nameof(TraitSet.RemoveTrait))]
+    class TM_PawnTracker__RemoveTrait__Postfix
+    {
+        static void Postfix(Pawn ___pawn)
+        {
+            TM_PawnTracker.ResolveComps(___pawn);
+        }
+    }
+
+    // This is how pawns gain/lose WildMan status
+    [HarmonyPatch(typeof(Pawn), nameof(Pawn.ChangeKind))]
+    class TM_PawnTracker__ChangeKind__Postfix
+    {
+        static void Postfix(Pawn __instance)
+        {
+            TM_PawnTracker.ResolveComps(__instance);
+        }
+    }
+}


### PR DESCRIPTION
CompAbilityUserMagic.CompTick changes look more complicated than they are. The biggest change there is moving the exit conditions up top (smaller blocks of code are easier to read immediately then exit). Then there were changes to the actual if statement starting the compTick to use a stored value instead of calculated. The rest of the method is just indentation changes.

The diffs are really hard to read for the Comp changes, so I recommend for CompTick and SetIsMagicUser/SetIsMightUser to look at the file directly how it is in this PR and compare it in another window to the current code.

I am purposely NOT saving the new variables. These SHOULD be calculated, we just don't need to calculate them often. For some reason when I rewrote this from a previous branch, I am no longer encountering loading issues. I think it was because I was originally including pawn.Spawned in the saved calculation which isn't correct. Fixed that in here.

Last note: In a dev quicktest with no magic/might users (10 pawns) this had a performance boost of compTick being 10x faster. These gains are significantly reduced when everyone is a magic/might user, but even then it should still be faster all around since IsMagicUser and IsMightUser is called all over the place.