### PR TITLE
Slight speedup for is undead

### DIFF
--- a/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
+++ b/RimWorldOfMagic/RimWorldOfMagic/RimWorldOfMagic.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>false</DebugSymbols>

--- a/v1.5/Defs/PawnDefs/Races_Skeletal.xml
+++ b/v1.5/Defs/PawnDefs/Races_Skeletal.xml
@@ -71,24 +71,25 @@
     </inspectorTabs>
     <race>
       <body>TM_Skeletal</body>
-	  <deathAction>
-		<workerClass>TorannMagic.DeathWorker_Skeletal</workerClass>
-	  </deathAction>
-	  <renderTree>Animal</renderTree>
-      <needsRest>false</needsRest>
-      <hasGenders>false</hasGenders>
-      <foodType>None</foodType>
-	  <fleshType>TM_SkeletalFlesh</fleshType>
-      <baseHungerRate>0.00</baseHungerRate>	  
-<!-- 	  <intelligence>ToolUser</intelligence> -->
-	  <trainability>None</trainability>
-      <thinkTreeConstant>TM_Elemental_AI_Constant</thinkTreeConstant>
-      <thinkTreeMain>TM_Elemental_AI</thinkTreeMain>
-      <baseBodySize>1</baseBodySize>
-	  <herdMigrationAllowed>false</herdMigrationAllowed>	 
-	  <wildness>10</wildness>		  
-	  <packAnimal>false</packAnimal>
-	  <herdAnimal>false</herdAnimal>
+      <deathAction>
+        <workerClass>TorannMagic.DeathWorker_Skeletal</workerClass>
+      </deathAction>
+      <renderTree>Animal</renderTree>
+        <needsRest>false</needsRest>
+        <hasGenders>false</hasGenders>
+        <foodType>None</foodType>
+      <fleshType>TM_SkeletalFlesh</fleshType>
+        <baseHungerRate>0.00</baseHungerRate>	  
+  <!-- 	  <intelligence>ToolUser</intelligence> -->
+      <trainability>None</trainability>
+        <thinkTreeConstant>TM_Elemental_AI_Constant</thinkTreeConstant>
+        <thinkTreeMain>TM_Elemental_AI</thinkTreeMain>
+        <baseBodySize>1</baseBodySize>
+      <herdMigrationAllowed>false</herdMigrationAllowed>	 
+      <wildness>10</wildness>		  
+      <packAnimal>false</packAnimal>
+      <herdAnimal>false</herdAnimal>
+      <bloodDef></bloodDef>
     </race>
     <drawGUIOverlay>false</drawGUIOverlay>
   </ThingDef>
@@ -104,44 +105,44 @@
       <ArmorRating_Sharp>0.7</ArmorRating_Sharp>
       <ArmorRating_Heat>2.5</ArmorRating_Heat>      
     </statBases>
-	<tools>
+    <tools>
+        <li>
+          <label>left hand</label>
+          <capacities>
+            <li>TM_ShadowBurn</li>
+          </capacities>
+          <power>19</power>
+          <cooldownTime>1.1</cooldownTime>
+          <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+        </li>
       <li>
-        <label>left hand</label>
-        <capacities>
-          <li>TM_ShadowBurn</li>
-        </capacities>
-        <power>19</power>
-        <cooldownTime>1.1</cooldownTime>
-        <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-      </li>
-	  <li>
-        <label>right hand</label>
-        <capacities>
-          <li>TM_ShadowBurn</li>
-        </capacities>
-        <power>19</power>
-        <cooldownTime>1.1</cooldownTime>
-        <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-      </li>
-	  <li>
-        <label>death stare</label>
-        <capacities>
-          <li>TM_DeathGaze</li>
-        </capacities>
-        <power>20</power>
-		<chanceFactor>.1</chanceFactor>
-        <cooldownTime>2</cooldownTime>
-        <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-      </li>
-	</tools>
+          <label>right hand</label>
+          <capacities>
+            <li>TM_ShadowBurn</li>
+          </capacities>
+          <power>19</power>
+          <cooldownTime>1.1</cooldownTime>
+          <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+        </li>
+      <li>
+          <label>death stare</label>
+          <capacities>
+            <li>TM_DeathGaze</li>
+          </capacities>
+          <power>20</power>
+      <chanceFactor>.1</chanceFactor>
+          <cooldownTime>2</cooldownTime>
+          <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+        </li>
+    </tools>
     <race>
-	  <baseHealthScale>4.0</baseHealthScale>	
+	    <baseHealthScale>4.0</baseHealthScale>	
       <lifeExpectancy>2000</lifeExpectancy>
-		<lifeStageAges>
+		  <lifeStageAges>
         <li>
           <def>TM_SkeletonLich_Lifestage</def>
           <minAge>100</minAge>
-		  <soundCall>TM_SkeletonAngry</soundCall>
+		      <soundCall>TM_SkeletonAngry</soundCall>
           <soundAngry>TM_SkeletonAngry</soundAngry>
           <soundWounded>TM_SkeletonPain</soundWounded>
           <soundDeath>TM_SkeletonAngryLow</soundDeath>
@@ -149,33 +150,32 @@
       </lifeStageAges>
       <soundMeleeHitPawn>TM_SkeletonPain</soundMeleeHitPawn>
       <soundMeleeHitBuilding>TM_SkeletonPainLow</soundMeleeHitBuilding>
-      <soundMeleeMiss>TM_SkeletonPain</soundMeleeMiss>      
+      <soundMeleeMiss>TM_SkeletonPain</soundMeleeMiss>
+      <bloodDef></bloodDef>    
     </race>
-	<butcherProducts>
-
-    </butcherProducts>
-	<comps>
-		<li>
-			<compClass>CompAttachBase</compClass>
-		</li>
-	  <li Class="TorannMagic.CompProperties_SkeletonLichController">
-		<alwaysManhunter>false</alwaysManhunter>
-		<maxRangeForCloseThreat>5</maxRangeForCloseThreat>
-		<maxRangeForFarThreat>60</maxRangeForFarThreat>
-		<chargeCooldownTicks>1480</chargeCooldownTicks>
-		<rangedCooldownTicks>550</rangedCooldownTicks>
-		<rangedBurstCount>4</rangedBurstCount>
-		<rangedTicksBetweenBursts>4</rangedTicksBetweenBursts>
-		<rangedAttackDelay>150</rangedAttackDelay>
-		<aoeCooldownTicks>650</aoeCooldownTicks>
-		<aoeAttackDelay>130</aoeAttackDelay>
-		<knockbackCooldownTicks>1500</knockbackCooldownTicks>
-		<knockbackAttackDelay>240</knockbackAttackDelay>
-		<tauntCooldownTicks>600</tauntCooldownTicks>
-		<tauntAttackDelay>200</tauntAttackDelay>
-		<tauntChance>1</tauntChance>
-	  </li>
-	</comps>
+    <butcherProducts></butcherProducts>
+    <comps>
+      <li>
+        <compClass>CompAttachBase</compClass>
+      </li>
+      <li Class="TorannMagic.CompProperties_SkeletonLichController">
+      <alwaysManhunter>false</alwaysManhunter>
+      <maxRangeForCloseThreat>5</maxRangeForCloseThreat>
+      <maxRangeForFarThreat>60</maxRangeForFarThreat>
+      <chargeCooldownTicks>1480</chargeCooldownTicks>
+      <rangedCooldownTicks>550</rangedCooldownTicks>
+      <rangedBurstCount>4</rangedBurstCount>
+      <rangedTicksBetweenBursts>4</rangedTicksBetweenBursts>
+      <rangedAttackDelay>150</rangedAttackDelay>
+      <aoeCooldownTicks>650</aoeCooldownTicks>
+      <aoeAttackDelay>130</aoeAttackDelay>
+      <knockbackCooldownTicks>1500</knockbackCooldownTicks>
+      <knockbackAttackDelay>240</knockbackAttackDelay>
+      <tauntCooldownTicks>600</tauntCooldownTicks>
+      <tauntAttackDelay>200</tauntAttackDelay>
+      <tauntChance>1</tauntChance>
+      </li>
+    </comps>
   </ThingDef>
  
   <PawnKindDef>
@@ -184,25 +184,25 @@
     <race>TM_SkeletonLichR</race>
     <combatPower>1000</combatPower>
     <defaultFactionType>TM_SkeletalFaction</defaultFactionType>
-	<ecoSystemWeight>0</ecoSystemWeight>
-	<canArriveManhunter>false</canArriveManhunter>
+    <ecoSystemWeight>0</ecoSystemWeight>
+    <canArriveManhunter>false</canArriveManhunter>
     <lifeStages>
-	  <li>
-	    <label>skeleton lich</label>
-        <labelPlural>skeletal lich</labelPlural>
-        <bodyGraphicData>
-          <texPath>PawnKind/skeleton_lich</texPath>
-          <graphicClass>Graphic_Multi</graphicClass>
-		  <shaderType>TransparentPostLight</shaderType>
-          <drawSize>2</drawSize>
-<!-- 		  <color>(180, 180, 180)</color> -->
-          <shadowData>
-            <volume>(0, 0, 0)</volume>
-            <offset>(0,0,0)</offset>
-          </shadowData>
-        </bodyGraphicData>
+      <li>
+        <label>skeleton lich</label>
+          <labelPlural>skeletal lich</labelPlural>
+          <bodyGraphicData>
+            <texPath>PawnKind/skeleton_lich</texPath>
+            <graphicClass>Graphic_Multi</graphicClass>
+        <shaderType>TransparentPostLight</shaderType>
+            <drawSize>2</drawSize>
+  <!-- 		  <color>(180, 180, 180)</color> -->
+            <shadowData>
+              <volume>(0, 0, 0)</volume>
+              <offset>(0,0,0)</offset>
+            </shadowData>
+          </bodyGraphicData>
       </li>
-	</lifeStages>
+	  </lifeStages>
   </PawnKindDef>  
   
   <ThingDef ParentName="TM_Skeletal_Base" Name="TM_GiantSkeleton">
@@ -215,7 +215,7 @@
       <ArmorRating_Sharp>0.9</ArmorRating_Sharp>
       <ArmorRating_Heat>1.8</ArmorRating_Heat>      
     </statBases>
-	<tools>
+	  <tools>
       <li>
         <label>left fist</label>
         <capacities>
@@ -225,7 +225,7 @@
         <cooldownTime>2.1</cooldownTime>
         <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
       </li>
-	  <li>
+	    <li>
         <label>right fist</label>
         <capacities>
           <li>Blunt</li>
@@ -234,7 +234,7 @@
         <cooldownTime>2.1</cooldownTime>
         <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
       </li>
-	  <li>
+	    <li>
         <label>teeth</label>
         <capacities>
           <li>Bite</li>
@@ -243,15 +243,15 @@
         <cooldownTime>2.5</cooldownTime>
         <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
       </li>
-	</tools>
+	  </tools>
     <race>
-	  <baseHealthScale>4</baseHealthScale>	
-      <lifeExpectancy>2000</lifeExpectancy>
-		<lifeStageAges>
+      <baseHealthScale>4</baseHealthScale>	
+        <lifeExpectancy>2000</lifeExpectancy>
+      <lifeStageAges>
         <li>
           <def>TM_GiantSkeleton_Lifestage</def>
           <minAge>100</minAge>
-		  <soundCall>TM_SkeletonAngry</soundCall>
+		      <soundCall>TM_SkeletonAngry</soundCall>
           <soundAngry>TM_SkeletonAngry</soundAngry>
           <soundWounded>TM_SkeletonPain</soundWounded>
           <soundDeath>TM_SkeletonAngryLow</soundDeath>
@@ -259,29 +259,28 @@
       </lifeStageAges>
       <soundMeleeHitPawn>TM_SkeletonPain</soundMeleeHitPawn>
       <soundMeleeHitBuilding>TM_SkeletonPainLow</soundMeleeHitBuilding>
-      <soundMeleeMiss>TM_SkeletonPain</soundMeleeMiss>      
+      <soundMeleeMiss>TM_SkeletonPain</soundMeleeMiss>
+      <bloodDef></bloodDef>
     </race>
-	<butcherProducts>
-
-    </butcherProducts>
-	<comps>
-		<li>
-			<compClass>CompAttachBase</compClass>
-		</li>
-	  <li Class="TorannMagic.CompProperties_SkeletonController">
-		<alwaysManhunter>false</alwaysManhunter>
-		<maxRangeForCloseThreat>5</maxRangeForCloseThreat>
-		<maxRangeForFarThreat>60</maxRangeForFarThreat>
-		<chargeCooldownTicks>1480</chargeCooldownTicks>
-		<rangedCooldownTicks>625</rangedCooldownTicks>
-		<rangedBurstCount>1</rangedBurstCount>
-		<rangedTicksBetweenBursts>10</rangedTicksBetweenBursts>
-		<aoeCooldownTicks>400</aoeCooldownTicks>
-		<knockbackCooldownTicks>0</knockbackCooldownTicks>
-		<tauntCooldownTicks>600</tauntCooldownTicks>
-		<tauntChance>.6</tauntChance>
-	  </li>
-	</comps>
+	  <butcherProducts></butcherProducts>
+    <comps>
+      <li>
+        <compClass>CompAttachBase</compClass>
+      </li>
+      <li Class="TorannMagic.CompProperties_SkeletonController">
+        <alwaysManhunter>false</alwaysManhunter>
+        <maxRangeForCloseThreat>5</maxRangeForCloseThreat>
+        <maxRangeForFarThreat>60</maxRangeForFarThreat>
+        <chargeCooldownTicks>1480</chargeCooldownTicks>
+        <rangedCooldownTicks>625</rangedCooldownTicks>
+        <rangedBurstCount>1</rangedBurstCount>
+        <rangedTicksBetweenBursts>10</rangedTicksBetweenBursts>
+        <aoeCooldownTicks>400</aoeCooldownTicks>
+        <knockbackCooldownTicks>0</knockbackCooldownTicks>
+        <tauntCooldownTicks>600</tauntCooldownTicks>
+        <tauntChance>.6</tauntChance>
+      </li>
+    </comps>
   </ThingDef>
  
   <PawnKindDef>
@@ -321,7 +320,7 @@
       <ArmorRating_Sharp>0.5</ArmorRating_Sharp>
       <ArmorRating_Heat>1.5</ArmorRating_Heat>      
     </statBases>
-	<tools>
+	  <tools>
       <li>
         <label>left fist</label>
         <capacities>
@@ -349,15 +348,15 @@
         <cooldownTime>2.5</cooldownTime>
         <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
       </li>
-	</tools>
+	  </tools>
     <race>
-	  <baseHealthScale>1</baseHealthScale>	
-      <lifeExpectancy>2000</lifeExpectancy>
-		<lifeStageAges>
+      <baseHealthScale>1</baseHealthScale>	
+        <lifeExpectancy>2000</lifeExpectancy>
+      <lifeStageAges>
         <li>
           <def>TM_Skeleton_Lifestage</def>
           <minAge>100</minAge>
-		  <soundCall>TM_SkeletonAngry</soundCall>
+		      <soundCall>TM_SkeletonAngry</soundCall>
           <soundAngry>TM_SkeletonAngry</soundAngry>
           <soundWounded>TM_SkeletonPain</soundWounded>
           <soundDeath>TM_SkeletonAngryLow</soundDeath>
@@ -365,29 +364,28 @@
       </lifeStageAges>
       <soundMeleeHitPawn>TM_SkeletonPain</soundMeleeHitPawn>
       <soundMeleeHitBuilding>TM_SkeletonPainLow</soundMeleeHitBuilding>
-      <soundMeleeMiss>TM_SkeletonPain</soundMeleeMiss>   	  
+      <soundMeleeMiss>TM_SkeletonPain</soundMeleeMiss>
+      <bloodDef></bloodDef>	  
     </race>
-	<butcherProducts>
-
-    </butcherProducts>
-	<comps>
-	  <li>
-		<compClass>CompAttachBase</compClass>
-	  </li>
-	  <li Class="TorannMagic.CompProperties_SkeletonController">
-		<alwaysManhunter>false</alwaysManhunter>
-		<maxRangeForCloseThreat>4</maxRangeForCloseThreat>
-		<maxRangeForFarThreat>40</maxRangeForFarThreat>
-		<chargeCooldownTicks>0</chargeCooldownTicks>
-		<rangedCooldownTicks>0</rangedCooldownTicks>
-		<rangedBurstCount>0</rangedBurstCount>
-		<rangedTicksBetweenBursts>10</rangedTicksBetweenBursts>
-		<aoeCooldownTicks>0</aoeCooldownTicks>
-		<knockbackCooldownTicks>0</knockbackCooldownTicks>
-		<tauntCooldownTicks>0</tauntCooldownTicks>
-		<tauntChance>0</tauntChance>
-	  </li>
-	</comps>
+    <butcherProducts></butcherProducts>
+    <comps>
+      <li>
+      <compClass>CompAttachBase</compClass>
+      </li>
+      <li Class="TorannMagic.CompProperties_SkeletonController">
+      <alwaysManhunter>false</alwaysManhunter>
+      <maxRangeForCloseThreat>4</maxRangeForCloseThreat>
+      <maxRangeForFarThreat>40</maxRangeForFarThreat>
+      <chargeCooldownTicks>0</chargeCooldownTicks>
+      <rangedCooldownTicks>0</rangedCooldownTicks>
+      <rangedBurstCount>0</rangedBurstCount>
+      <rangedTicksBetweenBursts>10</rangedTicksBetweenBursts>
+      <aoeCooldownTicks>0</aoeCooldownTicks>
+      <knockbackCooldownTicks>0</knockbackCooldownTicks>
+      <tauntCooldownTicks>0</tauntCooldownTicks>
+      <tauntChance>0</tauntChance>
+      </li>
+    </comps>
   </ThingDef>
  
   <PawnKindDef>


### PR DESCRIPTION
1.5 update seems to call get_CanBleed a TON. TM_Calc.IsUndead takes about .002 ms to complete in steam version. These changes remove harmony overhead and the extra checks that are not needed.  The extra XML changes that aren't bloodDefs are just indentations.

My reasoning for removing the checks in IsUndead is:
* Races can just set a bloodDef instead in the XML
* The trait seems always to be applied with the hediff, so checking seems redundant. I would rather check the trait, but unfortunately there are a lot of things that don't get the trait, like animals.

I do intend to take another pass at this at some point, but for now it is at least significantly faster than what is on steam. I would like to remove the transpiler, because they're hard to read, but I think this one might have to stay.